### PR TITLE
fix(retry): finite defaults, exponential backoff with jitter, retryable 429

### DIFF
--- a/src/application/auth.rs
+++ b/src/application/auth.rs
@@ -346,7 +346,7 @@ impl Auth {
             &url,
             headers,
             &Some(body),
-            RetryConfig::infinite(),
+            RetryConfig::default(),
         )
         .await?;
 
@@ -437,7 +437,7 @@ impl Auth {
             &url,
             headers,
             &Some(body),
-            RetryConfig::infinite(),
+            RetryConfig::default(),
         )
         .await?;
 
@@ -550,7 +550,7 @@ impl Auth {
             &url,
             headers,
             &Some(body),
-            RetryConfig::infinite(),
+            RetryConfig::default(),
         )
         .await?;
 

--- a/src/application/client.rs
+++ b/src/application/client.rs
@@ -32,6 +32,7 @@ use crate::model::responses::{
 use crate::model::responses::{
     ClosePositionResponse, CreateOrderResponse, CreateWorkingOrderResponse, UpdatePositionResponse,
 };
+use crate::model::retry::backoff_delay;
 use crate::model::streaming::{
     StreamingAccountDataField, StreamingChartField, StreamingMarketField, StreamingPriceField,
     get_streaming_account_data_fields, get_streaming_chart_fields, get_streaming_market_fields,
@@ -50,6 +51,7 @@ use lightstreamer_rs::subscription::{
     ChannelSubscriptionListener, Snapshot, Subscription, SubscriptionMode,
 };
 use lightstreamer_rs::utils::setup_signal_hook;
+use reqwest::StatusCode;
 use serde_json::Value;
 use std::collections::HashSet;
 use std::sync::Arc;
@@ -59,6 +61,32 @@ use tokio::time::sleep;
 use tracing::{debug, error, info, warn};
 
 const MAX_CONNECTION_ATTEMPTS: u64 = 3;
+
+/// Returns `true` if an error from the order-confirmation endpoint is transient
+/// and worth polling again.
+///
+/// The IG `GET /confirms/{dealReference}` endpoint returns `404 Not Found` until
+/// the deal has been processed, so a not-found result means "not yet available"
+/// rather than a permanent failure. Transient cases retried by
+/// [`Client::get_order_confirmation_w_retry`]:
+///
+/// - [`AppError::RateLimitExceeded`] — rate limited.
+/// - [`AppError::Network`] — connection / transport error.
+/// - [`AppError::NotFound`] / [`AppError::Unexpected`] with a `404` or `5xx`
+///   status — confirmation not yet available or a server error.
+///
+/// Everything else (auth failures, invalid input, deserialization, 4xx client
+/// errors) is permanent and returned to the caller immediately.
+#[must_use]
+fn is_transient_confirmation_error(err: &AppError) -> bool {
+    match err {
+        AppError::RateLimitExceeded | AppError::Network(_) | AppError::NotFound => true,
+        AppError::Unexpected(status) => {
+            *status == StatusCode::NOT_FOUND || status.is_server_error()
+        }
+        _ => false,
+    }
+}
 
 /// Main client for interacting with IG Markets API
 ///
@@ -665,20 +693,36 @@ impl OrderService for Client {
         retries: u64,
         delay_ms: u64,
     ) -> Result<OrderConfirmationResponse, AppError> {
-        let mut attempts = 0;
+        // `delay_ms` is the backoff base; the actual per-attempt wait grows
+        // exponentially (with jitter) via the shared `RetryConfig` policy.
+        let base = Duration::from_millis(delay_ms);
+        let mut attempt: u32 = 0;
         loop {
             match self.get_order_confirmation(deal_reference).await {
                 Ok(response) => return Ok(response),
                 Err(e) => {
-                    attempts += 1;
-                    if attempts > retries {
+                    // Only poll again on transient errors; permanent failures
+                    // (auth, invalid input, deserialization) return immediately.
+                    if !is_transient_confirmation_error(&e) {
                         return Err(e);
                     }
+                    if u64::from(attempt) >= retries {
+                        return Err(e);
+                    }
+                    let delay = backoff_delay(base, attempt);
+                    let delay_ms = u64::try_from(delay.as_millis()).unwrap_or(u64::MAX);
+                    let next_attempt = attempt.checked_add(1).ok_or_else(|| {
+                        AppError::Generic("retry attempt counter overflow".to_string())
+                    })?;
                     warn!(
-                        "Failed to get order confirmation (attempt {}/{}): {}. Retrying in {} ms...",
-                        attempts, retries, e, delay_ms
+                        deal_reference = %deal_reference,
+                        attempt = next_attempt,
+                        max_retries = retries,
+                        delay_ms,
+                        "retrying order confirmation after transient error"
                     );
-                    sleep(Duration::from_millis(delay_ms)).await;
+                    sleep(delay).await;
+                    attempt = next_attempt;
                 }
             }
         }
@@ -1767,5 +1811,59 @@ impl StreamerClient {
 
         info!("Disconnected {} streaming client(s)", disconnected);
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_transient_confirmation_error;
+    use crate::error::AppError;
+    use reqwest::StatusCode;
+
+    #[test]
+    fn test_confirmation_error_rate_limit_is_transient() {
+        assert!(is_transient_confirmation_error(
+            &AppError::RateLimitExceeded
+        ));
+    }
+
+    #[test]
+    fn test_confirmation_error_not_found_is_transient() {
+        // Confirmation not yet available: IG returns 404 until the deal settles.
+        assert!(is_transient_confirmation_error(&AppError::NotFound));
+        assert!(is_transient_confirmation_error(&AppError::Unexpected(
+            StatusCode::NOT_FOUND
+        )));
+    }
+
+    #[test]
+    fn test_confirmation_error_server_error_is_transient() {
+        assert!(is_transient_confirmation_error(&AppError::Unexpected(
+            StatusCode::INTERNAL_SERVER_ERROR
+        )));
+        assert!(is_transient_confirmation_error(&AppError::Unexpected(
+            StatusCode::BAD_GATEWAY
+        )));
+    }
+
+    #[test]
+    fn test_confirmation_error_invalid_input_is_permanent() {
+        assert!(!is_transient_confirmation_error(&AppError::InvalidInput(
+            "bad".to_string()
+        )));
+    }
+
+    #[test]
+    fn test_confirmation_error_auth_and_deser_are_permanent() {
+        assert!(!is_transient_confirmation_error(&AppError::Unauthorized));
+        assert!(!is_transient_confirmation_error(
+            &AppError::OAuthTokenExpired
+        ));
+        assert!(!is_transient_confirmation_error(
+            &AppError::Deserialization("bad".to_string())
+        ));
+        assert!(!is_transient_confirmation_error(&AppError::Unexpected(
+            StatusCode::BAD_REQUEST
+        )));
     }
 }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -8,6 +8,26 @@ pub const ERROR_COOLDOWN_SECONDS: u64 = 300;
 pub const DEFAULT_SLEEP_TIME: u64 = 24;
 /// Default page size for API requests
 pub const DEFAULT_PAGE_SIZE: u32 = 50;
+/// Default maximum number of retries for transient HTTP failures when the
+/// `MAX_RETRY_COUNT` environment variable is unset.
+///
+/// This default is intentionally finite: unbounded retry was removed in
+/// PR #26 and must never be reintroduced. "No retry count configured" now
+/// means "use this finite default", never "retry forever".
+pub const DEFAULT_MAX_RETRIES: u32 = 3;
+/// Default base delay in seconds between retries when the `RETRY_DELAY_SECS`
+/// environment variable is unset. Used as the base for exponential backoff.
+pub const DEFAULT_RETRY_DELAY_SECS: u64 = 10;
+/// Maximum backoff delay in seconds. Exponential backoff (`base * 2^attempt`)
+/// saturates at this cap — the cap is the policy, so rounding down to it is
+/// intentional and documented.
+pub const MAX_RETRY_DELAY_SECS: u64 = 60;
+/// Compatibility retry cap for the deprecated "infinite" retry constructors
+/// ([`crate::model::retry::RetryConfig::infinite`] and
+/// [`crate::model::retry::RetryConfig::with_delay`]). Unbounded retry is banned
+/// (PR #26); these constructors now clamp to this large-but-finite value so
+/// existing callers keep compiling while never looping forever.
+pub const DEPRECATED_INFINITE_RETRY_CAP: u32 = 1000;
 /// Base delay in milliseconds used for proximity-based delays in the rate limiter
 /// This value is used to calculate wait times when approaching rate limits
 pub const BASE_DELAY_MS: u64 = 1000;

--- a/src/model/http.rs
+++ b/src/model/http.rs
@@ -369,10 +369,16 @@ impl Default for HttpClient {
 /// * `Ok(Response)` - Successful HTTP response
 /// * `Err(AppError)` - Error if request fails (excluding rate limit errors which are retried)
 ///
+/// Retry is always finite: transient failures (429, 5xx, and IG allowance
+/// rate limits) are retried with exponential backoff up to
+/// `retry_config.max_retries()`; everything else fails fast. The 401
+/// token-refresh path is handled by the caller, not here.
+///
 /// # Example
 ///
 /// ```ignore
-/// use ig_client::model::http::{make_http_request, RetryConfig};
+/// use ig_client::model::http::make_http_request;
+/// use ig_client::model::retry::RetryConfig;
 /// use reqwest::{Client, Method};
 /// use std::sync::Arc;
 /// use tokio::sync::RwLock;
@@ -384,7 +390,7 @@ impl Default for HttpClient {
 ///     ("Content-Type", "application/json"),
 /// ];
 ///
-/// // Infinite retries with 10 second delay (default)
+/// // Finite defaults (DEFAULT_MAX_RETRIES retries, exponential backoff)
 /// let response = make_http_request(
 ///     &client,
 ///     rate_limiter.clone(),
@@ -392,32 +398,10 @@ impl Default for HttpClient {
 ///     "https://demo-api.ig.com/gateway/deal/markets/EPIC",
 ///     headers.clone(),
 ///     &None::<()>,
-///     RetryConfig::infinite(),
+///     RetryConfig::default(),
 /// ).await?;
 ///
-/// // Maximum 3 retries with default 10 second delay
-/// let response = make_http_request(
-///     &client,
-///     rate_limiter.clone(),
-///     Method::GET,
-///     "https://demo-api.ig.com/gateway/deal/markets/EPIC",
-///     headers.clone(),
-///     &None::<()>,
-///     RetryConfig::with_max_retries(3),
-/// ).await?;
-///
-/// // Infinite retries with custom 5 second delay
-/// let response = make_http_request(
-///     &client,
-///     rate_limiter.clone(),
-///     Method::GET,
-///     "https://demo-api.ig.com/gateway/deal/markets/EPIC",
-///     headers.clone(),
-///     &None::<()>,
-///     RetryConfig::with_delay(5),
-/// ).await?;
-///
-/// // Maximum 3 retries with custom 5 second delay
+/// // Maximum 3 retries with a 5 second base delay
 /// let response = make_http_request(
 ///     &client,
 ///     rate_limiter,
@@ -437,18 +421,18 @@ pub async fn make_http_request<B: Serialize>(
     body: &Option<B>,
     retry_config: RetryConfig,
 ) -> Result<Response, AppError> {
-    let mut retry_count = 0;
     let max_retries = retry_config.max_retries();
-    let delay_secs = retry_config.delay_secs();
 
-    loop {
+    // Bounded loop: `attempt` ranges over [0, max_retries]. Attempt 0 is the
+    // first try; each further attempt is a retry. This can never loop forever.
+    for attempt in 0..=max_retries {
         // Wait for rate limiter before making request
         {
             let limiter = rate_limiter.read().await;
             limiter.wait().await;
         }
 
-        debug!("{} {}", method, url);
+        debug!(%method, %url, "http request");
 
         // Build request
         let mut request = client.request(method.clone(), url);
@@ -466,23 +450,23 @@ pub async fn make_http_request<B: Serialize>(
         // Send request
         let response = request.send().await?;
         let status = response.status();
-        debug!("Response status: {}", status);
+        debug!(status = ?status, "http response");
 
         if status.is_success() {
             return Ok(response);
         }
 
-        match status {
+        // Classify the failure into a retryable error or an immediate return.
+        // Body-dependent statuses (401, 403) are handled inline; everything
+        // else goes through the pure `classify_status` helper.
+        let retryable_err: AppError = match status {
             StatusCode::FORBIDDEN => {
                 let body_text = response.text().await.unwrap_or_default();
 
                 // Historical data allowance is a weekly quota (default 10,000 data points).
                 // Retrying is pointless — fail fast and let the caller decide.
                 if body_text.contains("exceeded-account-historical-data-allowance") {
-                    error!(
-                        "Historical data allowance exceeded (weekly quota exhausted): {}",
-                        body_text
-                    );
+                    error!("historical data allowance exceeded (weekly quota exhausted)");
                     return Err(AppError::HistoricalDataAllowanceExceeded {
                         allowance_expiry: 0,
                     });
@@ -492,41 +476,129 @@ pub async fn make_http_request<B: Serialize>(
                     || body_text.contains("exceeded-account-allowance")
                     || body_text.contains("exceeded-account-trading-allowance")
                 {
-                    retry_count += 1;
-
-                    // Check if we've exceeded max retries (0 = infinite)
-                    if max_retries > 0 && retry_count > max_retries {
-                        error!(
-                            "Rate limit exceeded after {} attempts. Max retries ({}) reached.",
-                            retry_count - 1,
-                            max_retries
-                        );
-                        return Err(AppError::RateLimitExceeded);
-                    }
-
-                    warn!(
-                        "Rate limit exceeded (attempt {}): {}. Waiting {} seconds before retry...",
-                        retry_count, body_text, delay_secs
-                    );
-                    tokio::time::sleep(tokio::time::Duration::from_secs(delay_secs)).await;
-                    continue; // Retry the request
+                    warn!(status = ?status, "allowance rate limit hit");
+                    AppError::RateLimitExceeded
+                } else {
+                    error!(status = ?status, "forbidden");
+                    return Err(AppError::Unexpected(status));
                 }
-                error!("Forbidden: {}", body_text);
-                return Err(AppError::Unexpected(status));
             }
             StatusCode::UNAUTHORIZED => {
                 let body_text = response.text().await.unwrap_or_default();
                 if body_text.contains("oauth-token-invalid") {
+                    // Surface to the caller so it can refresh the token and replay.
                     return Err(AppError::OAuthTokenExpired);
                 }
-                error!("Unauthorized: {}", body_text);
+                error!(status = ?status, "unauthorized");
                 return Err(AppError::Unauthorized);
             }
-            _ => {
-                let body = response.text().await.unwrap_or_default();
-                error!("Request failed with status {}: {}", status, body);
-                return Err(AppError::Unexpected(status));
-            }
+            other => match classify_status(other) {
+                StatusClass::Retryable => {
+                    if other == StatusCode::TOO_MANY_REQUESTS {
+                        warn!(status = ?other, "rate limit (429) hit");
+                        AppError::RateLimitExceeded
+                    } else {
+                        warn!(status = ?other, "server error");
+                        AppError::Unexpected(other)
+                    }
+                }
+                StatusClass::Permanent => {
+                    error!(status = ?other, "request failed");
+                    return Err(AppError::Unexpected(other));
+                }
+            },
+        };
+
+        // We have a transient failure. Retry with exponential backoff unless the
+        // budget is exhausted (`attempt` here is < max_retries only when retrying).
+        if attempt < max_retries {
+            let delay = retry_config.delay_for_attempt(attempt);
+            let delay_ms = u64::try_from(delay.as_millis()).unwrap_or(u64::MAX);
+            warn!(
+                attempt = attempt.saturating_add(1),
+                max_retries, delay_ms, "retrying after transient failure"
+            );
+            tokio::time::sleep(delay).await;
+            continue;
         }
+
+        error!(max_retries, "retries exhausted after transient failures");
+        return Err(retryable_err);
+    }
+
+    // Unreachable: `0..=max_retries` always yields at least one iteration and the
+    // final iteration returns. Kept to satisfy the type checker without a panic.
+    Err(AppError::RateLimitExceeded)
+}
+
+/// Classification of an HTTP status code for retry decisions.
+///
+/// Body-dependent statuses (401, 403) are handled separately in
+/// [`make_http_request`]; this covers the status-only decisions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum StatusClass {
+    /// Transient failure: retry with backoff.
+    Retryable,
+    /// Permanent failure: return immediately.
+    Permanent,
+}
+
+/// Classifies a non-success HTTP status as transient (retryable) or permanent.
+///
+/// Transient: `429 Too Many Requests` and any `5xx` server error. Everything
+/// else (client errors other than 429) is permanent and fails fast.
+#[must_use]
+#[inline]
+pub(crate) fn classify_status(status: StatusCode) -> StatusClass {
+    if status == StatusCode::TOO_MANY_REQUESTS || status.is_server_error() {
+        StatusClass::Retryable
+    } else {
+        StatusClass::Permanent
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{StatusClass, classify_status};
+    use reqwest::StatusCode;
+
+    #[test]
+    fn test_classify_status_429_is_retryable() {
+        assert_eq!(
+            classify_status(StatusCode::TOO_MANY_REQUESTS),
+            StatusClass::Retryable
+        );
+    }
+
+    #[test]
+    fn test_classify_status_500_is_retryable() {
+        assert_eq!(
+            classify_status(StatusCode::INTERNAL_SERVER_ERROR),
+            StatusClass::Retryable
+        );
+        assert_eq!(
+            classify_status(StatusCode::BAD_GATEWAY),
+            StatusClass::Retryable
+        );
+        assert_eq!(
+            classify_status(StatusCode::SERVICE_UNAVAILABLE),
+            StatusClass::Retryable
+        );
+    }
+
+    #[test]
+    fn test_classify_status_400_is_permanent() {
+        assert_eq!(
+            classify_status(StatusCode::BAD_REQUEST),
+            StatusClass::Permanent
+        );
+        assert_eq!(
+            classify_status(StatusCode::NOT_FOUND),
+            StatusClass::Permanent
+        );
+        assert_eq!(
+            classify_status(StatusCode::CONFLICT),
+            StatusClass::Permanent
+        );
     }
 }

--- a/src/model/http.rs
+++ b/src/model/http.rs
@@ -494,6 +494,10 @@ pub async fn make_http_request<B: Serialize>(
             }
             other => match classify_status(other) {
                 StatusClass::Retryable => {
+                    // Drain the body (without logging it) so reqwest can return
+                    // the connection to the pool; an undrained body forces the
+                    // connection closed and amplifies load during retry storms.
+                    let _ = response.bytes().await;
                     if other == StatusCode::TOO_MANY_REQUESTS {
                         warn!(status = ?other, "rate limit (429) hit");
                         AppError::RateLimitExceeded

--- a/src/model/retry.rs
+++ b/src/model/retry.rs
@@ -3,40 +3,65 @@
    Email: jb@taunais.com
    Date: 20/10/25
 ******************************************************************************/
+use crate::constants::{
+    DEFAULT_MAX_RETRIES, DEFAULT_RETRY_DELAY_SECS, DEPRECATED_INFINITE_RETRY_CAP,
+    MAX_RETRY_DELAY_SECS,
+};
 use crate::prelude::{Deserialize, Serialize};
 use crate::utils::config::get_env_or_none;
 use pretty_simple_display::{DebugPretty, DisplaySimple};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-/// Configuration for HTTP request retry behavior
+/// Configuration for HTTP request retry behavior.
+///
+/// Retry is always finite: when a field is unset the finite defaults
+/// [`DEFAULT_MAX_RETRIES`] and [`DEFAULT_RETRY_DELAY_SECS`] apply. Unbounded
+/// retry was removed in PR #26 and must not be reintroduced.
 #[derive(DebugPretty, DisplaySimple, Clone, Deserialize, Serialize)]
 pub struct RetryConfig {
-    /// Maximum number of retries on rate limit (None = infinite retries)
+    /// Maximum number of retries on transient failures.
+    ///
+    /// `None` means "use [`DEFAULT_MAX_RETRIES`]" — it is never interpreted as
+    /// infinite retries.
     pub max_retry_count: Option<u32>,
-    /// Delay in seconds between retries (None = use default 10 seconds)
+    /// Base delay in seconds between retries.
+    ///
+    /// `None` means "use [`DEFAULT_RETRY_DELAY_SECS`]". This value is the base
+    /// for exponential backoff, not a fixed per-attempt delay.
     pub retry_delay_secs: Option<u64>,
 }
 
 impl RetryConfig {
-    /// Creates a new retry configuration with infinite retries and 10 second delay
+    /// Creates a new retry configuration with the finite defaults.
+    ///
+    /// Equivalent to [`RetryConfig::default`]: reads `MAX_RETRY_COUNT` /
+    /// `RETRY_DELAY_SECS` from the environment when set, otherwise uses
+    /// [`DEFAULT_MAX_RETRIES`] and [`DEFAULT_RETRY_DELAY_SECS`].
     #[must_use]
     pub fn new() -> Self {
         Self::default()
     }
 
-    /// Creates a new retry configuration with infinite retries
+    /// Deprecated: unbounded retry is banned (PR #26).
     ///
-    /// Uses `RETRY_DELAY_SECS` environment variable if set, otherwise defaults to 10 seconds.
+    /// Previously this returned a config with infinite retries. It now clamps to
+    /// [`DEPRECATED_INFINITE_RETRY_CAP`] — a large but finite cap — so callers
+    /// keep compiling while never looping forever. Use [`RetryConfig::default`]
+    /// or [`RetryConfig::with_max_retries`] instead.
+    ///
+    /// Uses `RETRY_DELAY_SECS` when set, otherwise [`DEFAULT_RETRY_DELAY_SECS`].
     #[must_use]
+    #[deprecated(note = "unbounded retry is banned; use a finite RetryConfig")]
     pub fn infinite() -> Self {
         Self {
-            max_retry_count: None, // infinite retries
+            max_retry_count: Some(DEPRECATED_INFINITE_RETRY_CAP),
             retry_delay_secs: get_env_or_none("RETRY_DELAY_SECS"),
         }
     }
 
-    /// Creates a new retry configuration with a maximum number of retries
+    /// Creates a new retry configuration with a maximum number of retries.
     ///
-    /// Uses `RETRY_DELAY_SECS` environment variable if set, otherwise defaults to 10 seconds.
+    /// Uses `RETRY_DELAY_SECS` when set, otherwise [`DEFAULT_RETRY_DELAY_SECS`].
     #[must_use]
     pub fn with_max_retries(max_retries: u32) -> Self {
         Self {
@@ -45,16 +70,21 @@ impl RetryConfig {
         }
     }
 
-    /// Creates a new retry configuration with custom delay
+    /// Deprecated: this constructor left the retry count unbounded.
+    ///
+    /// It now clamps the retry count to [`DEPRECATED_INFINITE_RETRY_CAP`] — a
+    /// large but finite cap — while still applying the custom base delay. Use
+    /// [`RetryConfig::with_max_retries_and_delay`] for an explicit finite cap.
     #[must_use]
+    #[deprecated(note = "unbounded retry is banned; use a finite RetryConfig")]
     pub fn with_delay(delay_secs: u64) -> Self {
         Self {
-            max_retry_count: None, // infinite retries
+            max_retry_count: Some(DEPRECATED_INFINITE_RETRY_CAP),
             retry_delay_secs: Some(delay_secs),
         }
     }
 
-    /// Creates a new retry configuration with both max retries and custom delay
+    /// Creates a new retry configuration with both max retries and custom delay.
     #[must_use]
     pub fn with_max_retries_and_delay(max_retries: u32, delay_secs: u64) -> Self {
         Self {
@@ -63,17 +93,71 @@ impl RetryConfig {
         }
     }
 
-    /// Gets the maximum retry count (0 = infinite)
+    /// Gets the maximum retry count.
+    ///
+    /// Always finite: returns [`DEFAULT_MAX_RETRIES`] when unconfigured. A value
+    /// of `0` means "try once, never retry"; it is never treated as infinite.
     #[must_use]
     pub fn max_retries(&self) -> u32 {
-        self.max_retry_count.unwrap_or(0)
+        self.max_retry_count.unwrap_or(DEFAULT_MAX_RETRIES)
     }
 
-    /// Gets the retry delay in seconds (default: 10)
+    /// Gets the base retry delay in seconds.
+    ///
+    /// Returns [`DEFAULT_RETRY_DELAY_SECS`] when unconfigured.
     #[must_use]
     pub fn delay_secs(&self) -> u64 {
-        self.retry_delay_secs.unwrap_or(10)
+        self.retry_delay_secs.unwrap_or(DEFAULT_RETRY_DELAY_SECS)
     }
+
+    /// Computes the backoff delay before the given 0-based retry `attempt`.
+    ///
+    /// Exponential: `base * 2^attempt` seconds, where `base` is
+    /// [`RetryConfig::delay_secs`], saturating at [`MAX_RETRY_DELAY_SECS`]. The
+    /// cap is the policy, so rounding down to it is intentional. A jitter of
+    /// `[0, 25%]` of the delay is added to avoid thundering-herd retries; the
+    /// jitter entropy comes from the current wall-clock subsecond nanoseconds
+    /// (this is jitter, not cryptographic randomness).
+    #[must_use]
+    pub fn delay_for_attempt(&self, attempt: u32) -> Duration {
+        backoff_delay(Duration::from_secs(self.delay_secs()), attempt)
+    }
+}
+
+/// Computes an exponential backoff delay with jitter for a given `base` delay
+/// and 0-based `attempt`.
+///
+/// The delay is `base * 2^attempt`, saturating at [`MAX_RETRY_DELAY_SECS`]
+/// (the cap is the policy). Checked arithmetic is used on the exponent so a
+/// large `attempt` cannot overflow; it simply saturates at the cap. A jitter of
+/// `[0, 25%]` of the delay is added, derived from wall-clock subsecond
+/// nanoseconds — this is jitter, not cryptographic randomness.
+#[must_use]
+pub(crate) fn backoff_delay(base: Duration, attempt: u32) -> Duration {
+    let cap = Duration::from_secs(MAX_RETRY_DELAY_SECS);
+
+    // base * 2^attempt. `checked_shl` guards the exponent (a shift >= 64 yields
+    // the max factor); the multiply then saturates and we clamp to `cap_ms`.
+    // Saturating to the cap here is intentional — the cap is the policy.
+    let base_ms = u64::try_from(base.as_millis()).unwrap_or(u64::MAX);
+    let cap_ms = u64::try_from(cap.as_millis()).unwrap_or(u64::MAX);
+
+    let factor = 1u64.checked_shl(attempt).unwrap_or(u64::MAX);
+    let scaled_ms = base_ms.saturating_mul(factor).min(cap_ms);
+
+    // Jitter in [0, 25%] of the (capped) delay. Entropy from wall-clock
+    // subsecond nanoseconds — documented as jitter, not crypto.
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |d| u64::from(d.subsec_nanos()));
+    let max_jitter = scaled_ms / 4;
+    let jitter_ms = if max_jitter == 0 {
+        0
+    } else {
+        nanos % (max_jitter + 1)
+    };
+
+    Duration::from_millis(scaled_ms.saturating_add(jitter_ms))
 }
 
 impl Default for RetryConfig {
@@ -85,5 +169,98 @@ impl Default for RetryConfig {
             max_retry_count,
             retry_delay_secs,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RetryConfig;
+    use crate::constants::{
+        DEFAULT_MAX_RETRIES, DEFAULT_RETRY_DELAY_SECS, DEPRECATED_INFINITE_RETRY_CAP,
+        MAX_RETRY_DELAY_SECS,
+    };
+    use std::time::Duration;
+
+    #[test]
+    fn test_retry_config_default_is_finite() {
+        // Constructed directly (not via env) so the assertion is deterministic.
+        let config = RetryConfig {
+            max_retry_count: None,
+            retry_delay_secs: None,
+        };
+        assert_eq!(config.max_retries(), DEFAULT_MAX_RETRIES);
+        assert_eq!(config.delay_secs(), DEFAULT_RETRY_DELAY_SECS);
+    }
+
+    #[test]
+    fn test_retry_config_explicit_zero_is_not_infinite() {
+        let config = RetryConfig {
+            max_retry_count: Some(0),
+            retry_delay_secs: None,
+        };
+        // Zero means "try once, never retry" — distinct from the unset default.
+        assert_eq!(config.max_retries(), 0);
+    }
+
+    #[test]
+    fn test_delay_for_attempt_grows_and_caps() {
+        let config = RetryConfig {
+            max_retry_count: None,
+            retry_delay_secs: Some(1), // 1s base keeps the math easy to bound.
+        };
+
+        // Each attempt's delay must sit within [base*2^n, base*2^n * 1.25].
+        for attempt in 0u32..4 {
+            let base_ms: u64 = 1000 * (1u64 << attempt);
+            let expected = base_ms.min(MAX_RETRY_DELAY_SECS * 1000);
+            let got =
+                u64::try_from(config.delay_for_attempt(attempt).as_millis()).unwrap_or(u64::MAX);
+            assert!(
+                got >= expected,
+                "attempt {attempt}: {got} < lower bound {expected}"
+            );
+            let upper = expected + expected / 4;
+            assert!(
+                got <= upper,
+                "attempt {attempt}: {got} > upper bound {upper}"
+            );
+        }
+
+        // Monotonic growth (ignoring jitter) until the cap: compare the
+        // exponential component only via the lower bounds already asserted.
+        let d0 = config.delay_for_attempt(0);
+        let d1 = config.delay_for_attempt(1);
+        let d2 = config.delay_for_attempt(2);
+        // Lower bound of d1 (2000ms) exceeds upper bound of d0 (1250ms), etc.
+        assert!(d1 >= Duration::from_millis(2000) && d0 <= Duration::from_millis(1250));
+        assert!(d2 >= Duration::from_millis(4000) && d1 <= Duration::from_millis(2500));
+    }
+
+    #[test]
+    fn test_delay_for_attempt_saturates_at_cap() {
+        let config = RetryConfig {
+            max_retry_count: None,
+            retry_delay_secs: Some(10),
+        };
+        // A very large attempt must saturate at the cap (+ up to 25% jitter),
+        // never overflow.
+        let got = config.delay_for_attempt(60);
+        let cap = Duration::from_secs(MAX_RETRY_DELAY_SECS);
+        assert!(got >= cap);
+        assert!(got <= cap + cap / 4);
+    }
+
+    #[test]
+    #[allow(deprecated)]
+    fn test_deprecated_infinite_is_finite() {
+        assert_eq!(
+            RetryConfig::infinite().max_retries(),
+            DEPRECATED_INFINITE_RETRY_CAP
+        );
+        assert_eq!(
+            RetryConfig::with_delay(5).max_retries(),
+            DEPRECATED_INFINITE_RETRY_CAP
+        );
+        assert_eq!(RetryConfig::with_delay(5).delay_secs(), 5);
     }
 }

--- a/tests/unit/utils/test_retry.rs
+++ b/tests/unit/utils/test_retry.rs
@@ -1,31 +1,32 @@
+use ig_client::constants::{
+    DEFAULT_MAX_RETRIES, DEFAULT_RETRY_DELAY_SECS, DEPRECATED_INFINITE_RETRY_CAP,
+    MAX_RETRY_DELAY_SECS,
+};
 use ig_client::model::retry::RetryConfig;
+use std::time::Duration;
 
 #[test]
-fn test_retry_config_new() {
+fn test_retry_config_new_has_positive_delay() {
     let config = RetryConfig::new();
-    assert_eq!(config.max_retries(), 0); // infinite
-    assert_eq!(config.delay_secs(), 10); // default
+    assert!(config.delay_secs() > 0);
 }
 
 #[test]
-fn test_retry_config_infinite() {
-    let config = RetryConfig::infinite();
-    assert_eq!(config.max_retries(), 0); // infinite
-    assert_eq!(config.delay_secs(), 10); // default
+fn test_retry_config_default_unset_is_finite() {
+    // Construct directly (not via env) so the assertion is deterministic and
+    // does not depend on MAX_RETRY_COUNT / RETRY_DELAY_SECS being unset.
+    let config = RetryConfig {
+        max_retry_count: None,
+        retry_delay_secs: None,
+    };
+    assert_eq!(config.max_retries(), DEFAULT_MAX_RETRIES);
+    assert_eq!(config.delay_secs(), DEFAULT_RETRY_DELAY_SECS);
 }
 
 #[test]
 fn test_retry_config_with_max_retries() {
     let config = RetryConfig::with_max_retries(5);
     assert_eq!(config.max_retries(), 5);
-    assert_eq!(config.delay_secs(), 10); // default
-}
-
-#[test]
-fn test_retry_config_with_delay() {
-    let config = RetryConfig::with_delay(30);
-    assert_eq!(config.max_retries(), 0); // infinite
-    assert_eq!(config.delay_secs(), 30);
 }
 
 #[test]
@@ -36,10 +37,27 @@ fn test_retry_config_with_max_retries_and_delay() {
 }
 
 #[test]
-fn test_retry_config_default() {
+#[allow(deprecated)]
+fn test_retry_config_deprecated_infinite_is_finite() {
+    // The deprecated "infinite" constructor must now be finite.
+    let config = RetryConfig::infinite();
+    assert_eq!(config.max_retries(), DEPRECATED_INFINITE_RETRY_CAP);
+}
+
+#[test]
+#[allow(deprecated)]
+fn test_retry_config_deprecated_with_delay_is_finite() {
+    let config = RetryConfig::with_delay(30);
+    assert_eq!(config.max_retries(), DEPRECATED_INFINITE_RETRY_CAP);
+    assert_eq!(config.delay_secs(), 30);
+}
+
+#[test]
+fn test_retry_config_default_has_positive_delay() {
     let config = RetryConfig::default();
-    // Should use environment variables or defaults
     assert!(config.delay_secs() > 0);
+    // The retry count is always finite regardless of environment.
+    assert!(config.max_retries() >= 1 || config.max_retries() == 0);
 }
 
 #[test]
@@ -50,11 +68,12 @@ fn test_retry_config_max_retries_getter() {
     };
     assert_eq!(config1.max_retries(), 10);
 
+    // Unset falls back to the finite default, never infinite.
     let config2 = RetryConfig {
         max_retry_count: None,
         retry_delay_secs: None,
     };
-    assert_eq!(config2.max_retries(), 0);
+    assert_eq!(config2.max_retries(), DEFAULT_MAX_RETRIES);
 }
 
 #[test]
@@ -69,5 +88,46 @@ fn test_retry_config_delay_secs_getter() {
         max_retry_count: None,
         retry_delay_secs: None,
     };
-    assert_eq!(config2.delay_secs(), 10);
+    assert_eq!(config2.delay_secs(), DEFAULT_RETRY_DELAY_SECS);
+}
+
+#[test]
+fn test_retry_config_backoff_grows_and_caps() {
+    let config = RetryConfig {
+        max_retry_count: None,
+        retry_delay_secs: Some(1), // 1s base keeps the bounds easy to reason about.
+    };
+
+    // delay_for_attempt(0) < delay_for_attempt(1) < delay_for_attempt(2)
+    // ignoring jitter: lower bound of attempt n+1 exceeds upper bound of n.
+    for attempt in 0u32..3 {
+        let base_ms: u64 = 1000 * (1u64 << attempt);
+        let expected = base_ms.min(MAX_RETRY_DELAY_SECS * 1000);
+        let got = u64::try_from(config.delay_for_attempt(attempt).as_millis()).unwrap_or(u64::MAX);
+        assert!(got >= expected, "attempt {attempt}: {got} < {expected}");
+        assert!(
+            got <= expected + expected / 4,
+            "attempt {attempt}: {got} exceeds +25% of {expected}"
+        );
+    }
+
+    // Explicit ordering with the jitter-safe bounds.
+    let d0 = config.delay_for_attempt(0);
+    let d1 = config.delay_for_attempt(1);
+    let d2 = config.delay_for_attempt(2);
+    assert!(d0 <= Duration::from_millis(1250));
+    assert!(d1 >= Duration::from_millis(2000) && d1 <= Duration::from_millis(2500));
+    assert!(d2 >= Duration::from_millis(4000));
+}
+
+#[test]
+fn test_retry_config_backoff_saturates_at_cap() {
+    let config = RetryConfig {
+        max_retry_count: None,
+        retry_delay_secs: Some(10),
+    };
+    // A large attempt saturates at the cap (+ up to 25% jitter), never overflows.
+    let cap = Duration::from_secs(MAX_RETRY_DELAY_SECS);
+    let got = config.delay_for_attempt(60);
+    assert!(got >= cap && got <= cap + cap / 4);
 }

--- a/tests/unit/utils/test_retry.rs
+++ b/tests/unit/utils/test_retry.rs
@@ -56,8 +56,11 @@ fn test_retry_config_deprecated_with_delay_is_finite() {
 fn test_retry_config_default_has_positive_delay() {
     let config = RetryConfig::default();
     assert!(config.delay_secs() > 0);
-    // The retry count is always finite regardless of environment.
-    assert!(config.max_retries() >= 1 || config.max_retries() == 0);
+    // The retry count is always finite: bounded by the deprecated-infinite cap
+    // regardless of the MAX_RETRY_COUNT environment override. The exact
+    // unset-default value (DEFAULT_MAX_RETRIES) is asserted env-independently in
+    // test_retry_config_max_retries_getter via direct field construction.
+    assert!(config.max_retries() <= DEPRECATED_INFINITE_RETRY_CAP);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

`login_v2`, `login_oauth` and `switch_account` passed `RetryConfig::infinite()` to `make_http_request`, so a persistent 403 allowance error retried forever every 10 s — and since every request funnels through `get_session()`, the whole client wedged. On top of that, `RetryConfig::default()` silently meant *infinite* whenever the `MAX_RETRY_COUNT` env var was unset, reverting the deliberate removal of unbounded retry in PR #26. This PR makes every retry path finite and brings the loop up to the rules' backoff discipline.

## Changes

- `RetryConfig::default()` resolves to a documented finite constant (`DEFAULT_MAX_RETRIES = 3`) when `MAX_RETRY_COUNT` is unset; `None` can no longer mean infinite, `Some(0)` still means try-once.
- `RetryConfig::infinite()` / `with_delay()` are `#[deprecated]` and clamped to a finite cap (1000 attempts); zero production call sites remain.
- The three auth flows use `RetryConfig::default()`.
- `make_http_request` is a bounded `for attempt in 0..=max_retries` loop; retry delays follow `base * 2^attempt` capped at 60 s plus 0–25 % jitter (entropy from `SystemTime` subsec-nanos — jitter, not crypto; no new dependency).
- HTTP 429 now maps to `AppError::RateLimitExceeded` and is retried with backoff via the extracted pure `classify_status()` (429 + 5xx retryable, other 4xx permanent). The 403 allowance markers and the 401 refresh-once-and-replay path are unchanged.
- `get_order_confirmation_w_retry` retries only transient errors (rate limit, network, not-found-yet, 5xx) and returns permanent ones immediately; delays derive from the shared backoff. Signature unchanged.

## Technical decisions

- Deprecate-and-clamp instead of removing `infinite()`: preserves the public surface (semver) while making the banned behavior unreachable in practice.
- Backoff policy lives in `RetryConfig` (`delay_for_attempt`), not at call sites; saturation at the 60 s cap is the documented rounding.
- Checked arithmetic on retry counters per `rules/global_rules.md`.

## Testing

- [x] Unit tests added or updated — 17 new/updated tests: finite-default semantics, `Some(0)` vs `None`, backoff growth + cap + saturation, deprecated-fn clamps, `classify_status` (429/5xx/4xx), confirmation-error transient/permanent classification
- [x] Live-API tests under `tests/integration/` remain env-gated
- [x] `make pre-push` run locally and clean

Resilience review (retry storms, refresh loops, blocking calls, overflow): PASS — no unbounded path remains; 401-refresh is once-per-request by construction; backoff math saturates safely.

Closes #45
