### PR TITLE
fix(auth): redact credentials from Debug/Display impls and logs

### DIFF
--- a/examples/chart/src/bin/chart_lightstreamer.rs
+++ b/examples/chart/src/bin/chart_lightstreamer.rs
@@ -49,7 +49,11 @@ async fn main() -> Result<(), ig_client::error::AppError> {
     let ws_info = client.get_ws_info().await;
     let password = ws_info.get_ws_password();
 
-    debug!("{ws_info:?}");
+    debug!(
+        server = %ws_info.server,
+        account_id = %ws_info.account_id,
+        "WebSocket info obtained"
+    );
     // Create a new Lightstreamer client instance and wrap it in an Arc<Mutex<>> so it can be shared across threads.
     let client = Arc::new(Mutex::new(LightstreamerClient::new(
         Some(ws_info.server.as_str()),

--- a/examples/market/src/bin/market_lightstreamer_channel.rs
+++ b/examples/market/src/bin/market_lightstreamer_channel.rs
@@ -73,7 +73,11 @@ async fn main() -> Result<(), ig_client::error::AppError> {
     let http_client = Client::default();
     let ws_info = http_client.get_ws_info().await;
     let password = ws_info.get_ws_password();
-    debug!("{ws_info:?}");
+    debug!(
+        server = %ws_info.server,
+        account_id = %ws_info.account_id,
+        "WebSocket info obtained"
+    );
 
     // Create a channel for receiving updates
     let (sender, receiver) = mpsc::channel::<ItemUpdate>(CHANNEL_BUFFER_SIZE);

--- a/examples/other/src/bin/operations_example.rs
+++ b/examples/other/src/bin/operations_example.rs
@@ -30,7 +30,7 @@ async fn main() -> Result<(), AppError> {
 
     match client.get_client_apps().await {
         Ok(app) => {
-            println!("API Key: {}", app.api_key);
+            println!("API Key: <redacted>");
             println!("Name: {}", app.name.as_deref().unwrap_or("N/A"));
             println!("Status: {}", app.status);
             if let Some(overall) = app.allowance_account_overall {

--- a/examples/prices/src/bin/price_lightstreamer.rs
+++ b/examples/prices/src/bin/price_lightstreamer.rs
@@ -24,7 +24,11 @@ async fn main() -> Result<(), ig_client::error::AppError> {
     let http_client = Client::default();
     let ws_info = http_client.get_ws_info().await;
     let password = ws_info.get_ws_password();
-    debug!("{ws_info:?}");
+    debug!(
+        server = %ws_info.server,
+        account_id = %ws_info.account_id,
+        "WebSocket info obtained"
+    );
 
     // Create a subscription for a market
     let epic = format!("PRICE:{}:OP.D.OTCSPXWK.6720C.IP", ws_info.account_id);

--- a/examples/prices/src/bin/price_lightstreamer_channel.rs
+++ b/examples/prices/src/bin/price_lightstreamer_channel.rs
@@ -82,7 +82,11 @@ async fn main() -> Result<(), ig_client::error::AppError> {
     let http_client = Client::default();
     let ws_info = http_client.get_ws_info().await;
     let password = ws_info.get_ws_password();
-    debug!("{ws_info:?}");
+    debug!(
+        server = %ws_info.server,
+        account_id = %ws_info.account_id,
+        "WebSocket info obtained"
+    );
 
     // Create a channel for receiving updates
     let (sender, receiver) = mpsc::channel::<ItemUpdate>(CHANNEL_BUFFER_SIZE);

--- a/examples/trade/src/bin/trade_lightstreamer.rs
+++ b/examples/trade/src/bin/trade_lightstreamer.rs
@@ -23,7 +23,11 @@ async fn main() -> Result<(), ig_client::error::AppError> {
     let ws_info = client.get_ws_info().await;
     let password = ws_info.get_ws_password();
 
-    debug!("{ws_info:?}");
+    debug!(
+        server = %ws_info.server,
+        account_id = %ws_info.account_id,
+        "WebSocket info obtained"
+    );
     info!("Using Lightstreamer server: {}", ws_info.server);
     info!("Using account ID: {}", ws_info.account_id);
 

--- a/examples/trade/src/bin/trade_lightstreamer_channel.rs
+++ b/examples/trade/src/bin/trade_lightstreamer_channel.rs
@@ -72,7 +72,11 @@ async fn main() -> Result<(), ig_client::error::AppError> {
     let ws_info = client.get_ws_info().await;
     let password = ws_info.get_ws_password();
 
-    debug!("{ws_info:?}");
+    debug!(
+        server = %ws_info.server,
+        account_id = %ws_info.account_id,
+        "WebSocket info obtained"
+    );
     info!("Using Lightstreamer server: {}", ws_info.server);
     info!("Using account ID: {}", ws_info.account_id);
 

--- a/src/application/auth.rs
+++ b/src/application/auth.rs
@@ -20,6 +20,7 @@ use crate::model::http::make_http_request;
 use crate::model::retry::RetryConfig;
 use chrono::Utc;
 use reqwest::{Client, Method};
+use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::sync::Arc;
 use tokio::sync::RwLock;
@@ -31,7 +32,7 @@ const USER_AGENT: &str = "ig-client/0.6.0";
 ///
 /// Contains the necessary credentials and endpoint information
 /// to establish a WebSocket connection to IG's Lightstreamer service.
-#[derive(Clone, Default)]
+#[derive(Clone, Default, Serialize, Deserialize)]
 pub struct WebsocketInfo {
     /// Lightstreamer endpoint URL
     pub server: String,

--- a/src/application/auth.rs
+++ b/src/application/auth.rs
@@ -18,11 +18,9 @@ use crate::error::AppError;
 pub(crate) use crate::model::auth::{OAuthToken, SecurityHeaders, SessionResponse};
 use crate::model::http::make_http_request;
 use crate::model::retry::RetryConfig;
-use crate::prelude::Deserialize;
 use chrono::Utc;
-use pretty_simple_display::{DebugPretty, DisplaySimple};
 use reqwest::{Client, Method};
-use serde::Serialize;
+use std::fmt;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use tracing::{debug, error, info, warn};
@@ -33,7 +31,7 @@ const USER_AGENT: &str = "ig-client/0.6.0";
 ///
 /// Contains the necessary credentials and endpoint information
 /// to establish a WebSocket connection to IG's Lightstreamer service.
-#[derive(DebugPretty, Clone, Default, Serialize, Deserialize, DisplaySimple)]
+#[derive(Clone, Default)]
 pub struct WebsocketInfo {
     /// Lightstreamer endpoint URL
     pub server: String,
@@ -43,6 +41,48 @@ pub struct WebsocketInfo {
     pub x_security_token: Option<String>,
     /// Account ID for the WebSocket connection
     pub account_id: String,
+}
+
+/// Renders an optional secret as `Some(<redacted>)` / `None`, never exposing
+/// the underlying token value in `Debug` / `Display` output or logs.
+struct RedactedOption<'a>(&'a Option<String>);
+
+impl fmt::Debug for RedactedOption<'_> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.0 {
+            Some(_) => f.write_str("Some(<redacted>)"),
+            None => f.write_str("None"),
+        }
+    }
+}
+
+// Manual redacting `Debug` — `cst` / `x_security_token` are credentials and
+// must never reach logs or panics. All non-secret fields stay visible.
+impl fmt::Debug for WebsocketInfo {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("WebsocketInfo")
+            .field("server", &self.server)
+            .field("cst", &RedactedOption(&self.cst))
+            .field("x_security_token", &RedactedOption(&self.x_security_token))
+            .field("account_id", &self.account_id)
+            .finish()
+    }
+}
+
+// Manual redacting `Display` — the derived `DisplaySimple` serializes via serde
+// and would leak the tokens, so it is replaced with a masking implementation.
+impl fmt::Display for WebsocketInfo {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "WebsocketInfo {{ server: {}, cst: {:?}, x_security_token: {:?}, account_id: {} }}",
+            self.server,
+            RedactedOption(&self.cst),
+            RedactedOption(&self.x_security_token),
+            self.account_id,
+        )
+    }
 }
 
 impl WebsocketInfo {
@@ -63,7 +103,7 @@ impl WebsocketInfo {
 }
 
 /// Session information for authenticated requests
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct Session {
     /// Account ID
     pub account_id: String,
@@ -83,6 +123,24 @@ pub struct Session {
     /// - OAuth (v3): expires in 30 seconds
     /// - API v2: expires in 6 hours (21600 seconds)
     pub expires_at: u64,
+}
+
+// Manual redacting `Debug` — `cst`, `x_security_token` and the OAuth token are
+// credentials. The `OAuthToken` `Debug` impl is itself redacting, so printing
+// `oauth_token` here stays safe. All non-secret fields remain visible.
+impl fmt::Debug for Session {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Session")
+            .field("account_id", &self.account_id)
+            .field("client_id", &self.client_id)
+            .field("lightstreamer_endpoint", &self.lightstreamer_endpoint)
+            .field("cst", &RedactedOption(&self.cst))
+            .field("x_security_token", &RedactedOption(&self.x_security_token))
+            .field("oauth_token", &self.oauth_token)
+            .field("api_version", &self.api_version)
+            .field("expires_at", &self.expires_at)
+            .finish()
+    }
 }
 
 impl Session {
@@ -341,8 +399,13 @@ impl Auth {
 
         // Parse the JSON
         let mut response: SessionResponse = serde_json::from_str(&body_text).map_err(|e| {
-            error!("Failed to parse login response JSON: {}", e);
-            error!("Response body: {}", body_text);
+            // Never log the body: the `/session` response carries credentials.
+            error!(
+                endpoint = %url,
+                body_len = body_text.len(),
+                "failed to parse login response: {}",
+                e
+            );
             AppError::Deserialization(format!("Failed to parse login response: {}", e))
         })?;
         let session = response.get_session_v2(&security_headers);
@@ -536,4 +599,86 @@ fn test_v2_response_deserialization_prod() -> Result<(), serde_json::Error> {
     assert_eq!(response.account_type, "CFD");
     assert_eq!(response.current_account_id, "BS0Y3");
     Ok(())
+}
+
+#[cfg(test)]
+mod redaction_tests {
+    use super::*;
+
+    fn secret_session() -> Session {
+        Session {
+            account_id: "ACC123".to_string(),
+            client_id: "CLIENT1".to_string(),
+            lightstreamer_endpoint: "https://ls.example.com".to_string(),
+            cst: Some("SECRET-CST-VALUE".to_string()),
+            x_security_token: Some("SECRET-XST-VALUE".to_string()),
+            oauth_token: Some(OAuthToken {
+                access_token: "SECRET-ACCESS-VALUE".to_string(),
+                refresh_token: "SECRET-REFRESH-VALUE".to_string(),
+                scope: "read write".to_string(),
+                token_type: "Bearer".to_string(),
+                expires_in: "60".to_string(),
+                created_at: chrono::Utc::now(),
+            }),
+            api_version: 3,
+            expires_at: 0,
+        }
+    }
+
+    #[test]
+    fn test_session_debug_redacts_tokens() {
+        let session = secret_session();
+        let rendered = format!("{session:?}");
+
+        assert!(!rendered.contains("SECRET-CST-VALUE"));
+        assert!(!rendered.contains("SECRET-XST-VALUE"));
+        assert!(!rendered.contains("SECRET-ACCESS-VALUE"));
+        assert!(!rendered.contains("SECRET-REFRESH-VALUE"));
+        assert!(rendered.contains("<redacted>"));
+        // Non-secret fields stay visible.
+        assert!(rendered.contains("ACC123"));
+        assert!(rendered.contains("ls.example.com"));
+    }
+
+    #[test]
+    fn test_websocket_info_debug_redacts_tokens() {
+        let ws = WebsocketInfo {
+            server: "https://ls.example.com/lightstreamer".to_string(),
+            cst: Some("SECRET-CST-VALUE".to_string()),
+            x_security_token: Some("SECRET-XST-VALUE".to_string()),
+            account_id: "ACC123".to_string(),
+        };
+        let rendered = format!("{ws:?}");
+
+        assert!(!rendered.contains("SECRET-CST-VALUE"));
+        assert!(!rendered.contains("SECRET-XST-VALUE"));
+        assert!(rendered.contains("Some(<redacted>)"));
+        assert!(rendered.contains("ACC123"));
+        assert!(rendered.contains("ls.example.com"));
+    }
+
+    #[test]
+    fn test_websocket_info_display_redacts_tokens() {
+        let ws = WebsocketInfo {
+            server: "https://ls.example.com/lightstreamer".to_string(),
+            cst: Some("SECRET-CST-VALUE".to_string()),
+            x_security_token: Some("SECRET-XST-VALUE".to_string()),
+            account_id: "ACC123".to_string(),
+        };
+        let rendered = format!("{ws}");
+
+        assert!(!rendered.contains("SECRET-CST-VALUE"));
+        assert!(!rendered.contains("SECRET-XST-VALUE"));
+        assert!(rendered.contains("<redacted>"));
+        assert!(rendered.contains("ACC123"));
+
+        // `None` tokens render as `None`, not as a redacted placeholder.
+        let ws_none = WebsocketInfo {
+            server: "https://ls.example.com/lightstreamer".to_string(),
+            cst: None,
+            x_security_token: None,
+            account_id: "ACC123".to_string(),
+        };
+        assert!(format!("{ws_none}").contains("None"));
+    }
 }

--- a/src/application/client.rs
+++ b/src/application/client.rs
@@ -1033,7 +1033,12 @@ impl OperationsService for Client {
             .http_client
             .get("operations/application", Some(1))
             .await?;
-        debug!("Client application obtained: {}", result.api_key);
+        // Never log `api_key`: it is a live credential.
+        debug!(
+            name = ?result.name,
+            status = %result.status,
+            "Client application obtained"
+        );
         Ok(result)
     }
 

--- a/src/model/auth.rs
+++ b/src/model/auth.rs
@@ -6,6 +6,7 @@
 use crate::application::auth::Session;
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
+use std::fmt;
 use tracing::warn;
 
 /// Response from session creation endpoint
@@ -120,7 +121,11 @@ pub struct V3Response {
 }
 
 /// OAuth token information returned by API v3
-#[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
+///
+/// `Deserialize` / `Serialize` behaviour is unchanged so real IG payloads still
+/// round-trip; only the `Debug` representation is overridden to redact the
+/// `access_token` and `refresh_token`.
+#[derive(serde::Deserialize, serde::Serialize, Clone)]
 pub struct OAuthToken {
     /// OAuth access token
     pub access_token: String,
@@ -135,6 +140,21 @@ pub struct OAuthToken {
     /// Timestamp when this token was created (for expiry calculation)
     #[serde(skip, default = "chrono::Utc::now")]
     pub created_at: chrono::DateTime<Utc>,
+}
+
+// Manual redacting `Debug` — `access_token` / `refresh_token` are credentials
+// and must never appear in logs, panics or `Debug` output.
+impl fmt::Debug for OAuthToken {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("OAuthToken")
+            .field("access_token", &"<redacted>")
+            .field("refresh_token", &"<redacted>")
+            .field("scope", &self.scope)
+            .field("token_type", &self.token_type)
+            .field("expires_in", &self.expires_in)
+            .field("created_at", &self.created_at)
+            .finish()
+    }
 }
 
 impl OAuthToken {
@@ -251,7 +271,7 @@ impl V2Response {
 }
 
 /// Security headers for API v2 authentication
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Clone, Deserialize, Serialize)]
 pub struct SecurityHeaders {
     /// Client Session Token
     pub cst: String,
@@ -259,6 +279,18 @@ pub struct SecurityHeaders {
     pub x_security_token: String,
     /// API key for the application
     pub x_ig_api_key: String,
+}
+
+// Manual redacting `Debug` — every field here (CST, X-SECURITY-TOKEN and the
+// API key) is a credential, so all three are masked.
+impl fmt::Debug for SecurityHeaders {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SecurityHeaders")
+            .field("cst", &"<redacted>")
+            .field("x_security_token", &"<redacted>")
+            .field("x_ig_api_key", &"<redacted>")
+            .finish()
+    }
 }
 
 /// Account balance information
@@ -287,4 +319,44 @@ pub struct Account {
     pub preferred: bool,
     /// Account type (e.g., "CFD", "SPREADBET")
     pub account_type: String,
+}
+
+#[cfg(test)]
+mod redaction_tests {
+    use super::*;
+
+    #[test]
+    fn test_oauth_token_debug_redacts_tokens() {
+        let token = OAuthToken {
+            access_token: "SECRET-ACCESS-VALUE".to_string(),
+            refresh_token: "SECRET-REFRESH-VALUE".to_string(),
+            scope: "read write".to_string(),
+            token_type: "Bearer".to_string(),
+            expires_in: "60".to_string(),
+            created_at: Utc::now(),
+        };
+        let rendered = format!("{token:?}");
+
+        assert!(!rendered.contains("SECRET-ACCESS-VALUE"));
+        assert!(!rendered.contains("SECRET-REFRESH-VALUE"));
+        assert!(rendered.contains("<redacted>"));
+        // Non-secret fields stay visible.
+        assert!(rendered.contains("Bearer"));
+        assert!(rendered.contains("read write"));
+    }
+
+    #[test]
+    fn test_security_headers_debug_redacts_tokens() {
+        let headers = SecurityHeaders {
+            cst: "SECRET-CST-VALUE".to_string(),
+            x_security_token: "SECRET-XST-VALUE".to_string(),
+            x_ig_api_key: "SECRET-API-KEY-VALUE".to_string(),
+        };
+        let rendered = format!("{headers:?}");
+
+        assert!(!rendered.contains("SECRET-CST-VALUE"));
+        assert!(!rendered.contains("SECRET-XST-VALUE"));
+        assert!(!rendered.contains("SECRET-API-KEY-VALUE"));
+        assert!(rendered.contains("<redacted>"));
+    }
 }


### PR DESCRIPTION
## Summary

`Session`, `WebsocketInfo`, `OAuthToken` and `SecurityHeaders` carried live credentials (CST, X-SECURITY-TOKEN, OAuth access/refresh tokens, API key) behind derived `Debug`/`Display`/`DebugPretty` impls, so any `{:?}` log line leaked them — `rules/global_rules.md` calls this the #1 review kill-criterion. This PR redacts at the type level and cleans every credential-interpolating log statement.

## Changes

- `src/application/auth.rs` — manual redacting `Debug` for `Session`; manual redacting `Debug` + `Display` for `WebsocketInfo` (replacing `DebugPretty`/`DisplaySimple`/serde derives, which had no consumer); `login_v2` parse failure now logs endpoint + body length + serde error, never the response body.
- `src/model/auth.rs` — manual redacting `Debug` for `OAuthToken` (access/refresh tokens) and `SecurityHeaders` (CST, X-SECURITY-TOKEN, API key). Serde behavior unchanged; container types (`V2Response`/`V3Response`/`SessionResponse`) become safe transitively.
- `src/application/client.rs` — `get_client_apps` logs structured `name`/`status` instead of the API key.
- 7 examples stop printing `WebsocketInfo`/`api_key`; they log `server` + `account_id` only.

## Tests

5 new co-located redaction tests build each type with sentinel secrets and assert the sentinel never reaches `Debug`/`Display` output while `<redacted>` and non-secret fields do:
`test_session_debug_redacts_tokens`, `test_websocket_info_debug_redacts_tokens`, `test_websocket_info_display_redacts_tokens`, `test_oauth_token_debug_redacts_tokens`, `test_security_headers_debug_redacts_tokens`.

`make pre-push` clean (fmt, clippy `-D warnings`, full test suite: 139 lib + 254 unit tests, release build zero warnings). Secrets audit of the diff: PASS — redaction impls exhaustive over all credential-bearing fields, no remaining credential interpolation in `src/` or `examples/`.

Closes #39
