### PR TITLE
fix(storage): repair migration, empty-epic stats, instrument_type, upsert classification, DDL (#41)

### DIFF
--- a/src/storage/historical_prices.rs
+++ b/src/storage/historical_prices.rs
@@ -60,7 +60,13 @@ pub async fn initialize_historical_prices_table(pool: &PgPool) -> Result<(), sql
     // are surfaced rather than silently discarded.
 
     // Drop the legacy two-column constraint if a pre-migration database has it.
-    // `IF EXISTS` makes this idempotent.
+    // `IF EXISTS` makes this idempotent. The target three-column constraint is
+    // NOT dropped here: `CREATE TABLE ... UNIQUE(epic, resolution, snapshot_time)`
+    // above already creates it (auto-named `historical_prices_epic_resolution_snapshot_time_key`),
+    // so dropping and re-adding it on every startup would churn an
+    // AccessExclusive lock for nothing. The tolerant ADD below handles both the
+    // fresh case (constraint already present → 42710 → skipped) and the migration
+    // case (old two-column DB whose legacy constraint was just dropped).
     sqlx::query(
         "ALTER TABLE historical_prices \
          DROP CONSTRAINT IF EXISTS historical_prices_epic_snapshot_time_key",
@@ -68,18 +74,9 @@ pub async fn initialize_historical_prices_table(pool: &PgPool) -> Result<(), sql
     .execute(pool)
     .await?;
 
-    // Drop the target constraint if present so it can be (re)created cleanly.
-    sqlx::query(
-        "ALTER TABLE historical_prices \
-         DROP CONSTRAINT IF EXISTS historical_prices_epic_resolution_snapshot_time_key",
-    )
-    .execute(pool)
-    .await?;
-
     // Add the three-column unique constraint. There is no `IF NOT EXISTS` for
-    // `ADD CONSTRAINT`; the preceding DROP normally clears the way, but tolerate
-    // a concurrent duplicate-object error (SQLSTATE 42710) while surfacing any
-    // other failure.
+    // `ADD CONSTRAINT`, so tolerate a duplicate-object error (SQLSTATE 42710)
+    // when it already exists while surfacing any other failure.
     if let Err(e) = sqlx::query(
         "ALTER TABLE historical_prices \
          ADD CONSTRAINT historical_prices_epic_resolution_snapshot_time_key \

--- a/src/storage/historical_prices.rs
+++ b/src/storage/historical_prices.rs
@@ -53,22 +53,52 @@ pub async fn initialize_historical_prices_table(pool: &PgPool) -> Result<(), sql
         );
     }
 
-    // Attempt to drop the old unique constraint
-    let _ = sqlx::query(
-        r#"
-        ALTER TABLE historical_prices 
-        DROP CONSTRAINT IF EXISTS historical_prices_epic_snapshot_time_key;
-        
-        ALTER TABLE historical_prices
-        DROP CONSTRAINT IF EXISTS historical_prices_epic_resolution_snapshot_time_key;
-        
-        ALTER TABLE historical_prices 
-        ADD CONSTRAINT historical_prices_epic_resolution_snapshot_time_key 
-        UNIQUE (epic, resolution, snapshot_time);
-        "#,
+    // Migrate the unique constraint to (epic, resolution, snapshot_time).
+    //
+    // Postgres' extended/prepared protocol rejects multiple statements in a
+    // single query, so each DDL statement must be issued on its own. Errors
+    // are surfaced rather than silently discarded.
+
+    // Drop the legacy two-column constraint if a pre-migration database has it.
+    // `IF EXISTS` makes this idempotent.
+    sqlx::query(
+        "ALTER TABLE historical_prices \
+         DROP CONSTRAINT IF EXISTS historical_prices_epic_snapshot_time_key",
     )
     .execute(pool)
-    .await;
+    .await?;
+
+    // Drop the target constraint if present so it can be (re)created cleanly.
+    sqlx::query(
+        "ALTER TABLE historical_prices \
+         DROP CONSTRAINT IF EXISTS historical_prices_epic_resolution_snapshot_time_key",
+    )
+    .execute(pool)
+    .await?;
+
+    // Add the three-column unique constraint. There is no `IF NOT EXISTS` for
+    // `ADD CONSTRAINT`; the preceding DROP normally clears the way, but tolerate
+    // a concurrent duplicate-object error (SQLSTATE 42710) while surfacing any
+    // other failure.
+    if let Err(e) = sqlx::query(
+        "ALTER TABLE historical_prices \
+         ADD CONSTRAINT historical_prices_epic_resolution_snapshot_time_key \
+         UNIQUE (epic, resolution, snapshot_time)",
+    )
+    .execute(pool)
+    .await
+    {
+        match e.as_database_error().and_then(|db| db.code()) {
+            // 42710 = duplicate_object: the constraint already exists.
+            Some(code) if code == "42710" => {
+                warn!(
+                    constraint = "historical_prices_epic_resolution_snapshot_time_key",
+                    "unique constraint already exists, skipping add"
+                );
+            }
+            _ => return Err(e),
+        }
+    }
 
     // Create index for better query performance
     sqlx::query(
@@ -167,8 +197,13 @@ pub async fn store_historical_prices(
             }
         };
 
-        // Use UPSERT (INSERT ... ON CONFLICT ... DO UPDATE)
-        let result = sqlx::query(
+        // Use UPSERT (INSERT ... ON CONFLICT ... DO UPDATE) and classify the
+        // outcome from the SAME statement via `RETURNING (xmax = 0)`:
+        // `xmax = 0` on the returned tuple means a fresh insert, while a
+        // non-zero `xmax` means the conflicting row was updated. This avoids a
+        // second round trip and is correct for same-batch duplicates (the older
+        // `created_at = updated_at` heuristic double-counted them as inserts).
+        let row = sqlx::query(
             r#"
             INSERT INTO historical_prices (
                 epic, resolution, snapshot_time,
@@ -178,7 +213,7 @@ pub async fn store_historical_prices(
                 close_bid, close_ask, close_last_traded,
                 last_traded_volume
             ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
-            ON CONFLICT (epic, resolution, snapshot_time) 
+            ON CONFLICT (epic, resolution, snapshot_time)
             DO UPDATE SET
                 open_bid = EXCLUDED.open_bid,
                 open_ask = EXCLUDED.open_ask,
@@ -194,6 +229,7 @@ pub async fn store_historical_prices(
                 close_last_traded = EXCLUDED.close_last_traded,
                 last_traded_volume = EXCLUDED.last_traded_volume,
                 updated_at = NOW()
+            RETURNING (xmax = 0) AS inserted
             "#,
         )
         .bind(epic)
@@ -212,28 +248,15 @@ pub async fn store_historical_prices(
         .bind(price.close_price.ask)
         .bind(price.close_price.last_traded)
         .bind(price.last_traded_volume)
-        .execute(&mut *tx)
+        .fetch_one(&mut *tx)
         .await?;
 
-        // Check if it was an insert or update
-        if result.rows_affected() > 0 {
-            // Query to check if this was an insert or update
-            let count: i64 = sqlx::query_scalar(
-                "SELECT COUNT(*) FROM historical_prices WHERE epic = $1 AND resolution = $2 AND snapshot_time = $3 AND created_at = updated_at"
-            )
-                .bind(epic)
-                .bind(resolution)
-                .bind(snapshot_time)
-                .fetch_one(&mut *tx)
-                .await?;
-
-            if count > 0 {
-                stats.inserted += 1;
-            } else {
-                stats.updated += 1;
-            }
+        // `DO UPDATE` always returns exactly one row, so classification is
+        // unambiguous.
+        if row.get::<bool, _>("inserted") {
+            stats.inserted += 1;
         } else {
-            stats.skipped += 1;
+            stats.updated += 1;
         }
 
         // Log progress every 100 records
@@ -334,10 +357,30 @@ pub async fn get_table_statistics(
         .await?
     };
 
+    // `COUNT(*)` is never NULL, but the aggregate columns
+    // (`MIN`/`MAX`/`AVG`, and the `::text` date bounds) are all NULL for an
+    // epic with no rows. Read every nullable column as an `Option` so a
+    // zero-row epic returns zeroed stats instead of panicking in `Row::get`.
+    let total_records: i64 = row.get("total_records");
+    if total_records == 0 {
+        return Ok(TableStats {
+            total_records: 0,
+            earliest_date: String::new(),
+            latest_date: String::new(),
+            avg_close_price: 0.0,
+            min_price: 0.0,
+            max_price: 0.0,
+        });
+    }
+
     Ok(TableStats {
-        total_records: row.get("total_records"),
-        earliest_date: row.get("earliest_date"),
-        latest_date: row.get("latest_date"),
+        total_records,
+        earliest_date: row
+            .get::<Option<String>, _>("earliest_date")
+            .unwrap_or_default(),
+        latest_date: row
+            .get::<Option<String>, _>("latest_date")
+            .unwrap_or_default(),
         avg_close_price: row.get::<Option<f64>, _>("avg_close_price").unwrap_or(0.0),
         min_price: row.get::<Option<f64>, _>("min_price").unwrap_or(0.0),
         max_price: row.get::<Option<f64>, _>("max_price").unwrap_or(0.0),

--- a/src/storage/market_database.rs
+++ b/src/storage/market_database.rs
@@ -441,10 +441,14 @@ impl MarketDatabaseService {
         // `OPT_CURRENCIES`, `INDICES`) WITHOUT surrounding quotes. Using
         // `format!("{:?}", ..)` would emit the `DebugPretty` (serde_json)
         // rendering, which includes literal quotes (e.g. `"\"OPT_CURRENCIES\""`).
+        // `instrument_type` is NOT NULL and used for filtering, so never store an
+        // empty string: fall back to an explicit `UNKNOWN` sentinel if the enum
+        // ever fails to serialize to a string (structurally unreachable today,
+        // but a wrong-but-visible value beats a silent empty one).
         let instrument_type = serde_json::to_value(market.instrument_type)
             .ok()
             .and_then(|v| v.as_str().map(str::to_owned))
-            .unwrap_or_default();
+            .unwrap_or_else(|| "UNKNOWN".to_string());
 
         let mut instrument = MarketInstrument::new(
             market.epic.clone(),

--- a/src/storage/market_database.rs
+++ b/src/storage/market_database.rs
@@ -437,10 +437,19 @@ impl MarketDatabaseService {
         market: &MarketData,
         node_id: &str,
     ) -> MarketInstrument {
+        // Persist the serde wire value of the instrument type (e.g.
+        // `OPT_CURRENCIES`, `INDICES`) WITHOUT surrounding quotes. Using
+        // `format!("{:?}", ..)` would emit the `DebugPretty` (serde_json)
+        // rendering, which includes literal quotes (e.g. `"\"OPT_CURRENCIES\""`).
+        let instrument_type = serde_json::to_value(market.instrument_type)
+            .ok()
+            .and_then(|v| v.as_str().map(str::to_owned))
+            .unwrap_or_default();
+
         let mut instrument = MarketInstrument::new(
             market.epic.clone(),
             market.instrument_name.clone(),
-            format!("{:?}", market.instrument_type).to_uppercase(),
+            instrument_type,
             node_id.to_string(),
             self.exchange_name.clone(),
         );
@@ -678,22 +687,23 @@ impl DatabaseStatistics {
 mod tests {
     use super::*;
     use crate::presentation::instrument::InstrumentType;
+    use sqlx::postgres::{PgConnectOptions, PgPoolOptions};
 
-    #[tokio::test]
-    #[ignore]
-    async fn test_convert_market_data_to_instrument() {
-        let service = MarketDatabaseService::new(
-            // This would be a real pool in actual tests
-            PgPool::connect("postgresql://test")
-                .await
-                .unwrap_or_else(|_| panic!("Test requires a PostgreSQL connection")),
-            "IG".to_string(),
-        );
+    /// Builds a `MarketDatabaseService` backed by a lazily-connected pool.
+    ///
+    /// `connect_lazy_with` never opens a socket (it only needs a Tokio
+    /// context), so pure conversion helpers (which do not touch the pool) can
+    /// be unit-tested without a live database and therefore run in CI.
+    fn lazy_service() -> MarketDatabaseService {
+        let pool = PgPoolOptions::new().connect_lazy_with(PgConnectOptions::new());
+        MarketDatabaseService::new(pool, "IG".to_string())
+    }
 
-        let market_data = MarketData {
+    fn market_data_with_type(instrument_type: InstrumentType) -> MarketData {
+        MarketData {
             epic: "IX.D.DAX.DAILY.IP".to_string(),
             instrument_name: "Germany 40".to_string(),
-            instrument_type: InstrumentType::Indices,
+            instrument_type,
             expiry: "DFB".to_string(),
             high_limit_price: Some(20000.0),
             low_limit_price: Some(5000.0),
@@ -704,7 +714,13 @@ mod tests {
             update_time_utc: Some("2023-12-01T10:30:00Z".to_string()),
             bid: Some(15450.2),
             offer: Some(15451.8),
-        };
+        }
+    }
+
+    #[tokio::test]
+    async fn test_convert_market_data_to_instrument_maps_fields() {
+        let service = lazy_service();
+        let market_data = market_data_with_type(InstrumentType::Indices);
 
         let instrument = service.convert_market_data_to_instrument(&market_data, "node_123");
 
@@ -717,5 +733,30 @@ mod tests {
         assert_eq!(instrument.high_limit_price, Some(20000.0));
         assert_eq!(instrument.bid, Some(15450.2));
         assert_eq!(instrument.offer, Some(15451.8));
+    }
+
+    #[tokio::test]
+    async fn test_convert_market_data_to_instrument_type_is_unquoted_wire_value() {
+        let service = lazy_service();
+
+        // Renamed variant: must persist the serde wire value with no quotes.
+        let opt = service
+            .convert_market_data_to_instrument(
+                &market_data_with_type(InstrumentType::OptCurrencies),
+                "node_1",
+            )
+            .instrument_type;
+        assert_eq!(opt, "OPT_CURRENCIES");
+        assert!(!opt.contains('"'), "wire value must not contain quotes");
+
+        // UPPERCASE-renamed variant.
+        let currencies = service
+            .convert_market_data_to_instrument(
+                &market_data_with_type(InstrumentType::Currencies),
+                "node_2",
+            )
+            .instrument_type;
+        assert_eq!(currencies, "CURRENCIES");
+        assert!(!currencies.contains('"'));
     }
 }

--- a/src/storage/utils.rs
+++ b/src/storage/utils.rs
@@ -7,7 +7,60 @@ use serde_json;
 use sqlx::{Executor, PgPool};
 use tracing::info;
 
-/// Stores a list of transactions in the database
+/// Initializes the `ig_options` table used by [`store_transactions`].
+///
+/// Ships the DDL in code (like the other storage tables) so persistence works
+/// against a fresh database. The `raw_hash` column is the deduplication key:
+/// it stores the MD5 digest of the raw transaction JSON and carries a `UNIQUE`
+/// constraint so re-ingesting an identical payload is a no-op. Call this once
+/// before [`store_transactions`].
+///
+/// # Arguments
+/// * `pool` - PostgreSQL connection pool
+///
+/// # Errors
+/// Returns [`AppError`] if the `CREATE TABLE` statement fails.
+#[must_use = "table initialization can fail and must be handled"]
+pub async fn initialize_ig_options_table(pool: &PgPool) -> Result<(), AppError> {
+    info!("Initializing ig_options table...");
+
+    sqlx::query(
+        r#"
+        CREATE TABLE IF NOT EXISTS ig_options (
+            id BIGSERIAL PRIMARY KEY,
+            reference TEXT NOT NULL,
+            deal_date TIMESTAMPTZ NOT NULL,
+            underlying TEXT,
+            strike DOUBLE PRECISION,
+            option_type TEXT,
+            expiry DATE,
+            transaction_type TEXT NOT NULL,
+            pnl_eur DOUBLE PRECISION NOT NULL,
+            is_fee BOOLEAN NOT NULL,
+            raw TEXT NOT NULL,
+            raw_hash TEXT NOT NULL UNIQUE,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        )
+        "#,
+    )
+    .execute(pool)
+    .await?;
+
+    sqlx::query("CREATE INDEX IF NOT EXISTS idx_ig_options_reference ON ig_options(reference)")
+        .execute(pool)
+        .await?;
+
+    info!("ig_options table initialized successfully");
+    Ok(())
+}
+
+/// Stores a list of transactions in the database.
+///
+/// Requires the `ig_options` table to exist; call
+/// [`initialize_ig_options_table`] first. Deduplication is keyed on
+/// `raw_hash`, which is computed database-side as `md5(raw)` from the bound
+/// raw JSON (a stable, dependency-free digest); `ON CONFLICT (raw_hash) DO
+/// NOTHING` makes re-ingesting an identical payload a no-op.
 ///
 /// # Arguments
 /// * `pool` - PostgreSQL connection pool
@@ -15,6 +68,7 @@ use tracing::info;
 ///
 /// # Returns
 /// * `Result<usize, AppError>` - Number of transactions inserted or an error
+#[must_use = "storage writes can fail and the inserted count must be handled"]
 pub async fn store_transactions(
     pool: &sqlx::PgPool,
     txs: &[StoreTransaction],
@@ -23,15 +77,19 @@ pub async fn store_transactions(
     let mut inserted = 0;
 
     for t in txs {
+        // `raw_hash` is derived from the raw JSON via Postgres' built-in
+        // `md5()` on the bound `$10` value (no string interpolation), giving a
+        // deterministic dedup key without an extra dependency.
         let result = tx
             .execute(
                 sqlx::query(
                     r#"
                     INSERT INTO ig_options (
                         reference, deal_date, underlying, strike,
-                        option_type, expiry, transaction_type, pnl_eur, is_fee, raw
+                        option_type, expiry, transaction_type, pnl_eur, is_fee, raw,
+                        raw_hash
                     )
-                    VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)
+                    VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10, md5($10))
                     ON CONFLICT (raw_hash) DO NOTHING
                     "#,
                 )

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -2,6 +2,7 @@ mod account_tests;
 mod auth_tests;
 mod common;
 mod market_tests;
+mod storage_tests;
 // order_tests, position_tests, working_order_tests temporarily disabled
 // These tests need significant refactoring for the new Client API
 // and involve real trading operations that should be carefully reviewed

--- a/tests/integration/storage_tests.rs
+++ b/tests/integration/storage_tests.rs
@@ -1,0 +1,207 @@
+//! Env-gated storage integration tests (issue #41 storage correctness).
+//!
+//! These tests require a live PostgreSQL and are marked `#[ignore]` so they
+//! never run in the default CI matrix. Run them explicitly against a
+//! disposable test database:
+//!
+//! ```bash
+//! DATABASE_URL=postgres://user:pass@localhost/ig_test \
+//!     cargo test --test integration_tests storage_tests -- --ignored
+//! ```
+//!
+//! Each test skips silently when `DATABASE_URL` is unset.
+
+use ig_client::presentation::market::{HistoricalPrice, PricePoint};
+use ig_client::presentation::transaction::StoreTransaction;
+use ig_client::storage::historical_prices::{
+    get_table_statistics, initialize_historical_prices_table, store_historical_prices,
+};
+use ig_client::storage::utils::{initialize_ig_options_table, store_transactions};
+use sqlx::{PgPool, Row};
+
+/// Returns a pool when `DATABASE_URL` is set, otherwise `None` so the test
+/// skips instead of failing on CI machines with no database.
+async fn test_pool() -> Option<PgPool> {
+    let url = std::env::var("DATABASE_URL").ok()?;
+    sqlx::postgres::PgPoolOptions::new()
+        .max_connections(2)
+        .connect(&url)
+        .await
+        .ok()
+}
+
+fn sample_price(snapshot: &str) -> HistoricalPrice {
+    HistoricalPrice {
+        snapshot_time: snapshot.to_string(),
+        open_price: PricePoint {
+            bid: Some(1.0),
+            ask: Some(1.1),
+            last_traded: None,
+        },
+        high_price: PricePoint {
+            bid: Some(2.0),
+            ask: Some(2.1),
+            last_traded: None,
+        },
+        low_price: PricePoint {
+            bid: Some(0.5),
+            ask: Some(0.6),
+            last_traded: None,
+        },
+        close_price: PricePoint {
+            bid: Some(1.5),
+            ask: Some(1.6),
+            last_traded: None,
+        },
+        last_traded_volume: Some(100),
+    }
+}
+
+/// Removes any rows for a test epic so the test starts from a clean slate.
+async fn delete_epic(pool: &PgPool, epic: &str) {
+    let _ = sqlx::query("DELETE FROM historical_prices WHERE epic = $1")
+        .bind(epic)
+        .execute(pool)
+        .await;
+}
+
+#[tokio::test]
+#[ignore = "requires a live PostgreSQL via DATABASE_URL"]
+async fn test_initialize_historical_prices_table_creates_unique_constraint() {
+    let Some(pool) = test_pool().await else {
+        return;
+    };
+
+    initialize_historical_prices_table(&pool)
+        .await
+        .expect("table initialization should succeed");
+
+    // The (epic, resolution, snapshot_time) unique constraint must now exist.
+    let row = sqlx::query(
+        "SELECT COUNT(*) AS n FROM pg_constraint \
+         WHERE conname = 'historical_prices_epic_resolution_snapshot_time_key'",
+    )
+    .fetch_one(&pool)
+    .await
+    .expect("constraint lookup should succeed");
+    let count: i64 = row.get("n");
+    assert_eq!(count, 1, "the three-column unique constraint must exist");
+
+    // Re-running initialization must remain idempotent.
+    initialize_historical_prices_table(&pool)
+        .await
+        .expect("re-initialization should be idempotent");
+}
+
+#[tokio::test]
+#[ignore = "requires a live PostgreSQL via DATABASE_URL"]
+async fn test_store_historical_prices_upsert_is_idempotent() {
+    let Some(pool) = test_pool().await else {
+        return;
+    };
+    let epic = "TEST.ISSUE41.UPSERT";
+    let resolution = "MINUTE";
+
+    initialize_historical_prices_table(&pool)
+        .await
+        .expect("table initialization should succeed");
+    delete_epic(&pool, epic).await;
+
+    let prices = vec![sample_price("2024/01/15 14:30:00")];
+
+    // First write: exactly one insert.
+    let first = store_historical_prices(&pool, epic, resolution, &prices)
+        .await
+        .expect("first store should succeed");
+    assert_eq!(first.inserted, 1, "first write must insert");
+    assert_eq!(first.updated, 0);
+    assert_eq!(first.skipped, 0);
+
+    // Second write with the same conflict key: exactly one update, no insert.
+    let second = store_historical_prices(&pool, epic, resolution, &prices)
+        .await
+        .expect("second store should succeed");
+    assert_eq!(second.inserted, 0, "second write must not re-insert");
+    assert_eq!(second.updated, 1, "second write must update");
+    assert_eq!(second.skipped, 0);
+
+    // Exactly one physical row survives (no duplicate, no delete).
+    let row = sqlx::query("SELECT COUNT(*) AS n FROM historical_prices WHERE epic = $1")
+        .bind(epic)
+        .fetch_one(&pool)
+        .await
+        .expect("count should succeed");
+    let count: i64 = row.get("n");
+    assert_eq!(count, 1, "upsert must not create duplicate rows");
+
+    delete_epic(&pool, epic).await;
+}
+
+#[tokio::test]
+#[ignore = "requires a live PostgreSQL via DATABASE_URL"]
+async fn test_get_table_statistics_empty_epic_returns_zeroed_stats() {
+    let Some(pool) = test_pool().await else {
+        return;
+    };
+    let epic = "TEST.ISSUE41.EMPTY";
+
+    initialize_historical_prices_table(&pool)
+        .await
+        .expect("table initialization should succeed");
+    delete_epic(&pool, epic).await;
+
+    // Must not panic on NULL MIN/MAX/AVG aggregates for a zero-row epic.
+    let stats = get_table_statistics(&pool, epic, None)
+        .await
+        .expect("statistics for an empty epic should succeed");
+
+    assert_eq!(stats.total_records, 0);
+    assert!(stats.earliest_date.is_empty());
+    assert!(stats.latest_date.is_empty());
+    assert!((stats.avg_close_price - 0.0).abs() < f64::EPSILON);
+    assert!((stats.min_price - 0.0).abs() < f64::EPSILON);
+    assert!((stats.max_price - 0.0).abs() < f64::EPSILON);
+}
+
+#[tokio::test]
+#[ignore = "requires a live PostgreSQL via DATABASE_URL"]
+async fn test_store_transactions_dedupes_on_raw_hash() {
+    let Some(pool) = test_pool().await else {
+        return;
+    };
+    let reference = "TEST-ISSUE41-DEDUP";
+
+    initialize_ig_options_table(&pool)
+        .await
+        .expect("ig_options initialization should succeed");
+    let _ = sqlx::query("DELETE FROM ig_options WHERE reference = $1")
+        .bind(reference)
+        .execute(&pool)
+        .await;
+
+    let tx = StoreTransaction {
+        transaction_type: "DEAL".to_string(),
+        pnl_eur: 12.5,
+        reference: reference.to_string(),
+        raw_json: r#"{"reference":"TEST-ISSUE41-DEDUP","amount":12.5}"#.to_string(),
+        ..Default::default()
+    };
+    let batch = vec![tx];
+
+    // First ingest inserts the row.
+    let first = store_transactions(&pool, &batch)
+        .await
+        .expect("first ingest should succeed");
+    assert_eq!(first, 1, "first ingest must insert one row");
+
+    // Re-ingesting the identical raw payload is a no-op (deduped on raw_hash).
+    let second = store_transactions(&pool, &batch)
+        .await
+        .expect("second ingest should succeed");
+    assert_eq!(second, 0, "identical payload must be deduplicated");
+
+    let _ = sqlx::query("DELETE FROM ig_options WHERE reference = $1")
+        .bind(reference)
+        .execute(&pool)
+        .await;
+}

--- a/tests/integration/storage_tests.rs
+++ b/tests/integration/storage_tests.rs
@@ -21,13 +21,18 @@ use sqlx::{PgPool, Row};
 
 /// Returns a pool when `DATABASE_URL` is set, otherwise `None` so the test
 /// skips instead of failing on CI machines with no database.
+///
+/// If `DATABASE_URL` **is** set but the connection fails, this panics rather
+/// than returning `None` — a broken DB configuration must surface as a failure
+/// when the ignored tests are run with `--ignored`, not silently pass.
 async fn test_pool() -> Option<PgPool> {
     let url = std::env::var("DATABASE_URL").ok()?;
-    sqlx::postgres::PgPoolOptions::new()
+    let pool = sqlx::postgres::PgPoolOptions::new()
         .max_connections(2)
         .connect(&url)
         .await
-        .ok()
+        .expect("DATABASE_URL is set but the Postgres connection failed");
+    Some(pool)
 }
 
 fn sample_price(snapshot: &str) -> HistoricalPrice {

--- a/tests/unit/storage/test_market_database.rs
+++ b/tests/unit/storage/test_market_database.rs
@@ -96,8 +96,9 @@ async fn convert_market_data_to_instrument_maps_fields() {
 
     assert_eq!(inst.epic, md.epic);
     assert_eq!(inst.instrument_name, md.instrument_name);
-    // DisplaySimple serializes to JSON with quotes
-    assert_eq!(inst.instrument_type, "\"INDICES\"");
+    // The serde wire value is persisted without surrounding quotes.
+    assert_eq!(inst.instrument_type, "INDICES");
+    assert!(!inst.instrument_type.contains('"'));
     assert_eq!(inst.node_id, "node-1");
     assert_eq!(inst.exchange, "IG");
     assert_eq!(inst.expiry, md.expiry);


### PR DESCRIPTION
## Summary

Five verified storage-layer data-correctness bugs. A constraint migration that always failed silently (so the unique constraint was never created), a panic on empty-epic statistics, instrument types stored with embedded JSON quotes, a per-record `SELECT COUNT(*)` that miscounted same-batch duplicates, and a `store_transactions` upsert against a `raw_hash` column with no DDL anywhere in the crate.

## Changes

- **Constraint migration** (`historical_prices.rs`): split the single multi-statement DDL string (which Postgres's prepared protocol rejected, error discarded with `let _ =`) into individual `DROP CONSTRAINT IF EXISTS` + `ADD CONSTRAINT` statements, each with errors surfaced. Duplicate-object (SQLSTATE 42710) on the add is tolerated; every other error propagates. The `(epic, resolution, snapshot_time)` unique constraint is now actually created.
- **Empty-epic stats**: `get_table_statistics` reads the nullable `MIN`/`MAX` aggregates as `Option` and returns zeroed stats when the epic has no rows, instead of panicking on NULL.
- **instrument_type**: stored as the serde wire value (`OPT_CURRENCIES`) via `serde_json::to_value(..).as_str()`, not `format!("{:?}", ..)` which emitted DebugPretty JSON with literal quotes.
- **Upsert classification**: the historical-price upsert appends `RETURNING (xmax = 0) AS inserted` and reads the flag from the same statement, removing the second `SELECT COUNT(*)` round-trip whose `created_at = updated_at` heuristic double-counted same-batch duplicates as inserts.
- **ig_options DDL**: ships the missing `CREATE TABLE ig_options (...)` including `raw_hash` (computed database-side as `md5($10)` from the bound raw payload) so `store_transactions` no longer depends on an undocumented external schema.

## Testing

- [x] Pure CI unit tests: instrument_type maps to the unquoted wire value
- [x] Env-gated `#[ignore]` integration tests (guarded on `DATABASE_URL`, never run in CI): constraint creation, upsert idempotence (1 insert then 1 update, single row), empty-epic stats return zeroed (no panic), transaction dedup on raw_hash
- [x] `make pre-push` clean; semver clean; bind parameters for all values (literal SQL only for DDL)

## Scope note

The sixth task from #41 — persisting UTC by adding `HistoricalPrice.snapshot_time_utc` — is a breaking change to a `pub`-fields struct and is split out to #60 for a version bump. This PR covers the five non-breaking fixes.

Closes #41
