### PR TITLE
fix(orders): round order size to nearest, not floor (#35)

### DIFF
--- a/src/model/requests.rs
+++ b/src/model/requests.rs
@@ -157,6 +157,20 @@ pub struct CreateOrderRequest {
     pub trailing_stop_increment: Option<f64>,
 }
 
+/// Rounds an order size to two decimal places (nearest, half away from zero).
+///
+/// IG accepts order sizes to two decimals. Rounding must go through the nearest
+/// value, not `floor`: `0.29 * 100.0` is `28.999999999999996` in `f64`, so a
+/// `floor`-based `(size * 100.0).floor() / 100.0` silently yields `0.28` and the
+/// order is placed with a smaller size than the caller requested. `round` maps
+/// it back to `0.29`. The rounding direction (nearest) is deliberate and applies
+/// uniformly to every order constructor.
+#[must_use]
+#[inline]
+fn round_order_size(size: f64) -> f64 {
+    (size * 100.0).round() / 100.0
+}
+
 impl CreateOrderRequest {
     /// Creates a new market order, typically used for CFD (Contract for Difference) accounts
     #[must_use]
@@ -167,7 +181,7 @@ impl CreateOrderRequest {
         currency_code: Option<String>,
         deal_reference: Option<String>,
     ) -> Self {
-        let rounded_size = (size * 100.0).floor() / 100.0;
+        let rounded_size = round_order_size(size);
 
         let currency_code = currency_code.unwrap_or_else(|| "EUR".to_string());
 
@@ -203,7 +217,7 @@ impl CreateOrderRequest {
         currency_code: Option<String>,
         deal_reference: Option<String>,
     ) -> Self {
-        let rounded_size = (size * 100.0).floor() / 100.0;
+        let rounded_size = round_order_size(size);
 
         let currency_code = currency_code.unwrap_or_else(|| "EUR".to_string());
 
@@ -269,7 +283,7 @@ impl CreateOrderRequest {
         deal_reference: Option<String>,
         currency_code: Option<String>,
     ) -> Self {
-        let rounded_size = (size * 100.0).floor() / 100.0;
+        let rounded_size = round_order_size(size);
 
         let currency_code = currency_code.unwrap_or_else(|| "EUR".to_string());
 
@@ -339,7 +353,7 @@ impl CreateOrderRequest {
         currency_code: Option<String>,
         force_open: bool, // Compensate position if it is already open
     ) -> Self {
-        let rounded_size = (size * 100.0).floor() / 100.0;
+        let rounded_size = round_order_size(size);
 
         let currency_code = currency_code.unwrap_or_else(|| "EUR".to_string());
 
@@ -395,7 +409,7 @@ impl CreateOrderRequest {
         deal_reference: Option<String>,
         currency_code: Option<String>,
     ) -> Self {
-        let rounded_size = (size * 100.0).floor() / 100.0;
+        let rounded_size = round_order_size(size);
 
         let currency_code = currency_code.unwrap_or_else(|| "EUR".to_string());
 
@@ -460,7 +474,7 @@ impl CreateOrderRequest {
         currency_code: Option<String>,
         force_open: bool,
     ) -> Self {
-        let rounded_size = (size * 100.0).floor() / 100.0;
+        let rounded_size = round_order_size(size);
 
         let currency_code = currency_code.unwrap_or_else(|| "EUR".to_string());
 

--- a/src/model/requests.rs
+++ b/src/model/requests.rs
@@ -319,7 +319,7 @@ impl CreateOrderRequest {
     /// - `epic`: A `String` that specifies the EPIC
     ///   (Exchanged Product Information Code) of the instrument for which the sell order is created.
     /// - `size`: A `f64` that represents the size of the sell
-    ///   order. The size is rounded to two decimal places.
+    ///   order. The size is rounded to the nearest two decimal places.
     /// - `expiry`: An optional `String` that indicates the expiry date or period for
     ///   the sell order. If `None`, no expiry date will be set for the order.
     /// - `deal_reference`: An optional `String` that contains a reference or identifier
@@ -343,7 +343,7 @@ impl CreateOrderRequest {
     ///     `limit_distance`): Set to `None` by default.
     ///
     /// # Notes
-    /// - The input `size` is automatically rounded down to two decimal places before being stored.
+    /// - The input `size` is automatically rounded to the nearest two decimal places before being stored.
     #[must_use]
     pub fn sell_option_to_market_w_force(
         epic: String,
@@ -456,7 +456,7 @@ impl CreateOrderRequest {
     ///
     /// # Behavior
     ///
-    /// * The size of the order will be rounded down to two decimal places for precision.
+    /// * The size of the order will be rounded to the nearest two decimal places for precision.
     /// * If a `currency_code` is not provided, the default currency code "EUR" is used.
     /// * Other parameters are directly mapped into the returned instance.
     ///

--- a/tests/unit/model/test_requests.rs
+++ b/tests/unit/model/test_requests.rs
@@ -80,8 +80,8 @@ fn create_order_limit_and_chainers() {
     assert_eq!(order.time_in_force, TimeInForce::GoodTillCancelled);
     assert_eq!(order.level, Some(16000.5));
     assert_eq!(order.currency_code, "USD");
-    // rounded down
-    assert!((order.size - 2.99).abs() < 1e-9);
+    // rounded to nearest two decimals: 2.999 -> 3.00
+    assert!((order.size - 3.0).abs() < 1e-9);
 
     assert_eq!(order.stop_level, Some(15900.0));
     assert_eq!(order.limit_level, Some(15000.0));
@@ -105,7 +105,8 @@ fn create_option_helpers_sell_and_buy_default_levels() {
     assert_eq!(sell.direction, Direction::Sell);
     assert_eq!(sell.order_type, OrderType::Limit);
     assert_eq!(sell.level, Some(DEFAULT_ORDER_SELL_LEVEL));
-    assert!((sell.size - 5.55).abs() < 1e-9);
+    // rounded to nearest two decimals: 5.555 -> 5.56
+    assert!((sell.size - 5.56).abs() < 1e-9);
     assert_eq!(sell.currency_code, "EUR");
     assert!(sell.deal_reference.is_some()); // auto generated when None
 
@@ -211,4 +212,58 @@ fn create_working_order_builders() {
     );
     assert_eq!(ws.order_type, OrderType::Stop);
     assert_eq!(ws.time_in_force, TimeInForce::GoodTillCancelled);
+}
+
+/// Regression for the floor-rounding bug: `(size * 100.0).floor() / 100.0`
+/// silently shrank sizes (0.29 -> 0.28) because `0.29 * 100.0` is
+/// `28.999999999999996` in f64. Every `CreateOrderRequest` constructor must send
+/// the requested size back unchanged for values with a clean two-decimal form.
+#[test]
+fn create_order_constructors_preserve_two_decimal_sizes() {
+    // Values whose `* 100.0` product falls just below an integer in f64, which
+    // `floor` truncated downward.
+    let sizes = [0.29_f64, 0.57, 0.58, 1.13, 2.29, 10.57];
+
+    for &s in &sizes {
+        let expect = |got: f64| {
+            assert!(
+                (got - s).abs() < 1e-9,
+                "size {s} was corrupted to {got} by the constructor"
+            );
+        };
+
+        expect(CreateOrderRequest::market("EPIC".to_string(), Direction::Buy, s, None, None).size);
+        expect(
+            CreateOrderRequest::limit("EPIC".to_string(), Direction::Buy, s, 100.0, None, None)
+                .size,
+        );
+        expect(
+            CreateOrderRequest::sell_option_to_market("EPIC".to_string(), s, None, None, None).size,
+        );
+        expect(
+            CreateOrderRequest::sell_option_to_market_w_force(
+                "EPIC".to_string(),
+                s,
+                None,
+                None,
+                None,
+                true,
+            )
+            .size,
+        );
+        expect(
+            CreateOrderRequest::buy_option_to_market("EPIC".to_string(), s, None, None, None).size,
+        );
+        expect(
+            CreateOrderRequest::buy_option_to_market_w_force(
+                "EPIC".to_string(),
+                s,
+                None,
+                None,
+                None,
+                true,
+            )
+            .size,
+        );
+    }
 }


### PR DESCRIPTION
## Summary

`CreateOrderRequest::market` and its five sibling constructors rounded order size with `(size * 100.0).floor() / 100.0`. Because `0.29 * 100.0` is `28.999999999999996` in f64, `floor` yielded `28` and a requested size of `0.29` was silently placed as `0.28` — a real trading-size corruption on every order built through these constructors.

## Changes

- Extract a documented `round_order_size` helper that rounds to the nearest two decimals (`(size * 100.0).round() / 100.0`) and use it in all six `CreateOrderRequest` constructors (`market`, `limit`, `sell_option_to_market`, `sell_option_to_market_w_force`, `buy_option_to_market`, `buy_option_to_market_w_force`).
- The rounding direction (nearest, was floor) is now deliberate and documented on the helper.

## Technical decisions

Two existing tests asserted the old floor behavior on genuinely 3-decimal inputs (`2.999 → 2.99`, `5.555 → 5.55`, tagged "rounded down"). Those encoded the bug; updated to the corrected nearest rounding (`3.00`, `5.56`). Values that already have a clean two-decimal form are the ones the bug corrupted, and they now round-trip exactly.

## Testing

- [x] Unit tests added — a regression test asserts `0.29, 0.57, 0.58, 1.13, 2.29, 10.57` survive every one of the six constructors unchanged (fails against the old floor code)
- [x] Two pre-existing tests updated to the corrected rounding contract
- [x] `make pre-push` clean; `cargo semver-checks`: no semver update required

Closes #35
