### PR TITLE
fix(account): correct P&L fallback and position netting direction (#37)

### DIFF
--- a/src/application/auth.rs
+++ b/src/application/auth.rs
@@ -680,7 +680,7 @@ impl Auth {
     ///
     /// It cannot loop back through the 401 handler: [`login`](Self::login) issues
     /// its HTTP requests through
-    /// [`make_http_request`](crate::model::http::make_http_request) directly, not
+    /// [`make_http_request`] directly, not
     /// through the [`HttpClient`](crate::model::http::HttpClient) refresh-and-replay
     /// path, so a 401 encountered *during* login surfaces as a typed error rather
     /// than recursing into `force_refresh`.

--- a/src/presentation/account.rs
+++ b/src/presentation/account.rs
@@ -270,22 +270,34 @@ impl Position {
     ///
     #[must_use]
     pub fn pnl(&self) -> f64 {
-        if let Some(pnl) = self.pnl {
-            pnl
-        } else {
-            match self.position.direction {
-                Direction::Buy => {
-                    let value = self.position.size * self.position.level;
-                    let current_value = self.position.size * self.market.bid.unwrap_or(value);
-                    current_value - value
-                }
-                Direction::Sell => {
-                    let value = self.position.size * self.position.level;
-                    let current_value = self.position.size * self.market.offer.unwrap_or(value);
-                    value - current_value
-                }
-            }
-        }
+        self.pnl
+            .unwrap_or_else(|| self.pnl_checked().unwrap_or(0.0))
+    }
+
+    /// Computes P&L from current market prices, or `None` when the required
+    /// price for the position's direction is unavailable.
+    ///
+    /// This is the single source of truth for position P&L: a Buy is marked
+    /// against `market.bid`, a Sell against `market.offer`, as
+    /// `(price - level) * size` (sign flipped for a Sell). When that price is
+    /// missing there is no basis for a P&L, so this returns `None` rather than
+    /// fabricating a value — callers that need a number use `pnl()`, which
+    /// treats the unknown case as `0.0`. Unlike the pre-`pnl()` field override,
+    /// this ignores any cached `self.pnl`.
+    ///
+    /// # Returns
+    /// `Some(pnl)` when the direction's market price is present, else `None`.
+    #[must_use]
+    pub fn pnl_checked(&self) -> Option<f64> {
+        let current_price = match self.position.direction {
+            Direction::Buy => self.market.bid?,
+            Direction::Sell => self.market.offer?,
+        };
+        let price_diff = match self.position.direction {
+            Direction::Buy => current_price - self.position.level,
+            Direction::Sell => self.position.level - current_price,
+        };
+        Some(price_diff * self.position.size)
     }
 
     /// Updates the profit and loss (PnL) for the current position in the market.
@@ -315,19 +327,9 @@ impl Position {
     /// where the `bid` or `offer` is unavailable. It assumes that the market or position data are initialized correctly.
     ///
     pub fn update_pnl(&mut self) {
-        let pnl = match self.position.direction {
-            Direction::Buy => {
-                let value = self.position.size * self.position.level;
-                let current_value = self.position.size * self.market.bid.unwrap_or(value);
-                current_value - value
-            }
-            Direction::Sell => {
-                let value = self.position.size * self.position.level;
-                let current_value = self.position.size * self.market.offer.unwrap_or(value);
-                value - current_value
-            }
-        };
-        self.pnl = Some(pnl);
+        // Store the market-derived P&L (0.0 when the direction's price is
+        // unavailable), through the single `pnl_checked` implementation.
+        self.pnl = Some(self.pnl_checked().unwrap_or(0.0));
     }
 }
 
@@ -445,15 +447,25 @@ impl Add for PositionDetails {
     type Output = PositionDetails;
 
     fn add(self, other: PositionDetails) -> PositionDetails {
-        let (contract_size, size) = if self.direction != other.direction {
+        let (contract_size, size, direction) = if self.direction != other.direction {
+            // Netting opposite directions: the surviving position takes the
+            // direction of the larger size (e.g. Buy 2 + Sell 3 -> Sell 1). On a
+            // tie the net is flat and the direction is immaterial; keep `self`.
+            let direction = if other.size > self.size {
+                other.direction
+            } else {
+                self.direction
+            };
             (
                 (self.contract_size - other.contract_size).abs(),
                 (self.size - other.size).abs(),
+                direction,
             )
         } else {
             (
                 self.contract_size + other.contract_size,
                 self.size + other.size,
+                self.direction,
             )
         };
 
@@ -463,7 +475,7 @@ impl Add for PositionDetails {
             created_date_utc: self.created_date_utc,
             deal_id: self.deal_id,
             deal_reference: self.deal_reference,
-            direction: self.direction,
+            direction,
             limit_level: other.limit_level.or(self.limit_level),
             level: (self.level + other.level) / 2.0, // Average level
             size,
@@ -982,6 +994,7 @@ impl From<&ItemUpdate> for AccountData {
 mod tests {
     use super::*;
     use crate::presentation::order::Direction;
+    use crate::utils::finance::calculate_pnl;
 
     fn sample_position_details(direction: Direction, level: f64, size: f64) -> PositionDetails {
         PositionDetails {
@@ -1095,5 +1108,56 @@ mod tests {
             pnl: None,
         };
         assert!((position.pnl() - 0.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn pnl_missing_price_with_size_two_is_zero_not_inflated() {
+        // Regression: the old fallback substituted the notional (size*level) as
+        // the price, giving size^2*level - size*level. With size != 1 that is
+        // non-zero garbage; the correct answer with no market price is 0.
+        for direction in [Direction::Buy, Direction::Sell] {
+            let details = sample_position_details(direction, 155.14, 2.0);
+            let market = sample_market(None, None);
+            let position = Position {
+                position: details,
+                market,
+                pnl: None,
+            };
+            assert!(position.pnl_checked().is_none());
+            assert!(
+                position.pnl().abs() < 1e-12,
+                "size-2 missing-price pnl must be 0, got {}",
+                position.pnl()
+            );
+        }
+    }
+
+    #[test]
+    fn pnl_size_two_with_price_scales_with_size() {
+        // Buy 2 @ 100, bid 105 => (105-100)*2 = 10.
+        let details = sample_position_details(Direction::Buy, 100.0, 2.0);
+        let market = sample_market(Some(105.0), None);
+        let position = Position {
+            position: details,
+            market,
+            pnl: None,
+        };
+        assert!((position.pnl() - 10.0).abs() < 1e-12);
+        assert!((calculate_pnl(&position).expect("has bid") - 10.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn netting_opposite_directions_takes_larger_side() {
+        // Buy 2 + Sell 3 => Sell 1 (net short).
+        let buy = sample_position_details(Direction::Buy, 100.0, 2.0);
+        let sell = sample_position_details(Direction::Sell, 102.0, 3.0);
+        let net = buy.clone() + sell.clone();
+        assert_eq!(net.direction, Direction::Sell);
+        assert!((net.size - 1.0).abs() < 1e-12);
+
+        // Symmetric: Sell 3 + Buy 2 => Sell 1 as well.
+        let net2 = sell + buy;
+        assert_eq!(net2.direction, Direction::Sell);
+        assert!((net2.size - 1.0).abs() < 1e-12);
     }
 }

--- a/src/presentation/account.rs
+++ b/src/presentation/account.rs
@@ -251,22 +251,12 @@ impl Position {
     ///
     /// # Logic
     ///
-    /// - If `self.pnl` is available, it directly returns the cached value.
-    /// - If not, the PnL is calculated based on the direction of the position:
-    ///   - For a Buy position:
-    ///     - The PnL is calculated as the difference between the `current_value`
-    ///       (based on the `market.bid` price or fallback value) and the original
-    ///       `value` (based on the position's size and level).
-    ///   - For a Sell position:
-    ///     - The PnL is calculated as the difference between the original
-    ///       `value` and the `current_value` (based on the `market.offer`
-    ///       price or fallback value).
-    ///
-    /// # Assumptions
-    /// - The `market.bid` and `market.offer` values are optional, so fallback
-    ///   to the original position value is used if they are unavailable.
-    /// - `self.position.direction` must be either `Direction::Buy` or
-    ///   `Direction::Sell`.
+    /// - If `self.pnl` is set, the cached value is returned directly.
+    /// - Otherwise it delegates to [`Position::pnl_checked`], which marks a Buy
+    ///   against `market.bid` and a Sell against `market.offer`. When the
+    ///   direction's market price is unavailable there is no basis for a P&L, so
+    ///   this returns `0.0` (use [`Position::pnl_checked`] to distinguish the
+    ///   unknown case as `None`).
     ///
     #[must_use]
     pub fn pnl(&self) -> f64 {
@@ -300,31 +290,17 @@ impl Position {
         Some(price_diff * self.position.size)
     }
 
-    /// Updates the profit and loss (PnL) for the current position in the market.
+    /// Updates the cached profit and loss (PnL) for the current position from
+    /// current market prices.
     ///
-    /// The method calculates the PnL based on the position's direction (Buy or Sell),
-    /// size, level (entry price), and the current bid or offer price from the market data.
-    /// The result is stored in the `pnl` field.
+    /// Delegates to [`Position::pnl_checked`] (a Buy marked against `market.bid`,
+    /// a Sell against `market.offer`) and stores the result in `self.pnl`. When
+    /// the direction's market price is unavailable there is no basis for a P&L,
+    /// so `0.0` is stored.
     ///
-    /// # Calculation:
-    /// - If the position is a Buy:
-    ///     - Calculate the initial value of the position as `size * level`.
-    ///     - Calculate the current value of the position using the current `bid` price from the market,
-    ///       or use the initial value if the `bid` price is not available.
-    ///     - PnL is the difference between the current value and the initial value.
-    /// - If the position is a Sell:
-    ///     - Calculate the initial value of the position as `size * level`.
-    ///     - Calculate the current value of the position using the current `offer` price from the market,
-    ///       or use the initial value if the `offer` price is not available.
-    ///     - PnL is the difference between the initial value and the current value.
-    ///
-    /// # Fields Updated:
-    /// - `self.pnl`: The calculated profit or loss is updated in this field. If no valid market price
-    ///   (bid/offer) is available, `pnl` will be calculated based on the initial value.
-    ///
-    /// # Panics:
-    /// This function does not explicitly panic but relies on the `unwrap_or` method to handle cases
-    /// where the `bid` or `offer` is unavailable. It assumes that the market or position data are initialized correctly.
+    /// # Fields Updated
+    /// - `self.pnl`: set to `Some(pnl)`, or `Some(0.0)` when the required market
+    ///   price is missing.
     ///
     pub fn update_pnl(&mut self) {
         // Store the market-derived P&L (0.0 when the direction's price is

--- a/src/utils/finance.rs
+++ b/src/utils/finance.rs
@@ -3,9 +3,11 @@
 // Financial calculation utilities for the IG client
 
 use crate::presentation::account::Position;
-use crate::presentation::order::Direction;
 
 /// Calculate the Profit and Loss (P&L) for a position based on current market prices
+///
+/// Thin wrapper over [`Position::pnl_checked`], the single source of truth for
+/// position P&L, kept for backwards compatibility.
 ///
 /// # Arguments
 ///
@@ -17,22 +19,7 @@ use crate::presentation::order::Direction;
 ///
 #[must_use]
 pub fn calculate_pnl(position: &Position) -> Option<f64> {
-    let (bid, offer) = (position.market.bid, position.market.offer);
-
-    // Get the appropriate price based on direction
-    let current_price = match position.position.direction {
-        Direction::Buy => bid?,
-        Direction::Sell => offer?,
-    };
-
-    // Calculate price difference
-    let price_diff = match position.position.direction {
-        Direction::Buy => current_price - position.position.level,
-        Direction::Sell => position.position.level - current_price,
-    };
-
-    // Return P&L
-    Some(price_diff * position.position.size)
+    position.pnl_checked()
 }
 
 /// Calculate the percentage return for a position


### PR DESCRIPTION
## Summary

`Position::pnl()` / `update_pnl()` produced garbage P&L for any position with size != 1 when the market price was missing (the fallback substituted the notional `size * level` as the price, yielding `size^2 * level - size * level`), and there were two divergent P&L implementations for the same type. Separately, `PositionDetails::add` never flipped direction when netting opposite-direction positions. This PR consolidates P&L into one implementation and fixes the netting direction.

## Changes

- **One P&L implementation**: new `Position::pnl_checked() -> Option<f64>` — Buy marked against `market.bid`, Sell against `market.offer`, `(price - level) * size` (sign flipped for Sell), `None` when the direction's price is missing. `pnl()` (cached override, else `pnl_checked().unwrap_or(0.0)`), `update_pnl()`, and `utils::finance::calculate_pnl` all delegate to it; the duplicate math is gone.
- **Missing-price P&L is 0**, not `size^2`-inflated.
- **Netting direction**: `PositionDetails::add` now takes the larger side's direction on opposite-direction netting (Buy 2 + Sell 3 → Sell 1); it previously always kept `self.direction`.

## Public API impact

Additive only: new `Position::pnl_checked()`. `pnl()`, `update_pnl()`, `calculate_pnl()` signatures unchanged. `cargo semver-checks`: no semver update required.

## Testing

- [x] size-2 missing-price P&L is 0 (both directions) — the regression the old fallback got wrong
- [x] size-2 with price scales linearly (`(105-100)*2 = 10`)
- [x] netting Buy 2 + Sell 3 → Sell 1 (and the symmetric Sell 3 + Buy 2)
- [x] `make pre-push` clean; semver clean

An adversarial review confirmed the sign convention, delegation, and tie-break. It also flagged two **pre-existing, out-of-scope** defects in `PositionDetails::add` (nets `contract_size` via `abs`-subtraction → 0 for same-instrument legs; averages `level` unweighted instead of size-weighted VWAP) — noted for a follow-up issue, not touched here.

Closes #37
