### PR TITLE
fix(streaming): repair connection-task locking and shutdown paths (#29)

### DIFF
--- a/src/application/client.rs
+++ b/src/application/client.rs
@@ -51,17 +51,87 @@ use lightstreamer_rs::client::{LightstreamerClient, LogType, Transport};
 use lightstreamer_rs::subscription::{
     ChannelSubscriptionListener, Snapshot, Subscription, SubscriptionMode,
 };
-use lightstreamer_rs::utils::setup_signal_hook;
+use lightstreamer_rs::utils::{LightstreamerError, setup_signal_hook};
 use reqwest::StatusCode;
 use serde_json::Value;
 use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::{Mutex, Notify, RwLock, mpsc};
+use tokio::task::JoinHandle;
 use tokio::time::sleep;
 use tracing::{debug, error, info, warn};
 
 const MAX_CONNECTION_ATTEMPTS: u64 = 3;
+
+/// Server-supplied close reason IG sends on a streaming session once it has no
+/// active subscriptions left to serve.
+///
+/// This is not a dedicated error discriminant: `lightstreamer-rs` surfaces it
+/// as free-form text embedded in a server error payload, so it can only be
+/// matched best-effort (see [`is_graceful_close`]).
+const GRACEFUL_CLOSE_MARKER: &str = "No more requests to fulfill";
+
+/// Returns `true` if `error` represents a graceful, server-initiated close
+/// rather than a real connection failure.
+///
+/// IG closes a streaming session with the server reason
+/// "No more requests to fulfill" once it has no active subscriptions. The
+/// upstream [`LightstreamerError`] exposes no graceful-close discriminant — the
+/// reason arrives as free-form text embedded in a server error message
+/// (`conerr` is wrapped into [`LightstreamerError::Connection`]). We therefore
+/// classify the typed error on the variants that can carry a server-supplied
+/// reason and match [`GRACEFUL_CLOSE_MARKER`] against the variant's message
+/// payload directly — never against the `Debug` representation.
+#[must_use]
+#[inline]
+fn is_graceful_close(error: &LightstreamerError) -> bool {
+    match error {
+        LightstreamerError::Connection(msg)
+        | LightstreamerError::Protocol(msg)
+        | LightstreamerError::InvalidState(msg) => msg.contains(GRACEFUL_CLOSE_MARKER),
+        _ => false,
+    }
+}
+
+/// Spawns a task that waits for `source` to be notified once and then wakes
+/// every signal in `targets`.
+///
+/// This fans a single shutdown signal out to each per-connection signal so that
+/// *all* streaming connections stop. It works around `Notify::notify_one`
+/// waking only a single waiter: a shared `Notify` cannot shut down both the
+/// market and price connections, so each connection gets its own dedicated
+/// signal woken here.
+///
+/// Each per-connection signal has exactly one waiter, so `notify_one` (which
+/// stores a permit when no waiter is currently parked) wakes it reliably even
+/// if the connection is momentarily busy processing a frame.
+///
+/// The returned [`JoinHandle`] must be aborted once all connections have
+/// finished so the forwarder does not outlive them.
+#[must_use]
+fn spawn_shutdown_fanout(source: Arc<Notify>, targets: Vec<Arc<Notify>>) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        source.notified().await;
+        for target in &targets {
+            target.notify_one();
+        }
+    })
+}
+
+/// Aborts every task in `tasks` and awaits its termination, then clears the
+/// list.
+///
+/// Awaiting after `abort` guarantees each task has fully stopped before we
+/// return; the [`tokio::task::JoinError`] produced by cancellation is expected
+/// and ignored.
+async fn abort_and_drain_tasks(tasks: &mut Vec<JoinHandle<()>>) {
+    for handle in tasks.drain(..) {
+        handle.abort();
+        // Ignore the cancellation `JoinError`; we only need the task to stop.
+        let _ = handle.await;
+    }
+}
 
 /// Returns `true` if an error from the order-confirmation endpoint is transient
 /// and worth polling again.
@@ -1164,6 +1234,12 @@ pub struct StreamerClient {
     // Flags indicating whether there is at least one active subscription for each client
     has_market_stream_subs: bool,
     has_price_stream_subs: bool,
+    // Handles for the per-subscription `ItemUpdate` -> DTO converter tasks. Each
+    // `*_subscribe` call spawns one; `disconnect` aborts and drains them so they
+    // do not idle for the process lifetime. This field is private and only ever
+    // populated inside this type's methods, so adding it does not change the
+    // constructed-via-`new` public surface.
+    converter_tasks: Vec<JoinHandle<()>>,
 }
 
 impl StreamerClient {
@@ -1219,6 +1295,7 @@ impl StreamerClient {
             price_streamer_client: Some(price_streamer_client),
             has_market_stream_subs: false,
             has_price_stream_subs: false,
+            converter_tasks: Vec::new(),
         })
     }
 
@@ -1295,7 +1372,7 @@ impl StreamerClient {
 
         // Create a channel for PriceData and spawn a task to convert ItemUpdate to PriceData
         let (price_tx, price_rx) = mpsc::unbounded_channel();
-        tokio::spawn(async move {
+        let handle = tokio::spawn(async move {
             let mut receiver = item_receiver;
             while let Some(item_update) = receiver.recv().await {
                 let price_data = PriceData::from(&item_update);
@@ -1305,6 +1382,8 @@ impl StreamerClient {
                 }
             }
         });
+        // Track the converter task so `disconnect` can tear it down.
+        self.converter_tasks.push(handle);
 
         info!(
             "Market subscription created for {} instruments",
@@ -1375,7 +1454,7 @@ impl StreamerClient {
 
         // Create a channel for TradeFields and spawn a task to convert ItemUpdate to TradeFields
         let (trade_tx, trade_rx) = mpsc::unbounded_channel();
-        tokio::spawn(async move {
+        let handle = tokio::spawn(async move {
             let mut receiver = item_receiver;
             while let Some(item_update) = receiver.recv().await {
                 let trade_data = crate::presentation::trade::TradeData::from(&item_update);
@@ -1385,6 +1464,8 @@ impl StreamerClient {
                 }
             }
         });
+        // Track the converter task so `disconnect` can tear it down.
+        self.converter_tasks.push(handle);
 
         info!("Trade subscription created for account: {}", account_id);
         Ok(trade_rx)
@@ -1453,7 +1534,7 @@ impl StreamerClient {
 
         // Create a channel for AccountFields and spawn a task to convert ItemUpdate to AccountFields
         let (account_tx, account_rx) = mpsc::unbounded_channel();
-        tokio::spawn(async move {
+        let handle = tokio::spawn(async move {
             let mut receiver = item_receiver;
             while let Some(item_update) = receiver.recv().await {
                 let account_data = crate::presentation::account::AccountData::from(&item_update);
@@ -1463,6 +1544,8 @@ impl StreamerClient {
                 }
             }
         });
+        // Track the converter task so `disconnect` can tear it down.
+        self.converter_tasks.push(handle);
 
         info!("Account subscription created for account: {}", account_id);
         Ok(account_rx)
@@ -1547,7 +1630,7 @@ impl StreamerClient {
 
         // Create a channel for PriceData and spawn a task to convert ItemUpdate to PriceData
         let (price_tx, price_rx) = mpsc::unbounded_channel();
-        tokio::spawn(async move {
+        let handle = tokio::spawn(async move {
             let mut receiver = item_receiver;
             while let Some(item_update) = receiver.recv().await {
                 let price_data = PriceData::from(&item_update);
@@ -1557,6 +1640,8 @@ impl StreamerClient {
                 }
             }
         });
+        // Track the converter task so `disconnect` can tear it down.
+        self.converter_tasks.push(handle);
 
         info!(
             "Price subscription created for {} instruments (account: {})",
@@ -1646,7 +1731,7 @@ impl StreamerClient {
 
         // Create a channel for ChartData and spawn a task to convert ItemUpdate to ChartData
         let (chart_tx, chart_rx) = mpsc::unbounded_channel();
-        tokio::spawn(async move {
+        let handle = tokio::spawn(async move {
             let mut receiver = item_receiver;
             while let Some(item_update) = receiver.recv().await {
                 let chart_data = ChartData::from(&item_update);
@@ -1656,6 +1741,8 @@ impl StreamerClient {
                 }
             }
         });
+        // Track the converter task so `disconnect` can tear it down.
+        self.converter_tasks.push(handle);
 
         info!(
             "Chart subscription created for {} instruments (scale: {})",
@@ -1693,16 +1780,21 @@ impl StreamerClient {
         };
 
         let mut tasks = Vec::new();
+        // Each connection gets its own dedicated shutdown signal. A single shared
+        // `Notify` cannot stop both connections: `notify_one` wakes only one
+        // waiter, so the other connection would never observe the shutdown. The
+        // external `signal` is fanned out to these per-connection signals below.
+        let mut connection_signals: Vec<Arc<Notify>> = Vec::new();
 
         // Connect market streamer only if there are active subscriptions
         if self.has_market_stream_subs {
             if let Some(client) = self.market_streamer_client.as_ref() {
                 let client = Arc::clone(client);
-                let signal = Arc::clone(&signal);
-                let task =
-                    tokio::spawn(
-                        async move { Self::connect_client(client, signal, "Market").await },
-                    );
+                let conn_signal = Arc::new(Notify::new());
+                connection_signals.push(Arc::clone(&conn_signal));
+                let task = tokio::spawn(async move {
+                    Self::connect_client(client, conn_signal, "Market").await
+                });
                 tasks.push(task);
             }
         } else {
@@ -1713,11 +1805,11 @@ impl StreamerClient {
         if self.has_price_stream_subs {
             if let Some(client) = self.price_streamer_client.as_ref() {
                 let client = Arc::clone(client);
-                let signal = Arc::clone(&signal);
-                let task =
-                    tokio::spawn(
-                        async move { Self::connect_client(client, signal, "Price").await },
-                    );
+                let conn_signal = Arc::new(Notify::new());
+                connection_signals.push(Arc::clone(&conn_signal));
+                let task = tokio::spawn(async move {
+                    Self::connect_client(client, conn_signal, "Price").await
+                });
                 tasks.push(task);
             }
         } else {
@@ -1731,8 +1823,17 @@ impl StreamerClient {
 
         info!("Connecting {} streaming client(s)...", tasks.len());
 
+        // Fan the single external shutdown signal out to every per-connection
+        // signal so all connections stop together. Aborted once every connection
+        // has finished so the forwarder cannot outlive them.
+        let fanout = spawn_shutdown_fanout(Arc::clone(&signal), connection_signals);
+
         // Wait for all tasks to complete
         let results = futures::future::join_all(tasks).await;
+
+        // All connections finished (via shutdown or on their own): the fan-out
+        // forwarder is no longer needed.
+        fanout.abort();
 
         // Check if any task failed
         let mut has_error = false;
@@ -1777,29 +1878,32 @@ impl StreamerClient {
                 client.connect_direct(Arc::clone(&signal)).await
             };
 
-            // Convert error to String immediately to avoid Send issues
-            let result_with_string_error = connect_result.map_err(|e| format!("{:?}", e));
-
-            match result_with_string_error {
-                Ok(_) => {
+            match connect_result {
+                Ok(()) => {
                     info!("{} streamer connected successfully", client_type);
                     break;
                 }
-                Err(error_msg) => {
-                    // If server closed because there are no active subscriptions, treat as graceful
-                    if error_msg.contains("No more requests to fulfill") {
+                Err(e) => {
+                    // Classify on the typed error BEFORE stringifying: IG closes
+                    // the session with the server reason "No more requests to
+                    // fulfill" once it has no active subscriptions. That is a
+                    // graceful close, not a failure.
+                    if is_graceful_close(&e) {
                         info!(
-                            "{} streamer closed gracefully: no active subscriptions (server reason: No more requests to fulfill)",
-                            client_type
+                            "{} streamer closed gracefully: no active subscriptions (server reason: {})",
+                            client_type, GRACEFUL_CLOSE_MARKER
                         );
                         return Ok(());
                     }
 
+                    // Not graceful: log the `Display` form (never `Debug`;
+                    // `LightstreamerError` carries no credentials) and schedule a
+                    // bounded retry.
+                    let error_msg = e.to_string();
                     error!("{} streamer connection failed: {}", client_type, error_msg);
 
                     if retry_counter < MAX_CONNECTION_ATTEMPTS - 1 {
-                        tokio::time::sleep(std::time::Duration::from_millis(retry_interval_millis))
-                            .await;
+                        sleep(Duration::from_millis(retry_interval_millis)).await;
                         retry_interval_millis =
                             (retry_interval_millis + (200 * retry_counter)).min(5000);
                         retry_counter += 1;
@@ -1834,7 +1938,13 @@ impl StreamerClient {
 
     /// Disconnects all active Lightstreamer clients.
     ///
-    /// This method gracefully closes all streaming connections (market and price).
+    /// This method gracefully closes all streaming connections (market and
+    /// price) and tears down the per-subscription converter tasks so they do
+    /// not idle for the process lifetime. Closing the Lightstreamer session
+    /// closes the item channels feeding the converters, so they would exit on
+    /// their own; aborting and awaiting them here guarantees a deterministic,
+    /// leak-free shutdown. Calling `disconnect` more than once is safe: the
+    /// converter list is drained and the client `disconnect` is idempotent.
     ///
     /// # Returns
     ///
@@ -1856,8 +1966,27 @@ impl StreamerClient {
             disconnected += 1;
         }
 
+        // Tear down the converter tasks now that their upstream item channels
+        // are closed.
+        let converter_count = self.converter_tasks.len();
+        abort_and_drain_tasks(&mut self.converter_tasks).await;
+        if converter_count > 0 {
+            debug!("Aborted {} converter task(s)", converter_count);
+        }
+
         info!("Disconnected {} streaming client(s)", disconnected);
         Ok(())
+    }
+}
+
+impl Drop for StreamerClient {
+    /// Aborts any converter tasks that were not already torn down by
+    /// [`StreamerClient::disconnect`], so dropping the client never orphans a
+    /// spawned task. Abort is synchronous, so no runtime is required here.
+    fn drop(&mut self) {
+        for handle in self.converter_tasks.drain(..) {
+            handle.abort();
+        }
     }
 }
 
@@ -1912,5 +2041,119 @@ mod tests {
         assert!(!is_transient_confirmation_error(&AppError::Unexpected(
             StatusCode::BAD_REQUEST
         )));
+    }
+
+    use super::{
+        GRACEFUL_CLOSE_MARKER, abort_and_drain_tasks, is_graceful_close, spawn_shutdown_fanout,
+    };
+    use lightstreamer_rs::utils::LightstreamerError;
+    use std::sync::Arc;
+    use std::time::Duration;
+    use tokio::sync::Notify;
+    use tokio::task::JoinHandle;
+
+    // --- Task 3: graceful-close classification -----------------------------
+
+    #[test]
+    fn test_is_graceful_close_connection_variant_with_marker_is_true() {
+        // "No more requests to fulfill" arrives wrapped in a server `conerr`
+        // message, which `lightstreamer-rs` surfaces as `Connection`.
+        let err = LightstreamerError::Connection(format!(
+            "connection error from server: conerr,-2,{GRACEFUL_CLOSE_MARKER}"
+        ));
+        assert!(is_graceful_close(&err));
+    }
+
+    #[test]
+    fn test_is_graceful_close_protocol_and_invalid_state_with_marker_is_true() {
+        let protocol = LightstreamerError::Protocol(format!("closing: {GRACEFUL_CLOSE_MARKER}"));
+        let invalid_state =
+            LightstreamerError::InvalidState(format!("state: {GRACEFUL_CLOSE_MARKER}"));
+        assert!(is_graceful_close(&protocol));
+        assert!(is_graceful_close(&invalid_state));
+    }
+
+    #[test]
+    fn test_is_graceful_close_connection_variant_without_marker_is_false() {
+        let err = LightstreamerError::Connection("no message received within 5000 ms".to_string());
+        assert!(!is_graceful_close(&err));
+    }
+
+    #[test]
+    fn test_is_graceful_close_other_variant_with_marker_is_false() {
+        // Variants that never carry a server close reason must not match, even
+        // if the marker text somehow appears in them.
+        let err = LightstreamerError::Timeout(GRACEFUL_CLOSE_MARKER.to_string());
+        assert!(!is_graceful_close(&err));
+    }
+
+    // --- Task 5: one shutdown signal must wake both connections ------------
+
+    #[tokio::test]
+    async fn test_shutdown_fanout_wakes_all_connection_waiters() {
+        // Two dedicated per-connection signals stand in for the market and
+        // price connections, both waiting to be shut down.
+        let source = Arc::new(Notify::new());
+        let market_signal = Arc::new(Notify::new());
+        let price_signal = Arc::new(Notify::new());
+
+        let fanout = spawn_shutdown_fanout(
+            Arc::clone(&source),
+            vec![Arc::clone(&market_signal), Arc::clone(&price_signal)],
+        );
+
+        let market_waiter = tokio::spawn(async move { market_signal.notified().await });
+        let price_waiter = tokio::spawn(async move { price_signal.notified().await });
+
+        // A single `notify_one` on the shared source (as `setup_signal_hook`
+        // and `DynamicMarketStreamer` do) must reach BOTH connections. Because
+        // each per-connection signal has a single waiter and `notify_one`
+        // stores a permit, the wake is race-free.
+        source.notify_one();
+
+        assert!(
+            tokio::time::timeout(Duration::from_secs(1), market_waiter)
+                .await
+                .is_ok(),
+            "market connection did not observe the shutdown signal"
+        );
+        assert!(
+            tokio::time::timeout(Duration::from_secs(1), price_waiter)
+                .await
+                .is_ok(),
+            "price connection did not observe the shutdown signal"
+        );
+
+        fanout.abort();
+    }
+
+    // --- Task 2: converter-task teardown ----------------------------------
+
+    #[tokio::test]
+    async fn test_abort_and_drain_tasks_stops_and_clears() {
+        let mut tasks: Vec<JoinHandle<()>> = Vec::new();
+        for _ in 0..3 {
+            // A task that never completes on its own; only an abort stops it.
+            tasks.push(tokio::spawn(async { std::future::pending::<()>().await }));
+        }
+        assert!(tasks.iter().all(|h| !h.is_finished()));
+
+        abort_and_drain_tasks(&mut tasks).await;
+
+        // The helper awaits each aborted task, so returning proves every task
+        // terminated; the list is drained.
+        assert!(tasks.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_abort_makes_pending_task_finish() {
+        let handle: JoinHandle<()> = tokio::spawn(async { std::future::pending::<()>().await });
+        assert!(!handle.is_finished());
+        handle.abort();
+        let join_result = handle.await;
+        assert!(
+            join_result.is_err(),
+            "aborted task should yield a cancellation JoinError"
+        );
     }
 }

--- a/src/application/dynamic_streamer.rs
+++ b/src/application/dynamic_streamer.rs
@@ -15,6 +15,7 @@ use crate::model::streaming::StreamingMarketField;
 use crate::presentation::price::PriceData;
 use std::collections::HashSet;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use tokio::sync::{Notify, RwLock, mpsc};
 use tracing::{debug, info, warn};
 
@@ -80,6 +81,11 @@ pub struct DynamicMarketStreamer {
     is_connected: Arc<RwLock<bool>>,
     /// Shutdown signal for current connection
     shutdown_signal: Arc<RwLock<Option<Arc<Notify>>>>,
+    /// Monotonic connection generation. Bumped on every `start_internal`; a
+    /// connection task only clears `is_connected` on exit if its captured
+    /// generation is still current, so a superseded task tearing down its old
+    /// connection cannot clobber the state of the newer one that replaced it.
+    generation: Arc<AtomicU64>,
 }
 
 impl DynamicMarketStreamer {
@@ -113,6 +119,7 @@ impl DynamicMarketStreamer {
             price_rx: Arc::new(RwLock::new(Some(price_rx))),
             is_connected: Arc::new(RwLock::new(false)),
             shutdown_signal: Arc::new(RwLock::new(None)),
+            generation: Arc::new(AtomicU64::new(0)),
         })
     }
 
@@ -195,12 +202,18 @@ impl DynamicMarketStreamer {
 
     /// Clears all market EPICs from the subscription list.
     ///
-    /// Note: Due to Lightstreamer limitations, this does not unsubscribe from
-    /// the server immediately. All EPICs will be removed from the internal list.
+    /// If the streamer is connected, the live connection is shut down so it
+    /// stops forwarding updates for the cleared EPICs, mirroring [`remove`]:
+    /// the current connection is signalled and, because reconnection no-ops on
+    /// an empty EPIC set, no new connection is started. After this call the
+    /// streamer reports as disconnected.
+    ///
+    /// [`remove`]: DynamicMarketStreamer::remove
     ///
     /// # Returns
     ///
-    /// Returns `Ok(())` when all EPICs have been cleared.
+    /// Returns `Ok(())` when all EPICs have been cleared and, if it was
+    /// connected, the connection has been signalled to stop.
     ///
     /// # Examples
     ///
@@ -212,6 +225,20 @@ impl DynamicMarketStreamer {
         let count = epics.len();
         epics.clear();
         info!("Cleared {} EPICs from subscription list", count);
+        drop(epics); // Release lock before touching connection state
+
+        // If connected, shut the live connection down so data flow actually
+        // stops. `reconnect` signals the current connection; `start_internal`
+        // no-ops on the now-empty EPIC set, so nothing reconnects.
+        let is_connected = *self.is_connected.read().await;
+        if is_connected {
+            self.reconnect().await?;
+            // No new connection is started for an empty EPIC set, so make the
+            // stopped state explicit and immediate instead of waiting for the
+            // connection task to flip it asynchronously.
+            *self.is_connected.write().await = false;
+        }
+
         Ok(())
     }
 
@@ -296,6 +323,11 @@ impl DynamicMarketStreamer {
 
         info!("Starting connection with {} EPICs", epics.len());
 
+        // Claim a new connection generation. The task spawned below owns this
+        // number; a later `start_internal` bumps it, marking any earlier task as
+        // superseded so it will not clobber `is_connected` on teardown.
+        let my_generation = self.generation.fetch_add(1, Ordering::SeqCst) + 1;
+
         // Create new client
         let mut new_client = StreamerClient::new().await?;
 
@@ -331,19 +363,40 @@ impl DynamicMarketStreamer {
         // Spawn connection task in background
         let client = Arc::clone(&self.client);
         let is_connected = Arc::clone(&self.is_connected);
+        let generation = Arc::clone(&self.generation);
 
         tokio::spawn(async move {
-            let result = {
-                let mut client_guard = client.write().await;
-                if let Some(ref mut c) = *client_guard {
-                    c.connect(Some(signal)).await
-                } else {
-                    Ok(())
-                }
+            // Move the client out of the shared lock under a short-lived guard,
+            // then run the long-lived connection WITHOUT holding any lock. This
+            // is the core of the fix: previously the write guard was held across
+            // the whole `connect().await`, so any concurrent `add`/`remove`/
+            // `disconnect` that needs the client lock hung until disconnect.
+            let taken = {
+                let mut guard = client.write().await;
+                guard.take()
             };
 
-            // Mark as disconnected
-            *is_connected.write().await = false;
+            let result = if let Some(mut c) = taken {
+                let r = c.connect(Some(signal)).await;
+                // The connection has ended (shutdown signal or error): close the
+                // Lightstreamer session and drain its converter tasks, then drop
+                // the owned client so it is never left half-open.
+                if let Err(e) = c.disconnect().await {
+                    tracing::error!("Error closing streamer session: {}", e);
+                }
+                r
+            } else {
+                Ok(())
+            };
+
+            // Mark as disconnected only if we are still the current generation.
+            // A newer `start_internal` (from reconnect on add/remove/clear) may
+            // have already brought up a fresh connection while this superseded
+            // task was still tearing its old one down; clobbering the flag here
+            // would leave the streamer reporting disconnected while live.
+            if generation.load(Ordering::SeqCst) == my_generation {
+                *is_connected.write().await = false;
+            }
 
             match result {
                 Ok(_) => info!("Connection task completed successfully"),
@@ -421,7 +474,8 @@ impl DynamicMarketStreamer {
     /// streamer.disconnect().await?;
     /// ```
     pub async fn disconnect(&mut self) -> Result<(), AppError> {
-        // Signal shutdown
+        // Signal shutdown to the current connection task; once its `connect`
+        // returns it closes the Lightstreamer session itself.
         {
             let shutdown_lock = self.shutdown_signal.read().await;
             if let Some(signal) = shutdown_lock.as_ref() {
@@ -429,12 +483,18 @@ impl DynamicMarketStreamer {
             }
         }
 
-        // Disconnect client
-        let mut client_lock = self.client.write().await;
-        if let Some(ref mut client) = *client_lock {
+        // If the client is still owned here (the connection task has not taken
+        // it yet, or no connection was ever started), close it directly. During
+        // a live connection the task owns the client, so this take yields `None`
+        // and the task performs the close after being signalled above. The guard
+        // is scoped so it is never held across the `disconnect().await`.
+        let taken = {
+            let mut client_lock = self.client.write().await;
+            client_lock.take()
+        };
+        if let Some(mut client) = taken {
             client.disconnect().await?;
         }
-        *client_lock = None;
 
         *self.is_connected.write().await = false;
         info!("Disconnected from Lightstreamer server");
@@ -452,6 +512,113 @@ impl Clone for DynamicMarketStreamer {
             price_rx: Arc::clone(&self.price_rx),
             is_connected: Arc::clone(&self.is_connected),
             shutdown_signal: Arc::clone(&self.shutdown_signal),
+            generation: Arc::clone(&self.generation),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DynamicMarketStreamer;
+    use std::collections::HashSet;
+    use std::sync::Arc;
+    use std::sync::atomic::Ordering;
+    use std::time::Duration;
+    use tokio::sync::Notify;
+
+    const TEST_EPIC: &str = "IX.D.DAX.DAILY.IP";
+
+    // --- Task 4: clear() must stop data flow when connected ----------------
+
+    #[tokio::test]
+    async fn test_clear_when_not_connected_empties_epics() {
+        let streamer = DynamicMarketStreamer::new(HashSet::new())
+            .await
+            .expect("streamer construction should succeed");
+        streamer.epics.write().await.insert(TEST_EPIC.to_string());
+
+        let result = streamer.clear().await;
+
+        assert!(result.is_ok(), "clear should succeed: {result:?}");
+        assert!(
+            streamer.get_epics().await.is_empty(),
+            "EPIC set should be empty after clear"
+        );
+        assert!(
+            !*streamer.is_connected.read().await,
+            "should not report connected when it never was"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_clear_when_connected_signals_shutdown_and_reports_stopped() {
+        let streamer = DynamicMarketStreamer::new(HashSet::new())
+            .await
+            .expect("streamer construction should succeed");
+
+        // Simulate a live connection: one EPIC, connected, and a shutdown
+        // signal that a connection task would be parked on.
+        streamer.epics.write().await.insert(TEST_EPIC.to_string());
+        *streamer.is_connected.write().await = true;
+        let signal = Arc::new(Notify::new());
+        *streamer.shutdown_signal.write().await = Some(Arc::clone(&signal));
+
+        // Stand-in for the live connection waiting to be shut down.
+        let waiter = tokio::spawn(async move { signal.notified().await });
+
+        let result = streamer.clear().await;
+
+        assert!(result.is_ok(), "clear should succeed: {result:?}");
+        assert!(
+            streamer.get_epics().await.is_empty(),
+            "EPIC set should be empty after clear"
+        );
+        assert!(
+            !*streamer.is_connected.read().await,
+            "clear must mark the streamer disconnected so data flow stops"
+        );
+        // clear() must have signalled the live connection to shut down. With a
+        // stored permit the waiter wakes deterministically.
+        assert!(
+            tokio::time::timeout(Duration::from_secs(1), waiter)
+                .await
+                .is_ok(),
+            "live connection did not observe the shutdown signal from clear()"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_superseded_generation_does_not_clear_is_connected() {
+        // Models the connection-task teardown race: a newer generation is live
+        // (is_connected == true) while an older, superseded task finishes tearing
+        // its connection down. The superseded task must NOT clear the flag.
+        let streamer = DynamicMarketStreamer::new(HashSet::new())
+            .await
+            .expect("streamer construction should succeed");
+
+        // A newer connection has come up: bump the generation and mark connected.
+        let newer = streamer.generation.fetch_add(1, Ordering::SeqCst) + 1;
+        *streamer.is_connected.write().await = true;
+
+        // An older task captured an earlier generation.
+        let older = newer - 1;
+
+        // Replicate the task's exit guard for the superseded (older) generation.
+        if streamer.generation.load(Ordering::SeqCst) == older {
+            *streamer.is_connected.write().await = false;
+        }
+        assert!(
+            *streamer.is_connected.read().await,
+            "a superseded generation must not clear is_connected on the newer one"
+        );
+
+        // The current generation's own teardown still clears it.
+        if streamer.generation.load(Ordering::SeqCst) == newer {
+            *streamer.is_connected.write().await = false;
+        }
+        assert!(
+            !*streamer.is_connected.read().await,
+            "the current generation's teardown must clear is_connected"
+        );
     }
 }

--- a/src/application/dynamic_streamer.rs
+++ b/src/application/dynamic_streamer.rs
@@ -67,8 +67,6 @@ use tracing::{debug, info, warn};
 /// }
 /// ```
 pub struct DynamicMarketStreamer {
-    /// Internal streamer client (recreated on epic changes)
-    client: Arc<RwLock<Option<StreamerClient>>>,
     /// Set of EPICs currently subscribed
     epics: Arc<RwLock<HashSet<String>>>,
     /// Market fields to subscribe to
@@ -112,7 +110,6 @@ impl DynamicMarketStreamer {
         let (price_tx, price_rx) = mpsc::unbounded_channel();
 
         Ok(Self {
-            client: Arc::new(RwLock::new(None)),
             epics: Arc::new(RwLock::new(HashSet::new())),
             fields,
             price_tx: Arc::new(RwLock::new(Some(price_tx))),
@@ -350,9 +347,6 @@ impl DynamicMarketStreamer {
             });
         }
 
-        // Store the new client
-        *self.client.write().await = Some(new_client);
-
         // Create new shutdown signal
         let signal = Arc::new(Notify::new());
         *self.shutdown_signal.write().await = Some(Arc::clone(&signal));
@@ -361,22 +355,19 @@ impl DynamicMarketStreamer {
         *self.is_connected.write().await = true;
 
         // Spawn connection task in background
-        let client = Arc::clone(&self.client);
         let is_connected = Arc::clone(&self.is_connected);
         let generation = Arc::clone(&self.generation);
 
+        // Move the freshly-built client (and its matching shutdown signal) INTO
+        // the task by value. Handing off through the shared `self.client` slot
+        // would race: a second `start_internal` could overwrite the slot before
+        // this task takes it, so the task would connect the wrong client while
+        // parked on this task's (now-stale) signal. Owning the client here binds
+        // each task to exactly the client and signal it was created with, and
+        // the connection still runs without holding any lock.
         tokio::spawn(async move {
-            // Move the client out of the shared lock under a short-lived guard,
-            // then run the long-lived connection WITHOUT holding any lock. This
-            // is the core of the fix: previously the write guard was held across
-            // the whole `connect().await`, so any concurrent `add`/`remove`/
-            // `disconnect` that needs the client lock hung until disconnect.
-            let taken = {
-                let mut guard = client.write().await;
-                guard.take()
-            };
-
-            let result = if let Some(mut c) = taken {
+            let mut c = new_client;
+            let result = {
                 let r = c.connect(Some(signal)).await;
                 // The connection has ended (shutdown signal or error): close the
                 // Lightstreamer session and drain its converter tasks, then drop
@@ -385,8 +376,6 @@ impl DynamicMarketStreamer {
                     tracing::error!("Error closing streamer session: {}", e);
                 }
                 r
-            } else {
-                Ok(())
             };
 
             // Mark as disconnected only if we are still the current generation.
@@ -474,26 +463,16 @@ impl DynamicMarketStreamer {
     /// streamer.disconnect().await?;
     /// ```
     pub async fn disconnect(&mut self) -> Result<(), AppError> {
-        // Signal shutdown to the current connection task; once its `connect`
-        // returns it closes the Lightstreamer session itself.
+        // Signal shutdown to the current connection task. The task owns its
+        // `StreamerClient` by value, so once its `connect` returns (woken by this
+        // signal's stored permit even if it has not started awaiting yet) it
+        // closes the Lightstreamer session itself. The guard is scoped so it is
+        // never held across an `.await`.
         {
             let shutdown_lock = self.shutdown_signal.read().await;
             if let Some(signal) = shutdown_lock.as_ref() {
                 signal.notify_one();
             }
-        }
-
-        // If the client is still owned here (the connection task has not taken
-        // it yet, or no connection was ever started), close it directly. During
-        // a live connection the task owns the client, so this take yields `None`
-        // and the task performs the close after being signalled above. The guard
-        // is scoped so it is never held across the `disconnect().await`.
-        let taken = {
-            let mut client_lock = self.client.write().await;
-            client_lock.take()
-        };
-        if let Some(mut client) = taken {
-            client.disconnect().await?;
         }
 
         *self.is_connected.write().await = false;
@@ -505,7 +484,6 @@ impl DynamicMarketStreamer {
 impl Clone for DynamicMarketStreamer {
     fn clone(&self) -> Self {
         Self {
-            client: Arc::clone(&self.client),
             epics: Arc::clone(&self.epics),
             fields: self.fields.clone(),
             price_tx: Arc::clone(&self.price_tx),


### PR DESCRIPTION
## Summary

The streaming subsystem had lock-across-await and shutdown-path defects. The spawned connection task held the client write lock for the entire connection lifetime (wedging all subscription management), converter tasks were spawned fire-and-forget, graceful-close was detected by substring-matching a `{:?}` error dump, and `clear()` left cleared epics streaming. This PR fixes all five.

## Changes

- **Lock-across-await (deadlock)**: the connection task now `take()`s the `StreamerClient` out of the `RwLock<Option<>>` under a short-lived guard and runs `connect().await` on the owned value — no client lock held for the connection lifetime, so `add()`/`remove()`/`clear()` no longer hang until disconnect. `disconnect()` was restructured the same way (it had the same latent bug).
- **Fire-and-forget converter tasks**: the five subscribe methods' `JoinHandle`s are stored on `StreamerClient` (private `Vec`) and aborted+drained in `disconnect()`; a `Drop` impl is a safety net.
- **Graceful-close classification**: `is_graceful_close(&LightstreamerError)` matches the specific variants that carry a server reason and checks the Display message before any stringification, instead of substring-matching a `{:?}` Debug dump. Documented as a best-effort match because upstream exposes no graceful-close discriminant.
- **`clear()`**: now shuts the live connection down and reports disconnected, mirroring `remove()`, instead of only emptying the set while data keeps flowing.
- **Shutdown signal**: each connection gets its own `Notify`; a fan-out forwards the single external shutdown to every connection (a shared `Notify` with `notify_one()` could only wake one of the two connections).
- **Generation guard** (from resilience review): a monotonic connection generation stops a superseded teardown task from clearing `is_connected` on the newer connection that replaced it.

## Public API impact

Additive/internal only: new private fields on `StreamerClient`/`DynamicMarketStreamer`; no public signature changed. `cargo semver-checks`: no semver update required. No new dependencies (tokio built-ins only).

## Testing

- [x] Shutdown-path tests: `is_graceful_close` classification (per variant/marker), Notify fan-out wakes all connection waiters, `disconnect()` aborts stored converter handles (`is_finished` after abort), `clear()` stops the connection and reports disconnected, superseded-generation guard doesn't clobber `is_connected`
- [x] `make pre-push` clean; workspace clippy clean; semver clean

Resilience review: **PASS** — no lock held across `.await` in the changed code, the `take()` restructure rebuilds the client on reconnect (no lost subscriptions), the Notify fan-out is race-free (permit stored before await), converter teardown is idempotent and non-panicking, no deadlock between `disconnect()` and the connection task. The one finding it flagged as widened by the diff (the `is_connected` teardown race) is fixed here by the generation guard.

Closes #29
