### PR TITLE
fix: eliminate production panics on auth and streaming paths (#32)

### DIFF
--- a/src/application/auth.rs
+++ b/src/application/auth.rs
@@ -296,6 +296,29 @@ fn proactive_refresh_margin_secs(session: &Session) -> u64 {
     }
 }
 
+/// Ensures a v3 (OAuth) login actually produced an OAuth session.
+///
+/// The v3 `/session` endpoint is expected to return an OAuth body. Because
+/// [`SessionResponse`] is untagged, a v2-shaped body sent to the v3 request
+/// still deserializes successfully — as a v2 session carrying no OAuth token.
+/// That is a server-side / protocol mismatch, not a client bug. On the reactive
+/// [`force_refresh`](Auth::force_refresh) -> [`login`](Auth::login) path a 401
+/// reaches this code more often, so a mismatched body must surface as a typed
+/// error rather than panic.
+///
+/// The offending response body / token is never logged.
+///
+/// # Errors
+/// Returns [`AppError::Unauthorized`] when the session lacks an OAuth token.
+fn ensure_oauth_session(session: Session) -> Result<Session, AppError> {
+    if session.is_oauth() {
+        Ok(session)
+    } else {
+        error!("v3 login response did not contain an OAuth token");
+        Err(AppError::Unauthorized)
+    }
+}
+
 /// Authentication manager for IG Markets API
 ///
 /// Handles all authentication operations including:
@@ -316,20 +339,41 @@ impl Auth {
     ///
     /// # Arguments
     /// * `config` - Configuration containing credentials and API settings
+    ///
+    /// # Panics
+    /// Panics only if the underlying `reqwest` client cannot be constructed,
+    /// which happens exclusively when the system TLS backend fails to
+    /// initialize at startup — an unrecoverable environment invariant. For
+    /// graceful handling of that case use [`Auth::try_new`], which returns a
+    /// typed [`AppError`] instead of panicking.
     pub fn new(config: Arc<Config>) -> Self {
-        let client = Client::builder()
-            .user_agent(USER_AGENT)
-            .build()
-            .expect("Failed to create HTTP client");
+        Self::try_new(config).expect("Failed to create HTTP client")
+    }
+
+    /// Creates a new Auth instance, returning an error if the HTTP client
+    /// cannot be constructed.
+    ///
+    /// This is the fallible counterpart to [`Auth::new`]: it surfaces a TLS /
+    /// client-builder failure as a typed [`AppError`] instead of panicking, so
+    /// callers can handle a broken TLS backend gracefully.
+    ///
+    /// # Arguments
+    /// * `config` - Configuration containing credentials and API settings
+    ///
+    /// # Errors
+    /// Returns [`AppError::Network`] if the underlying `reqwest` client cannot
+    /// be built (e.g. the system TLS backend fails to initialize).
+    pub fn try_new(config: Arc<Config>) -> Result<Self, AppError> {
+        let client = Client::builder().user_agent(USER_AGENT).build()?;
 
         let rate_limiter = Arc::new(RwLock::new(RateLimiter::new(&config.rate_limiter)));
 
-        Self {
+        Ok(Self {
             config,
             client,
             session: Arc::new(RwLock::new(None)),
             rate_limiter,
-        }
+        })
     }
 
     /// Gets WebSocket connection information for Lightstreamer, reusing the
@@ -571,9 +615,9 @@ impl Auth {
             session.account_id = self.config.credentials.account_id.clone();
         };
 
-        assert!(session.is_oauth());
-
-        Ok(session)
+        // A v2-shaped body on the v3 path (server-side mismatch) must not panic;
+        // surface it as a typed error instead.
+        ensure_oauth_session(session)
     }
 
     /// Proactively refreshes the session when it is within its refresh margin.
@@ -1140,6 +1184,58 @@ mod expiry_and_refresh_tests {
         // would perform a real login, so it is not called here (no network in
         // unit tests).
         let _ = Auth::force_refresh;
+    }
+}
+
+#[cfg(test)]
+mod oauth_login_guard_tests {
+    use super::*;
+
+    // Captured real IG demo v2 `/session` body (same shape as the existing
+    // deserialization tests). Deserialized through the untagged
+    // `SessionResponse` it lands on the V2 variant, so the derived session
+    // carries no OAuth token — exactly the mismatch `login_oauth` must reject.
+    const V2_BODY: &str = r#"{"accountType":"CFD","accountInfo":{"balance":21065.86,"deposit":3033.31,"profitLoss":-285.27,"available":16659.01},"currencyIsoCode":"EUR","currencySymbol":"E","currentAccountId":"ZZZZZ","lightstreamerEndpoint":"https://demo-apd.marketdatasystems.com","accounts":[{"accountId":"Z405P5","accountName":"Turbo24","preferred":false,"accountType":"PHYSICAL"},{"accountId":"ZHJ5N","accountName":"DEMO_A","preferred":false,"accountType":"CFD"},{"accountId":"ZZZZZ","accountName":"Opciones","preferred":true,"accountType":"CFD"}],"clientId":"101290216","timezoneOffset":1,"hasActiveDemoAccounts":true,"hasActiveLiveAccounts":true,"trailingStopsEnabled":false,"reroutingEnvironment":null,"dealingEnabled":true}"#;
+
+    #[test]
+    fn test_ensure_oauth_session_v2_body_on_v3_path_yields_unauthorized()
+    -> Result<(), serde_json::Error> {
+        // Deserialize a v2-shaped body the way `login_oauth` does after a v3
+        // request, then run it through the same guard.
+        let response: SessionResponse = serde_json::from_str(V2_BODY)?;
+        let session = response.get_session();
+        // A v2 body carries no OAuth token.
+        assert!(!session.is_oauth());
+
+        // The guard maps this to a typed error instead of panicking (the old
+        // `assert!(session.is_oauth())` would have aborted here).
+        match ensure_oauth_session(session) {
+            Err(AppError::Unauthorized) => Ok(()),
+            other => panic!("expected AppError::Unauthorized, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_ensure_oauth_session_oauth_body_passes_through() {
+        // A genuine v3 session passes the guard unchanged.
+        let session = Session {
+            account_id: "ACC123".to_string(),
+            client_id: "CLIENT1".to_string(),
+            lightstreamer_endpoint: "demo-apd.marketdatasystems.com".to_string(),
+            cst: None,
+            x_security_token: None,
+            oauth_token: Some(OAuthToken {
+                access_token: "ACCESS".to_string(),
+                refresh_token: "REFRESH".to_string(),
+                scope: "read write".to_string(),
+                token_type: "Bearer".to_string(),
+                expires_in: "60".to_string(),
+                created_at: Utc::now(),
+            }),
+            api_version: 3,
+            expires_at: 0,
+        };
+        assert!(ensure_oauth_session(session).is_ok());
     }
 }
 

--- a/src/application/auth.rs
+++ b/src/application/auth.rs
@@ -341,11 +341,12 @@ impl Auth {
     /// * `config` - Configuration containing credentials and API settings
     ///
     /// # Panics
-    /// Panics only if the underlying `reqwest` client cannot be constructed,
-    /// which happens exclusively when the system TLS backend fails to
-    /// initialize at startup — an unrecoverable environment invariant. For
-    /// graceful handling of that case use [`Auth::try_new`], which returns a
-    /// typed [`AppError`] instead of panicking.
+    /// Panics if the underlying `reqwest` client cannot be constructed at
+    /// startup — typically a missing TLS backend, but also invalid proxy or
+    /// certificate configuration. This is an unrecoverable environment
+    /// invariant at construction time. For graceful handling use
+    /// [`Auth::try_new`], which returns a typed [`AppError`] instead of
+    /// panicking.
     pub fn new(config: Arc<Config>) -> Self {
         Self::try_new(config).expect("Failed to create HTTP client")
     }

--- a/src/application/client.rs
+++ b/src/application/client.rs
@@ -104,11 +104,12 @@ impl Client {
     /// A new Client with default configuration
     ///
     /// # Panics
-    /// Panics only if the underlying [`HttpClient`] cannot be constructed,
-    /// which happens exclusively when the system TLS backend fails to
-    /// initialize at startup — an unrecoverable environment invariant. For
-    /// graceful handling of that case use [`Client::try_new`], which returns a
-    /// typed [`AppError`] instead of panicking.
+    /// Panics if the underlying [`HttpClient`] cannot be constructed at
+    /// startup — typically a missing TLS backend, but also invalid proxy or
+    /// certificate configuration. This is an unrecoverable environment
+    /// invariant at construction time. For graceful handling use
+    /// [`Client::try_new`], which returns a typed [`AppError`] instead of
+    /// panicking.
     pub fn new() -> Self {
         Self::try_new().expect("failed to create HTTP client")
     }

--- a/src/application/client.rs
+++ b/src/application/client.rs
@@ -4,6 +4,7 @@
    Date: 19/10/25
 ******************************************************************************/
 use crate::application::auth::WebsocketInfo;
+use crate::application::config::Config;
 use crate::application::interfaces::account::AccountService;
 use crate::application::interfaces::costs::CostsService;
 use crate::application::interfaces::market::MarketService;
@@ -101,9 +102,34 @@ impl Client {
     ///
     /// # Returns
     /// A new Client with default configuration
+    ///
+    /// # Panics
+    /// Panics only if the underlying [`HttpClient`] cannot be constructed,
+    /// which happens exclusively when the system TLS backend fails to
+    /// initialize at startup — an unrecoverable environment invariant. For
+    /// graceful handling of that case use [`Client::try_new`], which returns a
+    /// typed [`AppError`] instead of panicking.
     pub fn new() -> Self {
-        let http_client = Arc::new(HttpClient::default());
-        Self { http_client }
+        Self::try_new().expect("failed to create HTTP client")
+    }
+
+    /// Creates a new client instance without performing initial authentication,
+    /// returning an error if the underlying HTTP client cannot be constructed.
+    ///
+    /// This is the fallible counterpart to [`Client::new`]: it builds the
+    /// underlying [`HttpClient`] via [`HttpClient::new_lazy`] and surfaces a
+    /// client-construction failure as a typed [`AppError`] instead of panicking.
+    ///
+    /// # Returns
+    /// * `Ok(Client)` - A client ready to use with the default configuration.
+    /// * `Err(AppError)` - If the underlying HTTP client cannot be constructed.
+    ///
+    /// # Errors
+    /// Returns [`AppError::Network`] if the underlying `reqwest` client cannot
+    /// be built (e.g. the system TLS backend fails to initialize).
+    pub fn try_new() -> Result<Self, AppError> {
+        let http_client = Arc::new(HttpClient::new_lazy(Config::default())?);
+        Ok(Self { http_client })
     }
 
     /// Gets WebSocket connection information for Lightstreamer, reusing the

--- a/src/model/http.rs
+++ b/src/model/http.rs
@@ -79,8 +79,9 @@ impl HttpClient {
             .build()?;
         let rate_limiter = Arc::new(RwLock::new(RateLimiter::new(&config.rate_limiter)));
 
-        // Create Auth instance
-        let auth = Arc::new(Auth::new(config.clone()));
+        // Create Auth instance via the fallible constructor so the whole
+        // `new_lazy` path (and `Client::try_new` built on it) never panics.
+        let auth = Arc::new(Auth::try_new(config.clone())?);
 
         Ok(Self {
             auth,
@@ -371,15 +372,16 @@ impl Default for HttpClient {
     ///
     /// # Panics
     /// Panics if the underlying HTTP client cannot be constructed via
-    /// [`HttpClient::new_lazy`], which happens only when the system TLS backend
-    /// fails to initialize — an unrecoverable startup invariant. Callers that
-    /// need to handle that case gracefully should call
-    /// [`HttpClient::new_lazy`] directly and propagate the returned
+    /// [`HttpClient::new_lazy`] — typically a missing TLS backend, but also
+    /// invalid proxy or certificate configuration. This is an unrecoverable
+    /// startup invariant. Callers that need to handle that case gracefully
+    /// should call [`HttpClient::new_lazy`] directly and propagate the returned
     /// [`AppError`] with `?`.
     fn default() -> Self {
         let config = Config::default();
-        // The default TLS configuration should always succeed; this only fails
-        // if the system has no usable TLS backend, which is unrecoverable.
+        // Construction normally succeeds; it fails only if the reqwest client
+        // cannot be built (no usable TLS backend, or invalid proxy/certificate
+        // configuration), which is an unrecoverable startup invariant.
         Self::new_lazy(config).expect("failed to create default HTTP client")
     }
 }

--- a/src/model/http.rs
+++ b/src/model/http.rs
@@ -367,10 +367,19 @@ impl HttpClient {
 }
 
 impl Default for HttpClient {
+    /// Creates a lazily-authenticated client with the default configuration.
+    ///
+    /// # Panics
+    /// Panics if the underlying HTTP client cannot be constructed via
+    /// [`HttpClient::new_lazy`], which happens only when the system TLS backend
+    /// fails to initialize — an unrecoverable startup invariant. Callers that
+    /// need to handle that case gracefully should call
+    /// [`HttpClient::new_lazy`] directly and propagate the returned
+    /// [`AppError`] with `?`.
     fn default() -> Self {
         let config = Config::default();
-        // SAFETY: Default TLS configuration should always succeed.
-        // This only fails if the system has no TLS backend, which is unrecoverable.
+        // The default TLS configuration should always succeed; this only fails
+        // if the system has no usable TLS backend, which is unrecoverable.
         Self::new_lazy(config).expect("failed to create default HTTP client")
     }
 }

--- a/src/model/streaming.rs
+++ b/src/model/streaming.rs
@@ -78,24 +78,12 @@ impl Display for StreamingMarketField {
 ///
 /// # Returns
 ///
-/// A `Vec<String>` where each `String` is a serialized representation of a `StreamingMarketField` from the input set.
-///
-/// # Panics
-///
-/// This function will panic if the serialization of any `StreamingMarketField` fails.
-///
+/// A `Vec<String>` where each `String` is the exact IG Lightstreamer wire name
+/// of a `StreamingMarketField` from the input set.
 pub(crate) fn get_streaming_market_fields(fields: &HashSet<StreamingMarketField>) -> Vec<String> {
-    let mut fields_vec = Vec::new();
-    for field in fields {
-        // Serialize to a JSON value and extract the underlying string without quotes
-        let val = serde_json::to_value(field).expect("Failed to serialize StreamingMarketField");
-        match val {
-            serde_json::Value::String(s) => fields_vec.push(s),
-            // Fallback: use Debug which yields SCREAMING_SNAKE_CASE variant name
-            _ => fields_vec.push(format!("{:?}", field)),
-        }
-    }
-    fields_vec
+    // `Display` (via the `Debug` impl above) emits the exact IG Lightstreamer
+    // wire field name for every variant, so no fallible serialization is needed.
+    fields.iter().map(|field| field.to_string()).collect()
 }
 
 /// Streaming price fields available for price subscriptions.
@@ -594,25 +582,14 @@ impl Display for StreamingAccountDataField {
 ///
 /// # Returns
 ///
-/// A `Vec<String>` where each `String` is a serialized representation of a `StreamingAccountDataField` from the input set.
-///
-/// # Panics
-///
-/// This function will panic if the serialization of any `StreamingAccountDataField` fails.
-///
+/// A `Vec<String>` where each `String` is the exact IG Lightstreamer wire name
+/// of a `StreamingAccountDataField` from the input set.
 pub(crate) fn get_streaming_account_data_fields(
     fields: &HashSet<StreamingAccountDataField>,
 ) -> Vec<String> {
-    let mut fields_vec = Vec::new();
-    for field in fields {
-        let val =
-            serde_json::to_value(field).expect("Failed to serialize StreamingAccountDataField");
-        match val {
-            serde_json::Value::String(s) => fields_vec.push(s),
-            _ => fields_vec.push(format!("{:?}", field)),
-        }
-    }
-    fields_vec
+    // `Display` (via the `Debug` impl above) emits the exact IG Lightstreamer
+    // wire field name for every variant, so no fallible serialization is needed.
+    fields.iter().map(|field| field.to_string()).collect()
 }
 
 /// Streaming chart fields available for chart subscriptions (tick and candle).
@@ -729,21 +706,12 @@ impl std::fmt::Display for StreamingChartField {
 ///
 /// # Returns
 ///
-/// A `Vec<String>` of serialized field names for Lightstreamer subscriptions.
-///
-/// # Panics
-///
-/// Panics if serialization of any field fails.
+/// A `Vec<String>` of exact IG Lightstreamer wire field names for
+/// subscriptions.
 pub(crate) fn get_streaming_chart_fields(fields: &HashSet<StreamingChartField>) -> Vec<String> {
-    let mut out = Vec::with_capacity(fields.len());
-    for field in fields {
-        let val = serde_json::to_value(field).expect("Failed to serialize StreamingChartField");
-        match val {
-            serde_json::Value::String(s) => out.push(s),
-            _ => out.push(format!("{:?}", field)),
-        }
-    }
-    out
+    // `Display` (via the `Debug` impl above) emits the exact IG Lightstreamer
+    // wire field name for every variant, so no fallible serialization is needed.
+    fields.iter().map(|field| field.to_string()).collect()
 }
 
 #[cfg(test)]
@@ -815,6 +783,22 @@ mod tests {
         assert!(result.contains(&"BID".to_string()));
         assert!(result.contains(&"OFFER".to_string()));
         assert!(result.contains(&"HIGH".to_string()));
+    }
+
+    #[test]
+    fn test_get_streaming_account_data_fields_wire_names() {
+        // Pins the exact IG Lightstreamer wire names produced by the getter
+        // after replacing the serde_json round-trip with Display, so a future
+        // divergence between Display and the wire contract fails loudly.
+        let mut fields = HashSet::new();
+        fields.insert(StreamingAccountDataField::Pnl);
+        fields.insert(StreamingAccountDataField::AvailableCash);
+        fields.insert(StreamingAccountDataField::PnlLr);
+        let result = get_streaming_account_data_fields(&fields);
+        assert_eq!(result.len(), 3);
+        assert!(result.contains(&"PNL".to_string()));
+        assert!(result.contains(&"AVAILABLE_CASH".to_string()));
+        assert!(result.contains(&"PNL_LR".to_string()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Several production paths could panic instead of returning typed errors: `assert!(session.is_oauth())` on a server-controlled login response, `reqwest` client-build `.expect()` in the constructors, and `serde_json::to_value(..).expect(..)` on the streaming subscribe path. This PR removes the recoverable panics and, where a constructor panic can't be removed without breaking the public API, adds an additive fallible path and documents the residual startup invariant.

## Changes

- **assert → typed error**: `login_oauth` now maps a v2-shaped body received on the v3 path to `AppError::Unauthorized` (via a private `ensure_oauth_session` guard, logged without the payload) instead of panicking. This path is reached by the 401 → `force_refresh` → `login` retry, so a shape mismatch must not take down the caller.
- **streaming expects removed**: `get_streaming_market_fields`, `get_streaming_account_data_fields`, `get_streaming_chart_fields` build wire names via `Display` (which already emits the exact IG Lightstreamer names) instead of a fallible `serde_json` round-trip; the three now-false `# Panics` docs are deleted.
- **additive fallible constructors**: `Auth::try_new()` and `Client::try_new() -> Result<_, AppError>` (built on `HttpClient::new_lazy`). `new()` / `Default` keep their signatures; their remaining `reqwest`-build `.expect()` is now a documented startup invariant (TLS backend init) with a `# Panics` section pointing at the fallible path.

## Public API impact

Additive only: new `try_new()` methods. No signature, field, or trait impl changed. `cargo semver-checks`: no semver update required. Fully removing the `Default for HttpClient` impl and turning `new()` into `Result` would break the API and is deferred to a version bump.

## Testing

- [x] Unit test: a v2-shaped body on the v3 login path yields `AppError::Unauthorized`, not a panic
- [x] Unit test pinning the account-field wire names produced by the Display-based getter (closes a pre-existing coverage gap)
- [x] `make pre-push` clean; workspace clippy clean; semver clean

Verified the Display-based streaming getters emit byte-identical wire names to the old serde path (market/chart getters already had value-asserting tests; added one for the account getter).

Closes #32
