### PR TITLE
fix(auth): repair session lifecycle — switch token, server logout, v2 account, ws_info (#40)

### DIFF
--- a/examples/chart/src/bin/chart_lightstreamer.rs
+++ b/examples/chart/src/bin/chart_lightstreamer.rs
@@ -46,7 +46,7 @@ async fn main() -> Result<(), ig_client::error::AppError> {
     subscription.add_listener(Box::new(listener));
 
     let client = Client::default();
-    let ws_info = client.get_ws_info().await;
+    let ws_info = client.ws_info().await?;
     let password = ws_info.get_ws_password();
 
     debug!(

--- a/examples/market/src/bin/market_lightstreamer.rs
+++ b/examples/market/src/bin/market_lightstreamer.rs
@@ -22,7 +22,7 @@ fn callback(update: &PriceData) -> Result<(), AppError> {
 async fn main() -> Result<(), ig_client::error::AppError> {
     setup_logger();
     let http_client = Client::default();
-    let ws_info = http_client.get_ws_info().await;
+    let ws_info = http_client.ws_info().await?;
     let password = ws_info.get_ws_password();
 
     // Create a subscription for a market

--- a/examples/market/src/bin/market_lightstreamer_channel.rs
+++ b/examples/market/src/bin/market_lightstreamer_channel.rs
@@ -71,7 +71,7 @@ async fn main() -> Result<(), ig_client::error::AppError> {
     setup_logger();
 
     let http_client = Client::default();
-    let ws_info = http_client.get_ws_info().await;
+    let ws_info = http_client.ws_info().await?;
     let password = ws_info.get_ws_password();
     debug!(
         server = %ws_info.server,

--- a/examples/prices/src/bin/price_lightstreamer.rs
+++ b/examples/prices/src/bin/price_lightstreamer.rs
@@ -22,7 +22,7 @@ fn callback(update: &PriceData) -> Result<(), AppError> {
 async fn main() -> Result<(), ig_client::error::AppError> {
     setup_logger();
     let http_client = Client::default();
-    let ws_info = http_client.get_ws_info().await;
+    let ws_info = http_client.ws_info().await?;
     let password = ws_info.get_ws_password();
     debug!(
         server = %ws_info.server,

--- a/examples/prices/src/bin/price_lightstreamer_channel.rs
+++ b/examples/prices/src/bin/price_lightstreamer_channel.rs
@@ -80,7 +80,7 @@ async fn main() -> Result<(), ig_client::error::AppError> {
 
     // Initialize the IG client and get WebSocket credentials
     let http_client = Client::default();
-    let ws_info = http_client.get_ws_info().await;
+    let ws_info = http_client.ws_info().await?;
     let password = ws_info.get_ws_password();
     debug!(
         server = %ws_info.server,

--- a/examples/trade/src/bin/trade_lightstreamer.rs
+++ b/examples/trade/src/bin/trade_lightstreamer.rs
@@ -20,7 +20,7 @@ fn callback(update: &TradeData) -> Result<(), AppError> {
 async fn main() -> Result<(), ig_client::error::AppError> {
     setup_logger();
     let client = Client::default();
-    let ws_info = client.get_ws_info().await;
+    let ws_info = client.ws_info().await?;
     let password = ws_info.get_ws_password();
 
     debug!(

--- a/examples/trade/src/bin/trade_lightstreamer_channel.rs
+++ b/examples/trade/src/bin/trade_lightstreamer_channel.rs
@@ -69,7 +69,7 @@ async fn main() -> Result<(), ig_client::error::AppError> {
     setup_logger();
 
     let client = Client::default();
-    let ws_info = client.get_ws_info().await;
+    let ws_info = client.ws_info().await?;
     let password = ws_info.get_ws_password();
 
     debug!(

--- a/src/application/auth.rs
+++ b/src/application/auth.rs
@@ -219,6 +219,42 @@ impl From<SessionResponse> for Session {
     }
 }
 
+/// Merges freshly-issued v2 security tokens into a session after an account
+/// switch.
+///
+/// IG returns a new `X-SECURITY-TOKEN` (and sometimes a new `CST`) in the
+/// response to `PUT /session`. When a token is present it replaces the stale
+/// one; when absent the existing token is preserved — the switch response does
+/// not always re-issue both, and nulling a token would break the next request.
+/// All other session fields are carried through unchanged.
+#[must_use]
+fn apply_switch_headers(mut session: Session, cst: Option<&str>, xst: Option<&str>) -> Session {
+    if let Some(cst) = cst {
+        session.cst = Some(cst.to_string());
+    }
+    if let Some(xst) = xst {
+        session.x_security_token = Some(xst.to_string());
+    }
+    session
+}
+
+/// Decides whether a v2 login should switch to the configured account.
+///
+/// Returns `true` only when a *real* account was configured (not empty and not
+/// the [`DEFAULT_ACCOUNT_ID`](crate::constants::DEFAULT_ACCOUNT_ID) sentinel) and
+/// it differs from the account the login landed on. OAuth (v3) pins the account
+/// elsewhere and is never switched here. Guarding the sentinel is essential: it
+/// is non-empty, so without this check an unconfigured client would try to
+/// switch to `"default_account_id"`, which IG rejects, failing an otherwise-valid
+/// login.
+#[must_use]
+fn should_switch_account(api_version: u8, configured: &str, current: &str) -> bool {
+    api_version != 3
+        && !configured.is_empty()
+        && configured != crate::constants::DEFAULT_ACCOUNT_ID
+        && configured != current
+}
+
 /// Authentication manager for IG Markets API
 ///
 /// Handles all authentication operations including:
@@ -255,18 +291,36 @@ impl Auth {
         }
     }
 
+    /// Gets WebSocket connection information for Lightstreamer, reusing the
+    /// cached session.
+    ///
+    /// This calls [`Auth::get_session`], which returns the cached session when
+    /// it is still valid and only logs in (storing the new session) when none
+    /// exists or it has expired. The configured API version is honoured — no
+    /// per-call v2 re-login is performed.
+    ///
+    /// # Returns
+    /// * `Ok(WebsocketInfo)` - Endpoint and authentication tokens for the
+    ///   current session.
+    /// * `Err(AppError)` - If session retrieval (login / refresh) fails.
+    ///
+    /// # Errors
+    /// Returns [`AppError`] when the session cannot be retrieved (login or token
+    /// refresh failure).
+    pub async fn ws_info(&self) -> Result<WebsocketInfo, AppError> {
+        let session = self.get_session().await?;
+        Ok(session.get_websocket_info())
+    }
+
     /// Gets the WebSocket password for Lightstreamer authentication
     ///
     /// # Returns
     /// * WebSocket password in format "CST-{cst}|XST-{token}" or empty string if session is not available
+    #[deprecated(
+        note = "use ws_info() which reuses the cached session and returns a typed error instead of a default-on-error WebsocketInfo"
+    )]
     pub async fn get_ws_info(&self) -> WebsocketInfo {
-        match self.login_v2().await {
-            Ok(sess) => sess.get_websocket_info(),
-            Err(e) => {
-                error!("Failed to get WebSocket info, login failed: {}", e);
-                WebsocketInfo::default()
-            }
-        }
+        self.ws_info().await.unwrap_or_default()
     }
 
     /// Gets the current session, ensuring tokens are valid
@@ -314,11 +368,36 @@ impl Auth {
             self.login_v2().await?
         };
 
-        // Store session
-        let mut sess = self.session.write().await;
-        *sess = Some(session.clone());
+        // Store session. The write guard is scoped so it is released before any
+        // account-selection switch below: `switch_account` reads `self.session`
+        // via `get_session`, and holding the guard across that call would
+        // deadlock.
+        {
+            let mut sess = self.session.write().await;
+            *sess = Some(session.clone());
+        }
 
         info!("✓ Login successful, account: {}", session.account_id);
+
+        // v2 account selection: the v2 `/session` response reports IG's
+        // current/default account, which may differ from the configured one.
+        // Switch to the configured account when it is set and differs. This
+        // cannot recurse: the session was just stored above, so
+        // `switch_account` -> `get_session` returns the cached (valid) session
+        // and never triggers another login. OAuth (v3) already pins the account
+        // in `login_oauth`, so it is skipped here.
+        if api_version != 3 {
+            let configured = self.config.credentials.account_id.clone();
+            if should_switch_account(api_version, &configured, &session.account_id) {
+                info!("selecting configured account after v2 login");
+                // `Box::pin` breaks the compile-time async recursion cycle
+                // (login -> switch_account -> get_session -> login). The cycle
+                // is runtime-bounded: the session was stored above, so
+                // `get_session` returns it without logging in again.
+                return Box::pin(self.switch_account(&configured, None)).await;
+            }
+        }
+
         Ok(session)
     }
 
@@ -516,9 +595,11 @@ impl Auth {
             body["defaultAccount"] = serde_json::json!(default);
         }
 
-        // Build headers with authentication
+        // Build headers with authentication. Only the v2 (CST /
+        // X-SECURITY-TOKEN) path is reachable here: OAuth sessions
+        // (`api_version == 3`) are rejected above, so no `Authorization: Bearer`
+        // branch is needed.
         let api_key = self.config.credentials.api_key.clone();
-        let auth_header_value;
         let cst;
         let x_security_token;
 
@@ -528,22 +609,16 @@ impl Auth {
             ("Version", "1"),
         ];
 
-        // Add authentication headers based on session type
-        if let Some(oauth) = &current_session.oauth_token {
-            auth_header_value = format!("Bearer {}", oauth.access_token);
-            headers.push(("Authorization", auth_header_value.as_str()));
-        } else {
-            if let Some(cst_val) = &current_session.cst {
-                cst = cst_val.clone();
-                headers.push(("CST", cst.as_str()));
-            }
-            if let Some(token_val) = &current_session.x_security_token {
-                x_security_token = token_val.clone();
-                headers.push(("X-SECURITY-TOKEN", x_security_token.as_str()));
-            }
+        if let Some(cst_val) = &current_session.cst {
+            cst = cst_val.clone();
+            headers.push(("CST", cst.as_str()));
+        }
+        if let Some(token_val) = &current_session.x_security_token {
+            x_security_token = token_val.clone();
+            headers.push(("X-SECURITY-TOKEN", x_security_token.as_str()));
         }
 
-        let _response = make_http_request(
+        let response = make_http_request(
             &self.client,
             self.rate_limiter.clone(),
             Method::PUT,
@@ -554,26 +629,159 @@ impl Auth {
         )
         .await?;
 
-        // After switching, update the session
-        let mut new_session = current_session.clone();
+        // IG re-issues the X-SECURITY-TOKEN (and sometimes CST) in the switch
+        // response. Read them from the headers and merge them in; a missing
+        // header keeps the existing token rather than nulling it.
+        let new_cst = response
+            .headers()
+            .get("CST")
+            .and_then(|v| v.to_str().ok())
+            .map(String::from);
+        let new_x_security_token = response
+            .headers()
+            .get("X-SECURITY-TOKEN")
+            .and_then(|v| v.to_str().ok())
+            .map(String::from);
+
+        // IG re-issues X-SECURITY-TOKEN on a successful switch. Its absence on a
+        // 2xx response is anomalous (proxy stripping / response-shape drift): the
+        // old token is kept below, but flag it since it will 401 the next call.
+        if new_x_security_token.is_none() {
+            warn!("switch response carried no X-SECURITY-TOKEN; keeping the previous token");
+        }
+
+        // After switching, update the session with the fresh tokens and the new
+        // account id.
+        let mut new_session = apply_switch_headers(
+            current_session.clone(),
+            new_cst.as_deref(),
+            new_x_security_token.as_deref(),
+        );
         new_session.account_id = account_id.to_string();
 
-        let mut session = self.session.write().await;
-        *session = Some(new_session.clone());
+        {
+            let mut session = self.session.write().await;
+            *session = Some(new_session.clone());
+        }
 
         info!("✓ Switched to account: {}", account_id);
         Ok(new_session)
     }
 
-    /// Logs out and clears the current session
+    /// Logs out and clears the current session.
+    ///
+    /// Before clearing local state, this issues `DELETE /session` (IG API
+    /// Version 1) with the current authentication headers. For a **v2** session
+    /// (CST / X-SECURITY-TOKEN) this invalidates the session server-side. For a
+    /// **v3 / OAuth** session there is no IG token-revocation endpoint and the
+    /// short-lived access token has usually already expired, so `DELETE /session`
+    /// is best-effort: logout clears local state and the OAuth tokens lapse on
+    /// their own expiry rather than being actively revoked. A `401 Unauthorized`
+    /// (or an already-invalid OAuth token) is treated as already-logged-out and
+    /// reported as success.
+    ///
+    /// The local session is always cleared, even when the server-side call
+    /// fails, so the client is never wedged in an authenticated-but-unusable
+    /// state; the underlying failure is still returned as a typed error.
+    ///
+    /// # Errors
+    /// Returns [`AppError`] when the server-side logout request fails for a
+    /// reason other than an already-invalid session (401). The local session is
+    /// cleared regardless.
     pub async fn logout(&self) -> Result<(), AppError> {
         info!("Logging out");
 
-        let mut session = self.session.write().await;
-        *session = None;
+        // Snapshot the current session without holding the lock across the HTTP
+        // call. With no session there is nothing to revoke server-side.
+        let current_session = {
+            let session = self.session.read().await;
+            session.clone()
+        };
 
-        info!("✓ Logged out successfully");
-        Ok(())
+        let server_result = match current_session {
+            Some(sess) => self.revoke_session(&sess).await,
+            None => Ok(()),
+        };
+
+        // Always clear local state so the client is never wedged, regardless of
+        // the server-side outcome.
+        {
+            let mut session = self.session.write().await;
+            *session = None;
+        }
+
+        match server_result {
+            Ok(()) => {
+                info!("✓ Logged out successfully");
+                Ok(())
+            }
+            Err(e) => {
+                // The error type carries no secrets (see `AppError`), so it is
+                // safe to log; local state has already been cleared.
+                error!("server-side logout failed: {}", e);
+                Err(e)
+            }
+        }
+    }
+
+    /// Issues `DELETE /session` (IG API Version 1) to terminate the session
+    /// server-side.
+    ///
+    /// A `401 Unauthorized` (or an already-invalid OAuth token) means the
+    /// session is no longer valid server-side and is treated as success.
+    ///
+    /// # Errors
+    /// Returns [`AppError`] if the request fails for any reason other than an
+    /// already-invalid session.
+    async fn revoke_session(&self, session: &Session) -> Result<(), AppError> {
+        let url = format!("{}/session", self.config.rest_api.base_url);
+        let api_key = self.config.credentials.api_key.clone();
+
+        let auth_header_value;
+        let cst;
+        let x_security_token;
+
+        let mut headers = vec![
+            ("X-IG-API-KEY", api_key.as_str()),
+            ("Content-Type", "application/json"),
+            ("Version", "1"),
+        ];
+
+        if let Some(oauth) = &session.oauth_token {
+            auth_header_value = format!("Bearer {}", oauth.access_token);
+            headers.push(("Authorization", auth_header_value.as_str()));
+            headers.push(("IG-ACCOUNT-ID", session.account_id.as_str()));
+        } else {
+            if let Some(cst_val) = &session.cst {
+                cst = cst_val.clone();
+                headers.push(("CST", cst.as_str()));
+            }
+            if let Some(token_val) = &session.x_security_token {
+                x_security_token = token_val.clone();
+                headers.push(("X-SECURITY-TOKEN", x_security_token.as_str()));
+            }
+        }
+
+        match make_http_request(
+            &self.client,
+            self.rate_limiter.clone(),
+            Method::DELETE,
+            &url,
+            headers,
+            &None::<()>,
+            RetryConfig::default(),
+        )
+        .await
+        {
+            Ok(_) => Ok(()),
+            // A 401 (or an expired OAuth token) means the session is already
+            // invalid server-side: the logout goal is met.
+            Err(AppError::Unauthorized | AppError::OAuthTokenExpired) => {
+                debug!("session already invalid server-side; treating as logged out");
+                Ok(())
+            }
+            Err(e) => Err(e),
+        }
     }
 }
 
@@ -600,6 +808,110 @@ fn test_v2_response_deserialization_prod() -> Result<(), serde_json::Error> {
     assert_eq!(response.account_type, "CFD");
     assert_eq!(response.current_account_id, "BS0Y3");
     Ok(())
+}
+
+#[cfg(test)]
+mod session_lifecycle_tests {
+    use super::*;
+
+    fn v2_session(cst: Option<&str>, xst: Option<&str>) -> Session {
+        Session {
+            account_id: "ACC-OLD".to_string(),
+            client_id: "CLIENT1".to_string(),
+            lightstreamer_endpoint: "demo-apd.marketdatasystems.com".to_string(),
+            cst: cst.map(String::from),
+            x_security_token: xst.map(String::from),
+            oauth_token: None,
+            api_version: 2,
+            expires_at: 123,
+        }
+    }
+
+    #[test]
+    fn test_apply_switch_headers_replaces_xst_and_keeps_other_fields() {
+        let session = v2_session(Some("OLD-CST"), Some("OLD-XST"));
+        // A switch response that only re-issues the X-SECURITY-TOKEN.
+        let updated = apply_switch_headers(session, None, Some("NEW-XST"));
+
+        assert_eq!(updated.x_security_token.as_deref(), Some("NEW-XST"));
+        // CST is preserved when the header is absent.
+        assert_eq!(updated.cst.as_deref(), Some("OLD-CST"));
+        // Unrelated fields carry through unchanged.
+        assert_eq!(updated.account_id, "ACC-OLD");
+        assert_eq!(updated.expires_at, 123);
+        assert_eq!(updated.api_version, 2);
+    }
+
+    #[test]
+    fn test_apply_switch_headers_updates_both_tokens() {
+        let session = v2_session(Some("OLD-CST"), Some("OLD-XST"));
+        let updated = apply_switch_headers(session, Some("NEW-CST"), Some("NEW-XST"));
+
+        assert_eq!(updated.cst.as_deref(), Some("NEW-CST"));
+        assert_eq!(updated.x_security_token.as_deref(), Some("NEW-XST"));
+    }
+
+    #[test]
+    fn test_apply_switch_headers_none_preserves_existing_tokens() {
+        let session = v2_session(Some("OLD-CST"), Some("OLD-XST"));
+        // A switch response carrying neither header must not null the tokens.
+        let updated = apply_switch_headers(session, None, None);
+
+        assert_eq!(updated.cst.as_deref(), Some("OLD-CST"));
+        assert_eq!(updated.x_security_token.as_deref(), Some("OLD-XST"));
+    }
+
+    #[test]
+    fn test_should_switch_account_guards_the_sentinel_and_v3() {
+        use crate::constants::DEFAULT_ACCOUNT_ID;
+
+        // Real configured account that differs from the current one: switch.
+        assert!(should_switch_account(2, "ACC-B", "ACC-A"));
+        // Unconfigured default sentinel: must NOT switch (would fail login).
+        assert!(!should_switch_account(2, DEFAULT_ACCOUNT_ID, "ACC-A"));
+        // Empty configured account: must not switch.
+        assert!(!should_switch_account(2, "", "ACC-A"));
+        // Already on the configured account: no switch needed.
+        assert!(!should_switch_account(2, "ACC-A", "ACC-A"));
+        // OAuth (v3) is never switched through this path.
+        assert!(!should_switch_account(3, "ACC-B", "ACC-A"));
+    }
+
+    #[tokio::test]
+    async fn test_ws_info_uses_cached_session_without_login() {
+        let auth = Auth::new(Arc::new(Config::default()));
+
+        // Seed a valid (non-expired) v2 session with known tokens. Because the
+        // session is valid, `ws_info` -> `get_session` must return it without a
+        // network login (a login would require real credentials and fail).
+        let expires_at = (Utc::now().timestamp() + 3600) as u64;
+        let seeded = Session {
+            account_id: "ACC123".to_string(),
+            client_id: "CLIENT1".to_string(),
+            lightstreamer_endpoint: "demo-apd.marketdatasystems.com".to_string(),
+            cst: Some("CST-TOKEN".to_string()),
+            x_security_token: Some("XST-TOKEN".to_string()),
+            oauth_token: None,
+            api_version: 2,
+            expires_at,
+        };
+        {
+            let mut guard = auth.session.write().await;
+            *guard = Some(seeded);
+        }
+
+        let ws = match auth.ws_info().await {
+            Ok(ws) => ws,
+            Err(e) => panic!("ws_info should return Ok for a cached session: {e}"),
+        };
+
+        // The returned info derives from the cached session's tokens, proving no
+        // fresh login occurred.
+        assert_eq!(ws.account_id, "ACC123");
+        assert_eq!(ws.cst.as_deref(), Some("CST-TOKEN"));
+        assert_eq!(ws.x_security_token.as_deref(), Some("XST-TOKEN"));
+        assert!(ws.server.contains("demo-apd.marketdatasystems.com"));
+    }
 }
 
 #[cfg(test)]

--- a/src/application/client.rs
+++ b/src/application/client.rs
@@ -106,12 +106,32 @@ impl Client {
         Self { http_client }
     }
 
+    /// Gets WebSocket connection information for Lightstreamer, reusing the
+    /// cached session.
+    ///
+    /// Delegates to [`HttpClient::ws_info`], which returns the cached session
+    /// when it is valid and only logs in when needed.
+    ///
+    /// # Returns
+    /// * `Ok(WebsocketInfo)` - Server endpoint, authentication tokens, and
+    ///   account ID for the current session.
+    /// * `Err(AppError)` - If session retrieval (login / refresh) fails.
+    ///
+    /// # Errors
+    /// Returns [`AppError`] when the session cannot be retrieved.
+    pub async fn ws_info(&self) -> Result<WebsocketInfo, AppError> {
+        self.http_client.ws_info().await
+    }
+
     /// Gets WebSocket connection information for Lightstreamer
     ///
     /// # Returns
     /// * `WebsocketInfo` containing server endpoint, authentication tokens, and account ID
+    #[deprecated(
+        note = "use ws_info() which reuses the cached session and returns a typed error instead of a default-on-error WebsocketInfo"
+    )]
     pub async fn get_ws_info(&self) -> WebsocketInfo {
-        self.http_client.get_ws_info().await
+        self.ws_info().await.unwrap_or_default()
     }
 }
 
@@ -1131,7 +1151,7 @@ impl StreamerClient {
     pub async fn new() -> Result<Self, AppError> {
         let http_client_raw = Arc::new(RwLock::new(Client::new()));
         let http_client = http_client_raw.read().await;
-        let ws_info = http_client.get_ws_info().await;
+        let ws_info = http_client.ws_info().await?;
         let password = ws_info.get_ws_password();
 
         // Market data client (no adapter specified - uses default)

--- a/src/application/config.rs
+++ b/src/application/config.rs
@@ -125,7 +125,10 @@ impl Config {
             credentials: Credentials {
                 username,
                 password,
-                account_id: get_env_or_default("IG_ACCOUNT_ID", String::from("default_account_id")),
+                account_id: get_env_or_default(
+                    "IG_ACCOUNT_ID",
+                    String::from(crate::constants::DEFAULT_ACCOUNT_ID),
+                ),
                 api_key,
                 client_token: None,
                 account_token: None,

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -80,3 +80,10 @@ pub const DEFAULT_ORDER_SELL_LEVEL: f64 = 0.0;
 /// Developers can use this constant to ensure uniformity and consistency when working with order buy levels
 /// across the application.
 pub const DEFAULT_ORDER_BUY_LEVEL: f64 = 10000.0;
+
+/// Sentinel value used for `account_id` when `IG_ACCOUNT_ID` is not configured.
+///
+/// This is not a real IG account id: it signals "no account was explicitly
+/// configured, use whatever account the session lands on". Auth flows must not
+/// attempt to switch to this value.
+pub const DEFAULT_ACCOUNT_ID: &str = "default_account_id";

--- a/src/model/http.rs
+++ b/src/model/http.rs
@@ -90,12 +90,32 @@ impl HttpClient {
         })
     }
 
+    /// Gets WebSocket connection information for Lightstreamer, reusing the
+    /// cached session.
+    ///
+    /// Delegates to [`Auth::ws_info`], which returns the cached session when it
+    /// is valid and only logs in when needed.
+    ///
+    /// # Returns
+    /// * `Ok(WebsocketInfo)` - Server endpoint, authentication tokens, and
+    ///   account ID for the current session.
+    /// * `Err(AppError)` - If session retrieval (login / refresh) fails.
+    ///
+    /// # Errors
+    /// Returns [`AppError`] when the session cannot be retrieved.
+    pub async fn ws_info(&self) -> Result<WebsocketInfo, AppError> {
+        self.auth.ws_info().await
+    }
+
     /// Gets WebSocket connection information for Lightstreamer
     ///
     /// # Returns
     /// * `WebsocketInfo` containing server endpoint, authentication tokens, and account ID
+    #[deprecated(
+        note = "use ws_info() which reuses the cached session and returns a typed error instead of a default-on-error WebsocketInfo"
+    )]
     pub async fn get_ws_info(&self) -> WebsocketInfo {
-        self.auth.get_ws_info().await
+        self.ws_info().await.unwrap_or_default()
     }
 
     /// Makes a GET request


### PR DESCRIPTION
## Summary

The session lifecycle had four verified defects: `switch_account` kept sending the pre-switch `X-SECURITY-TOKEN`; `logout()` never terminated the session server-side; the v2 login path ignored the configured account; and `get_ws_info()` re-logged-in on every call and swallowed errors into an empty `WebsocketInfo`. This PR fixes all four with an additive, semver-clean public surface.

## Changes

- **switch_account** captures the `PUT /session` response, reads the fresh `X-SECURITY-TOKEN` (and `CST` when present) from its headers, and stores them; a missing header keeps the existing token (never nulls it) and logs a `warn!`. Removed the unreachable OAuth header branch (v3 is rejected earlier).
- **logout** issues `DELETE /session` (Version 1) with the current auth headers before clearing local state; a 401 is treated as already-logged-out; the local session is cleared regardless, and other failures surface as typed errors. v3/OAuth logout is documented as best-effort — IG has no OAuth revocation endpoint, so those tokens lapse on expiry.
- **v2 account selection**: after a v2 login, switch to the configured account when it genuinely differs — guarded against the `DEFAULT_ACCOUNT_ID` sentinel so an unconfigured client is never forced into an invalid switch that would fail login. Extracted `should_switch_account` as a pure, unit-tested helper.
- **ws_info**: new additive `ws_info() -> Result<WebsocketInfo, AppError>` on `Auth`, `HttpClient` and `Client` reuses the cached session (logs in only when needed, stores the result). The old `get_ws_info()` is `#[deprecated]` (kept for compatibility) and no longer re-logs-in per call. All in-repo callers and the 7 streaming examples migrated to `ws_info()`.

## Public API impact

Additive only: new `ws_info()` methods; `get_ws_info()` deprecated, not removed. `cargo semver-checks`: no semver update required.

## Testing

- [x] Unit tests: `should_switch_account` (sentinel/empty/v3/real-account cases), `apply_switch_headers` (replace / preserve-on-absent), `ws_info` returns cached session without login
- [x] `make pre-push` clean; workspace clippy clean; semver clean

Three specialist reviews ran on the diff: secrets-auditor **PASS** (no credential leaks), resilience-reviewer **PASS** (recursion bounded — session stored before switch, 300s margin can't fire against a 6h token; no lock across await), broker-api-critic surfaced the `DEFAULT_ACCOUNT_ID` sentinel blocker (fixed here) and the v3-logout overclaim (doc corrected). Two larger follow-ups noted (carry the `accounts` list for pre-validation; apply the sentinel guard to the v3 path) are tracked for a separate issue.

Closes #40
