### PR TITLE
fix(rate-limit): honor max_requests, non-polling wait, per-class buckets (#48)

### DIFF
--- a/src/application/rate_limiter.rs
+++ b/src/application/rate_limiter.rs
@@ -105,8 +105,11 @@ pub struct RateLimiter {
 ///   (one request per period).
 /// - `period_seconds == 0` falls back to a one-second period.
 ///
-/// Rounding is toward zero (integer nanosecond division); the result is clamped
-/// to at least one nanosecond so the interval is always non-zero.
+/// Rounding is toward positive infinity (ceiling division): the per-cell
+/// interval is never shorter than `period / max_requests`, so the enforced rate
+/// never *exceeds* the configured budget for periods that are not evenly
+/// divisible. The result is clamped to at least one nanosecond so the interval
+/// is always non-zero.
 #[must_use]
 #[inline]
 fn replenish_period(config: &RateLimiterConfig) -> Duration {
@@ -119,8 +122,10 @@ fn replenish_period(config: &RateLimiterConfig) -> Duration {
     // `as_nanos` is u128; clamp to u64 for the very large (multi-century) periods
     // that cannot occur in practice but must not panic.
     let period_nanos = u64::try_from(period.as_nanos()).unwrap_or(u64::MAX);
-    // `max_requests >= 1` here, so this division can never divide by zero.
-    let per_cell_nanos = (period_nanos / u64::from(max_requests)).max(1);
+    // Ceiling division: round the interval UP so the derived rate can only be
+    // at or below `max_requests` per period, never above it. `max_requests >= 1`
+    // here, so this can never divide by zero.
+    let per_cell_nanos = period_nanos.div_ceil(u64::from(max_requests)).max(1);
     Duration::from_nanos(per_cell_nanos)
 }
 
@@ -359,33 +364,47 @@ mod tests {
         assert_eq!(per_second_period(0), Duration::from_secs(1));
     }
 
-    #[tokio::test]
-    async fn test_wait_for_replenishes_at_configured_rate() {
-        // 20 requests / 1 second => one cell every 50ms. With burst_size 1 only
-        // the initial cell is immediately available; the next must wait ~50ms.
+    #[test]
+    fn test_configured_quota_replenishes_at_max_requests_rate() {
+        // Deterministic (no wall clock): drive the config-derived quota through
+        // governor's FakeRelativeClock. 20 requests / 1 second => one cell every
+        // 50ms. Under the OLD `with_period(period)` bug the interval was the whole
+        // 1s period, so advancing 50ms would NOT replenish — this test pins the fix.
+        use governor::clock::FakeRelativeClock;
+
         let config = RateLimiterConfig {
             max_requests: 20,
             period_seconds: 1,
             burst_size: 1,
         };
-        let limiter = RateLimiter::new(&config);
+        let interval = replenish_period(&config);
+        assert_eq!(interval, Duration::from_millis(50));
 
-        // Consume the single burst cell.
-        assert!(limiter.check_for(RateLimitClass::NonTrading));
+        let burst = NonZeroU32::new(config.burst_size).expect("burst is non-zero");
+        let quota = Quota::with_period(interval)
+            .expect("non-zero interval")
+            .allow_burst(burst);
+        let clock = FakeRelativeClock::default();
+        let limiter = GovernorRateLimiter::direct_with_clock(quota, clock.clone());
 
-        let start = std::time::Instant::now();
-        limiter.wait_for(RateLimitClass::NonTrading).await;
-        let elapsed = start.elapsed();
+        // The single burst cell is available, then exhausted.
+        assert!(limiter.check().is_ok());
+        assert!(limiter.check().is_err(), "burst cell must be exhausted");
 
-        // Under the OLD `with_period(period)` bug the interval was the whole 1s
-        // period (~1000ms); honoring max_requests makes it ~50ms.
+        // Before a full interval elapses the cell stays denied (the old 1s-per-cell
+        // bug would still be denied here — that is fine — but see the next step).
+        clock.advance(interval / 2);
         assert!(
-            elapsed >= Duration::from_millis(20),
-            "waited {elapsed:?}, expected ~50ms replenishment (rate limiting must apply)"
+            limiter.check().is_err(),
+            "must not replenish before the configured interval"
         );
+
+        // After the full 50ms interval exactly one cell replenishes. The old bug
+        // (1s per cell) would still deny here — so this asserts max_requests is honored.
+        clock.advance(interval / 2);
         assert!(
-            elapsed < Duration::from_millis(500),
-            "waited {elapsed:?}, the old 1s-per-cell bug is not fixed"
+            limiter.check().is_ok(),
+            "one cell must replenish after the configured 50ms interval"
         );
     }
 
@@ -418,9 +437,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_wait_for_returns_promptly_when_slot_available() {
-        // A fresh bucket with burst capacity admits the first request without any
-        // wait — proving `wait_for` resolves via the scheduler, not a 10ms poll.
+    async fn test_wait_for_returns_without_parking_when_slot_available() {
+        // A fresh bucket with burst capacity has a permit available, so `wait_for`
+        // resolves immediately via governor's scheduler rather than parking or
+        // polling. Asserted deterministically via permit availability (no wall
+        // clock): `check_for` is true, and the subsequent `wait_for` must not hang.
         let config = RateLimiterConfig {
             max_requests: 10,
             period_seconds: 1,
@@ -428,12 +449,13 @@ mod tests {
         };
         let limiter = RateLimiter::new(&config);
 
-        let start = std::time::Instant::now();
-        limiter.wait_for(RateLimitClass::NonTrading).await;
         assert!(
-            start.elapsed() < Duration::from_millis(50),
-            "wait_for should return promptly when a slot is available"
+            limiter.check_for(RateLimitClass::NonTrading),
+            "a burst slot must be available on a fresh bucket"
         );
+        // Must return without parking because a permit is available; if it hung,
+        // the test would time out rather than pass.
+        limiter.wait_for(RateLimitClass::NonTrading).await;
     }
 
     #[test]

--- a/src/application/rate_limiter.rs
+++ b/src/application/rate_limiter.rs
@@ -8,8 +8,33 @@
 //!
 //! This module provides rate limiting functionality using the `governor` crate
 //! to ensure compliance with IG Markets API rate limits.
+//!
+//! # Enforced budget
+//!
+//! `RateLimiter` holds one `governor` token bucket per
+//! `RateLimitClass`, all derived from the single
+//! `RateLimiterConfig` passed to
+//! `RateLimiter::new`:
+//!
+//! - `NonTrading` honors the configured budget
+//!   exactly: `max_requests` requests per `period_seconds`, with `burst_size`
+//!   burst capacity. The per-cell replenishment interval is `period_seconds /
+//!   max_requests`.
+//! - `Trading` uses a stricter, fixed budget derived
+//!   from IG's published per-app trading limit (~1 request/second), independent
+//!   of the configured budget so a permissive config cannot loosen it.
+//! - `Historical` uses its own conservative bucket
+//!   because historical price fetches also draw down a weekly data-point
+//!   allowance.
+//!
+//! The buckets are independent, so bulk non-trading traffic can never queue
+//! order placement behind it.
 
 use crate::application::config::RateLimiterConfig;
+use crate::constants::{
+    DEFAULT_RATE_LIMIT_BURST_SIZE, FALLBACK_RATE_LIMIT_MAX_REQUESTS,
+    HISTORICAL_RATE_LIMIT_PER_SECOND, TRADING_HISTORICAL_BURST_SIZE, TRADING_RATE_LIMIT_PER_SECOND,
+};
 use governor::{
     Quota, RateLimiter as GovernorRateLimiter,
     clock::QuantaClock,
@@ -19,17 +44,129 @@ use std::num::NonZeroU32;
 use std::sync::Arc;
 use std::time::Duration;
 
+/// Concrete `governor` direct rate limiter used for every class.
+type DirectLimiter = GovernorRateLimiter<NotKeyed, InMemoryState, QuantaClock>;
+
+/// Number of nanoseconds in one second, used when deriving per-second budgets.
+const NANOS_PER_SECOND: u64 = 1_000_000_000;
+
+/// Rate-limit class for an IG endpoint.
+///
+/// IG applies separate budgets to trading and non-trading traffic, and
+/// historical price fetches additionally draw down a weekly data-point
+/// allowance. Each class maps to an independent token bucket inside
+/// `RateLimiter` so one kind of traffic never starves another.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(u8)]
+pub enum RateLimitClass {
+    /// Order and position mutations (`positions/otc`, `workingorders/otc`).
+    ///
+    /// Subject to IG's strict per-app trading limit; the most tightly paced
+    /// class.
+    Trading,
+    /// Historical price fetches (endpoints under `prices/`).
+    ///
+    /// Subject to a weekly data-point allowance in addition to a per-second
+    /// rate, so it gets its own conservative bucket.
+    Historical,
+    /// Everything else: market data, account queries, sentiment, watchlists,
+    /// working-order and position *reads*, and so on.
+    ///
+    /// Paced by the configured `RateLimiterConfig` budget.
+    NonTrading,
+}
+
 /// Rate limiter for controlling API request rates
 ///
-/// Uses the `governor` crate to implement a token bucket algorithm
-/// for rate limiting API requests.
+/// Uses the `governor` crate to implement a token bucket algorithm for rate
+/// limiting API requests, with one independent bucket per `RateLimitClass`.
+/// See the [module documentation](self) for the enforced budget of each class.
 #[derive(Clone)]
 pub struct RateLimiter {
-    limiter: Arc<GovernorRateLimiter<NotKeyed, InMemoryState, QuantaClock>>,
+    /// Bucket for `RateLimitClass::NonTrading` — the configured budget.
+    non_trading: Arc<DirectLimiter>,
+    /// Bucket for `RateLimitClass::Trading` — derived strict trading budget.
+    trading: Arc<DirectLimiter>,
+    /// Bucket for `RateLimitClass::Historical` — derived conservative budget.
+    historical: Arc<DirectLimiter>,
+}
+
+/// Computes the per-cell replenishment interval that honors the configured
+/// budget: `period_seconds / max_requests`.
+///
+/// This is the core fix for issue #48. The previous implementation used the
+/// whole `period_seconds` as the interval and ignored `max_requests` entirely,
+/// so a `{ max_requests: 60, period_seconds: 60 }` config allowed ~1
+/// request/minute instead of 60.
+///
+/// Guards the structurally-invalid zero cases without dividing by zero or
+/// building a zero-length period:
+/// - `max_requests == 0` falls back to [`FALLBACK_RATE_LIMIT_MAX_REQUESTS`]
+///   (one request per period).
+/// - `period_seconds == 0` falls back to a one-second period.
+///
+/// Rounding is toward zero (integer nanosecond division); the result is clamped
+/// to at least one nanosecond so the interval is always non-zero.
+#[must_use]
+#[inline]
+fn replenish_period(config: &RateLimiterConfig) -> Duration {
+    let max_requests = config.max_requests.max(FALLBACK_RATE_LIMIT_MAX_REQUESTS);
+    let period = if config.period_seconds == 0 {
+        Duration::from_secs(1)
+    } else {
+        Duration::from_secs(config.period_seconds)
+    };
+    // `as_nanos` is u128; clamp to u64 for the very large (multi-century) periods
+    // that cannot occur in practice but must not panic.
+    let period_nanos = u64::try_from(period.as_nanos()).unwrap_or(u64::MAX);
+    // `max_requests >= 1` here, so this division can never divide by zero.
+    let per_cell_nanos = (period_nanos / u64::from(max_requests)).max(1);
+    Duration::from_nanos(per_cell_nanos)
+}
+
+/// Per-cell replenishment interval for a fixed "requests per second" budget.
+///
+/// Used to derive the trading and historical buckets. Guards `requests_per_second
+/// == 0` by treating it as one, and clamps the result to at least one nanosecond.
+#[must_use]
+#[inline]
+fn per_second_period(requests_per_second: u32) -> Duration {
+    let rps = u64::from(requests_per_second.max(1));
+    Duration::from_nanos((NANOS_PER_SECOND / rps).max(1))
+}
+
+/// Builds a direct `governor` limiter for a per-cell interval and burst size.
+///
+/// Guards both invalid inputs without panicking:
+/// - a zero `burst_size` falls back to [`DEFAULT_RATE_LIMIT_BURST_SIZE`];
+/// - a zero-length `period_per_cell` (structurally unreachable given the callers)
+///   falls back to a one-request-per-second quota via [`Quota::per_second`].
+#[must_use]
+fn build_limiter(period_per_cell: Duration, burst_size: u32) -> Arc<DirectLimiter> {
+    let burst = NonZeroU32::new(burst_size)
+        .or_else(|| NonZeroU32::new(DEFAULT_RATE_LIMIT_BURST_SIZE))
+        .unwrap_or(NonZeroU32::MIN);
+
+    let quota = match Quota::with_period(period_per_cell) {
+        Some(quota) => quota.allow_burst(burst),
+        // Unreachable in practice: `replenish_period` / `per_second_period`
+        // always yield a non-zero interval. Fall back to a safe quota instead of
+        // panicking so the limiter stays functional.
+        None => Quota::per_second(NonZeroU32::MIN).allow_burst(burst),
+    };
+
+    Arc::new(GovernorRateLimiter::direct(quota))
 }
 
 impl RateLimiter {
     /// Creates a new rate limiter from configuration
+    ///
+    /// The non-trading bucket honors the configured budget exactly: it admits
+    /// `config.max_requests` requests per `config.period_seconds`, with
+    /// `config.burst_size` burst capacity (replenishing one cell every
+    /// `period_seconds / max_requests`). The trading and historical buckets use
+    /// stricter, fixed budgets derived from IG's published limits and are
+    /// independent of the configured budget. See the [module documentation](self).
     ///
     /// # Arguments
     ///
@@ -51,30 +188,74 @@ impl RateLimiter {
     ///     burst_size: 10,
     /// };
     ///
+    /// // Non-trading admits 60 requests/minute (one cell per second, +burst).
     /// let limiter = RateLimiter::new(&config);
     /// ```
     #[must_use]
     pub fn new(config: &RateLimiterConfig) -> Self {
-        let period = Duration::from_secs(config.period_seconds);
-
-        let burst_size = NonZeroU32::new(config.burst_size)
-            .unwrap_or_else(|| NonZeroU32::new(10).expect("10 is non-zero"));
-
-        let quota = Quota::with_period(period)
-            .expect("Valid period")
-            .allow_burst(burst_size);
-
-        let limiter = GovernorRateLimiter::direct(quota);
+        let non_trading = build_limiter(replenish_period(config), config.burst_size);
+        let trading = build_limiter(
+            per_second_period(TRADING_RATE_LIMIT_PER_SECOND),
+            TRADING_HISTORICAL_BURST_SIZE,
+        );
+        let historical = build_limiter(
+            per_second_period(HISTORICAL_RATE_LIMIT_PER_SECOND),
+            TRADING_HISTORICAL_BURST_SIZE,
+        );
 
         Self {
-            limiter: Arc::new(limiter),
+            non_trading,
+            trading,
+            historical,
         }
     }
 
-    /// Waits until a request can be made according to the rate limit
+    /// Returns the underlying limiter for a given rate-limit class.
+    #[inline]
+    fn limiter_for(&self, class: RateLimitClass) -> &DirectLimiter {
+        match class {
+            RateLimitClass::Trading => &self.trading,
+            RateLimitClass::Historical => &self.historical,
+            RateLimitClass::NonTrading => &self.non_trading,
+        }
+    }
+
+    /// Waits until a request in the given class can be made according to its
+    /// rate limit.
     ///
-    /// This method blocks until the rate limiter allows the request to proceed.
-    /// It uses an async-friendly waiting mechanism.
+    /// Uses `governor`'s async scheduler ([`until_ready`](GovernorRateLimiter::until_ready)):
+    /// the future is parked until a slot is available rather than busy-polling.
+    /// Each class has an independent bucket, so waiting on one class never blocks
+    /// another.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// use ig_client::application::rate_limiter::RateLimitClass;
+    /// limiter.wait_for(RateLimitClass::Trading).await;
+    /// // Place order here
+    /// ```
+    pub async fn wait_for(&self, class: RateLimitClass) {
+        self.limiter_for(class).until_ready().await;
+    }
+
+    /// Checks if a request in the given class can be made immediately without
+    /// waiting.
+    ///
+    /// # Returns
+    ///
+    /// * `true` if a request can be made immediately
+    /// * `false` if that class's rate limit has been reached
+    #[must_use]
+    pub fn check_for(&self, class: RateLimitClass) -> bool {
+        self.limiter_for(class).check().is_ok()
+    }
+
+    /// Waits until a non-trading request can be made according to the rate limit
+    ///
+    /// Convenience wrapper over [`wait_for`](Self::wait_for) with
+    /// `RateLimitClass::NonTrading`. Blocks (asynchronously) until the rate
+    /// limiter allows the request to proceed.
     ///
     /// # Example
     ///
@@ -83,12 +264,13 @@ impl RateLimiter {
     /// // Make API request here
     /// ```
     pub async fn wait(&self) {
-        while self.limiter.check().is_err() {
-            tokio::time::sleep(Duration::from_millis(10)).await;
-        }
+        self.wait_for(RateLimitClass::NonTrading).await;
     }
 
-    /// Checks if a request can be made immediately without waiting
+    /// Checks if a non-trading request can be made immediately without waiting
+    ///
+    /// Convenience wrapper over [`check_for`](Self::check_for) with
+    /// `RateLimitClass::NonTrading`.
     ///
     /// # Returns
     ///
@@ -106,14 +288,16 @@ impl RateLimiter {
     /// ```
     #[must_use]
     pub fn check(&self) -> bool {
-        self.limiter.check().is_ok()
+        self.check_for(RateLimitClass::NonTrading)
     }
 }
 
 impl std::fmt::Debug for RateLimiter {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("RateLimiter")
-            .field("limiter", &"GovernorRateLimiter")
+            .field("non_trading", &"GovernorRateLimiter")
+            .field("trading", &"GovernorRateLimiter")
+            .field("historical", &"GovernorRateLimiter")
             .finish()
     }
 }
@@ -122,42 +306,155 @@ impl std::fmt::Debug for RateLimiter {
 mod tests {
     use super::*;
 
+    #[test]
+    fn test_replenish_period_honors_max_requests() {
+        // 60 requests per 60 seconds => one cell every 1 second.
+        let config = RateLimiterConfig {
+            max_requests: 60,
+            period_seconds: 60,
+            burst_size: 3,
+        };
+        assert_eq!(replenish_period(&config), Duration::from_secs(1));
+        // The OLD bug used the whole 60s period as the interval (~1 req/minute);
+        // the interval must be P/N, not P.
+        assert_ne!(replenish_period(&config), Duration::from_secs(60));
+
+        // 4 requests per 12 seconds => one cell every 3 seconds.
+        let config = RateLimiterConfig {
+            max_requests: 4,
+            period_seconds: 12,
+            burst_size: 3,
+        };
+        assert_eq!(replenish_period(&config), Duration::from_secs(3));
+    }
+
+    #[test]
+    fn test_replenish_period_zero_max_requests_falls_back() {
+        // max_requests == 0 is structurally invalid: fall back to one request per
+        // period (10s per cell) rather than dividing by zero.
+        let config = RateLimiterConfig {
+            max_requests: 0,
+            period_seconds: 10,
+            burst_size: 1,
+        };
+        assert_eq!(replenish_period(&config), Duration::from_secs(10));
+    }
+
+    #[test]
+    fn test_replenish_period_zero_period_falls_back() {
+        // period_seconds == 0 falls back to a one-second period: 5 req/s => 200ms.
+        let config = RateLimiterConfig {
+            max_requests: 5,
+            period_seconds: 0,
+            burst_size: 1,
+        };
+        assert_eq!(replenish_period(&config), Duration::from_millis(200));
+    }
+
+    #[test]
+    fn test_per_second_period_matches_rate() {
+        assert_eq!(per_second_period(1), Duration::from_secs(1));
+        assert_eq!(per_second_period(4), Duration::from_millis(250));
+        // Zero is treated as one to avoid dividing by zero.
+        assert_eq!(per_second_period(0), Duration::from_secs(1));
+    }
+
     #[tokio::test]
-    async fn test_rate_limiter_allows_requests() {
+    async fn test_wait_for_replenishes_at_configured_rate() {
+        // 20 requests / 1 second => one cell every 50ms. With burst_size 1 only
+        // the initial cell is immediately available; the next must wait ~50ms.
+        let config = RateLimiterConfig {
+            max_requests: 20,
+            period_seconds: 1,
+            burst_size: 1,
+        };
+        let limiter = RateLimiter::new(&config);
+
+        // Consume the single burst cell.
+        assert!(limiter.check_for(RateLimitClass::NonTrading));
+
+        let start = std::time::Instant::now();
+        limiter.wait_for(RateLimitClass::NonTrading).await;
+        let elapsed = start.elapsed();
+
+        // Under the OLD `with_period(period)` bug the interval was the whole 1s
+        // period (~1000ms); honoring max_requests makes it ~50ms.
+        assert!(
+            elapsed >= Duration::from_millis(20),
+            "waited {elapsed:?}, expected ~50ms replenishment (rate limiting must apply)"
+        );
+        assert!(
+            elapsed < Duration::from_millis(500),
+            "waited {elapsed:?}, the old 1s-per-cell bug is not fixed"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_trading_not_blocked_behind_saturated_non_trading() {
+        // Single-cell non-trading bucket that will not replenish for ~60s.
+        let config = RateLimiterConfig {
+            max_requests: 1,
+            period_seconds: 60,
+            burst_size: 1,
+        };
+        let limiter = RateLimiter::new(&config);
+
+        // Saturate the non-trading bucket: first admits, second is denied.
+        assert!(limiter.check_for(RateLimitClass::NonTrading));
+        assert!(
+            !limiter.check_for(RateLimitClass::NonTrading),
+            "non-trading bucket should be saturated"
+        );
+
+        // Trading and historical have independent buckets and still admit.
+        assert!(
+            limiter.check_for(RateLimitClass::Trading),
+            "trading must not be blocked behind a saturated non-trading bucket"
+        );
+        assert!(
+            limiter.check_for(RateLimitClass::Historical),
+            "historical must not be blocked behind a saturated non-trading bucket"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_wait_for_returns_promptly_when_slot_available() {
+        // A fresh bucket with burst capacity admits the first request without any
+        // wait — proving `wait_for` resolves via the scheduler, not a 10ms poll.
         let config = RateLimiterConfig {
             max_requests: 10,
             period_seconds: 1,
             burst_size: 5,
         };
-
         let limiter = RateLimiter::new(&config);
 
-        // Should allow first few requests immediately
-        for _ in 0..5 {
-            assert!(limiter.check());
-        }
+        let start = std::time::Instant::now();
+        limiter.wait_for(RateLimitClass::NonTrading).await;
+        assert!(
+            start.elapsed() < Duration::from_millis(50),
+            "wait_for should return promptly when a slot is available"
+        );
     }
 
-    #[tokio::test]
-    async fn test_rate_limiter_wait() {
+    #[test]
+    fn test_check_delegates_to_non_trading() {
+        // `check()` (no class) must observe the same bucket as
+        // `check_for(NonTrading)` so existing callers keep their semantics.
         let config = RateLimiterConfig {
-            max_requests: 2,
-            period_seconds: 1,
-            burst_size: 2,
+            max_requests: 1,
+            period_seconds: 60,
+            burst_size: 1,
         };
-
         let limiter = RateLimiter::new(&config);
 
-        // First two requests should succeed immediately
-        limiter.wait().await;
-        limiter.wait().await;
-
-        // Third request should wait
-        let start = std::time::Instant::now();
-        limiter.wait().await;
-        let elapsed = start.elapsed();
-
-        // Should have waited some time (but not too long for the test)
-        assert!(elapsed.as_millis() > 0);
+        assert!(limiter.check());
+        assert!(
+            !limiter.check(),
+            "check() must delegate to the non-trading bucket"
+        );
+        assert!(
+            !limiter.check_for(RateLimitClass::NonTrading),
+            "check_for(NonTrading) must observe the same saturated bucket as check()"
+        );
     }
 }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -36,6 +36,39 @@ pub const BASE_DELAY_MS: u64 = 1000;
 pub const SAFETY_BUFFER_MS: u64 = 1000;
 /// User agent string used in HTTP requests to identify this client to the IG Markets API
 pub const USER_AGENT: &str = "Rust-IG-Client/0.1.9";
+/// Conservative per-app trading request budget, in requests per second,
+/// enforced by the rate limiter for order / position mutations
+/// (`positions/otc`, `workingorders/otc`).
+///
+/// IG applies account-level bans for trading rate violations and the published
+/// per-app trading limit is roughly one request per second, so this budget is
+/// fixed independently of the configured non-trading budget: a permissive
+/// `RateLimiterConfig` can never loosen it.
+pub const TRADING_RATE_LIMIT_PER_SECOND: u32 = 1;
+/// Conservative per-app historical-price request budget, in requests per second,
+/// enforced by the rate limiter for endpoints under `prices/`.
+///
+/// Historical price fetches also draw down a weekly data-point allowance (default
+/// 10,000 points), so the per-second rate is kept low to avoid exhausting the
+/// allowance in bursts. Like the trading budget, it is fixed independently of the
+/// configured non-trading budget.
+pub const HISTORICAL_RATE_LIMIT_PER_SECOND: u32 = 1;
+/// Burst capacity for the derived trading and historical rate-limit buckets.
+///
+/// Kept at one so the derived per-second budgets admit no burst beyond a single
+/// in-flight request, matching IG's strict trading / historical limits.
+pub const TRADING_HISTORICAL_BURST_SIZE: u32 = 1;
+/// Fallback replenishment budget (requests per period) used when
+/// [`crate::application::config::RateLimiterConfig::max_requests`] is configured
+/// as zero, which is structurally invalid.
+///
+/// One request per configured period is the safe floor and avoids a
+/// divide-by-zero when computing the per-cell replenishment interval.
+pub const FALLBACK_RATE_LIMIT_MAX_REQUESTS: u32 = 1;
+/// Fallback burst capacity used when
+/// [`crate::application::config::RateLimiterConfig::burst_size`] is configured as
+/// zero. Preserves the historical default of allowing a small burst.
+pub const DEFAULT_RATE_LIMIT_BURST_SIZE: u32 = 10;
 /// A constant representing the default sell level for orders.
 ///
 /// This value is set to `0.0` by default and can be used to indicate an initial or

--- a/src/model/http.rs
+++ b/src/model/http.rs
@@ -6,7 +6,7 @@
 
 use crate::application::auth::{Auth, Session, WebsocketInfo};
 use crate::application::config::Config;
-use crate::application::rate_limiter::RateLimiter;
+use crate::application::rate_limiter::{RateLimitClass, RateLimiter};
 use crate::error::AppError;
 use crate::model::retry::RetryConfig;
 use reqwest::Client as HttpInternalClient;
@@ -423,16 +423,22 @@ pub async fn make_http_request<B: Serialize>(
 ) -> Result<Response, AppError> {
     let max_retries = retry_config.max_retries();
 
+    // Pace this request against the bucket for its endpoint class (trading /
+    // historical / non-trading) so trading calls never queue behind bulk
+    // non-trading traffic. The class is derived purely from the method + URL.
+    let class = classify_endpoint(&method, url);
+
     // Bounded loop: `attempt` ranges over [0, max_retries]. Attempt 0 is the
     // first try; each further attempt is a retry. This can never loop forever.
     for attempt in 0..=max_retries {
-        // Wait for rate limiter before making request
-        {
-            let limiter = rate_limiter.read().await;
-            limiter.wait().await;
-        }
+        // Wait for rate limiter before making request. Clone the limiter (cheap
+        // `Arc` copy) out of the read guard and drop the guard before awaiting,
+        // so a pending config swap on the write side is never blocked behind an
+        // in-flight rate-limit wait.
+        let limiter = rate_limiter.read().await.clone();
+        limiter.wait_for(class).await;
 
-        debug!(%method, %url, "http request");
+        debug!(%method, %url, class = ?class, "http request");
 
         // Build request
         let mut request = client.request(method.clone(), url);
@@ -561,10 +567,96 @@ pub(crate) fn classify_status(status: StatusCode) -> StatusClass {
     }
 }
 
+/// Classifies an IG endpoint into its `RateLimitClass` from the HTTP method
+/// and request path (or full URL).
+///
+/// Mapping:
+/// - `POST` / `PUT` / `DELETE` on `positions/otc` or `workingorders/otc`
+///   (order and position mutations, including position close via
+///   `POST` + `_method: DELETE`) → `RateLimitClass::Trading`.
+/// - Any path under `prices/` (historical price fetches) →
+///   `RateLimitClass::Historical`.
+/// - Everything else (market data, account queries, sentiment, watchlists,
+///   working-order / position *reads*, …) → `RateLimitClass::NonTrading`.
+///
+/// `path` may be a bare path or a full URL; matching is by path substring, so
+/// both `positions/otc` and `.../positions/otc/{deal_id}` classify as trading.
+/// A `GET` on `positions` or `workingorders` is a read and stays non-trading.
+#[must_use]
+#[inline]
+pub(crate) fn classify_endpoint(method: &Method, path: &str) -> RateLimitClass {
+    let is_mutation = matches!(*method, Method::POST | Method::PUT | Method::DELETE);
+    let is_trading_path = path.contains("positions/otc") || path.contains("workingorders/otc");
+
+    if is_mutation && is_trading_path {
+        RateLimitClass::Trading
+    } else if path.contains("prices/") {
+        RateLimitClass::Historical
+    } else {
+        RateLimitClass::NonTrading
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{StatusClass, classify_status};
-    use reqwest::StatusCode;
+    use super::{StatusClass, classify_endpoint, classify_status};
+    use crate::application::rate_limiter::RateLimitClass;
+    use reqwest::{Method, StatusCode};
+
+    const BASE: &str = "https://demo-api.ig.com/gateway/deal";
+
+    #[test]
+    fn test_classify_endpoint_post_positions_otc_is_trading() {
+        assert_eq!(
+            classify_endpoint(&Method::POST, &format!("{BASE}/positions/otc")),
+            RateLimitClass::Trading
+        );
+    }
+
+    #[test]
+    fn test_classify_endpoint_get_prices_is_historical() {
+        assert_eq!(
+            classify_endpoint(&Method::GET, &format!("{BASE}/prices/CS.D.EURUSD.MINI.IP")),
+            RateLimitClass::Historical
+        );
+    }
+
+    #[test]
+    fn test_classify_endpoint_get_markets_is_non_trading() {
+        assert_eq!(
+            classify_endpoint(&Method::GET, &format!("{BASE}/markets/CS.D.EURUSD.MINI.IP")),
+            RateLimitClass::NonTrading
+        );
+    }
+
+    #[test]
+    fn test_classify_endpoint_put_position_update_is_trading() {
+        // Position amend: PUT positions/otc/{deal_id}.
+        assert_eq!(
+            classify_endpoint(&Method::PUT, &format!("{BASE}/positions/otc/DIAAAABBBCCC")),
+            RateLimitClass::Trading
+        );
+    }
+
+    #[test]
+    fn test_classify_endpoint_delete_working_order_is_trading() {
+        assert_eq!(
+            classify_endpoint(
+                &Method::DELETE,
+                &format!("{BASE}/workingorders/otc/DIAAAABBBCCC")
+            ),
+            RateLimitClass::Trading
+        );
+    }
+
+    #[test]
+    fn test_classify_endpoint_get_positions_read_is_non_trading() {
+        // A GET on positions is a read, not a mutation, so it stays non-trading.
+        assert_eq!(
+            classify_endpoint(&Method::GET, &format!("{BASE}/positions")),
+            RateLimitClass::NonTrading
+        );
+    }
 
     #[test]
     fn test_classify_status_429_is_retryable() {

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -32,7 +32,7 @@ pub use crate::application::config::{
 };
 
 // Rate limiter
-pub use crate::application::rate_limiter::RateLimiter;
+pub use crate::application::rate_limiter::{RateLimitClass, RateLimiter};
 
 // Service interfaces
 pub use crate::application::interfaces::account::AccountService;


### PR DESCRIPTION
## Summary

`RateLimiter::new` built its `governor` quota from `period_seconds` and `burst_size` only — `RateLimiterConfig.max_requests` was silently ignored, so a config of `{max_requests: 60, period_seconds: 60}` enforced ~1 request/minute instead of 60. Since IG bans accounts for rate violations, a mis-shaped quota is a real operational risk. This PR makes the limiter honor the configured budget, replaces the busy-poll wait with governor's async scheduler, and adds per-class limiting so bulk market-data traffic can't queue order placement.

## Changes

- Quota now replenishes one cell every `period_seconds / max_requests`, honoring the configured rate; `max_requests == 0` / `period_seconds == 0` fall back to documented constants (no divide-by-zero, no `expect`).
- `wait()` awaits governor's `until_ready()` instead of polling `check()` every 10 ms.
- New **additive** `RateLimitClass { Trading, Historical, NonTrading }` with one independent bucket per class. `wait_for(class)` / `check_for(class)` added; existing `wait()` / `check()` delegate to `NonTrading`. `RateLimiter::new` and `RateLimiterConfig` are unchanged.
- `make_http_request` classifies each endpoint (`classify_endpoint`: POST/PUT/DELETE on `positions/otc` & `workingorders/otc` → Trading; `prices/` → Historical; else NonTrading) and waits on that class's bucket. No public signature changed; the limiter is cloned out of the read guard before awaiting.

## Technical decisions

- Trading and Historical use fixed conservative budgets (~1 req/s) derived from IG's per-app trading limit and the weekly historical-data allowance, independent of the configured non-trading budget so a permissive config can't loosen them.
- Per-class buckets are separate governor limiters, so saturating one class never starves another — trading orders are never queued behind bulk non-trading reads.

## Public API impact

Additive only: new `pub enum RateLimitClass` (re-exported in `prelude`), new `RateLimiter::wait_for`/`check_for`. No existing item changed or removed. `cargo semver-checks`: **no semver update required**.

## Testing

- [x] Unit tests added or updated — quota honors max_requests (a test that fails against the old code and passes now), zero-config fallbacks, per-class independence (`check_for(Trading)` admits while `NonTrading` is saturated), `classify_endpoint` mapping
- [x] `make pre-push` run locally and clean

Resilience review: PASS — no unbounded wait, no lock held across the await in a way that can block a writer, per-class independence verified.

Closes #48
