### PR TITLE
test: offline coverage for auth, HTTP retry, streaming, DTO round-trips (#42)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ futures = { workspace = true}
 thiserror = { workspace = true}
 
 [dev-dependencies]
-
+wiremock = "0.6"
 
 [[test]]
 name = "unit_tests"

--- a/src/application/dynamic_streamer.rs
+++ b/src/application/dynamic_streamer.rs
@@ -505,6 +505,199 @@ mod tests {
     use tokio::sync::Notify;
 
     const TEST_EPIC: &str = "IX.D.DAX.DAILY.IP";
+    const OTHER_EPIC: &str = "IX.D.FTSE.DAILY.IP";
+
+    // --- EPIC-set mutation while disconnected (no network required) --------
+
+    #[tokio::test]
+    async fn test_add_inserts_epic_when_not_connected() {
+        let streamer = DynamicMarketStreamer::new(HashSet::new())
+            .await
+            .expect("streamer construction should succeed");
+
+        let result = streamer.add(TEST_EPIC.to_string()).await;
+
+        assert!(result.is_ok(), "add should succeed: {result:?}");
+        assert_eq!(
+            streamer.get_epics().await,
+            vec![TEST_EPIC.to_string()],
+            "add must insert the EPIC into the subscription set"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_add_is_idempotent_for_duplicate_epic() {
+        let streamer = DynamicMarketStreamer::new(HashSet::new())
+            .await
+            .expect("streamer construction should succeed");
+
+        for _ in 0..3 {
+            let result = streamer.add(TEST_EPIC.to_string()).await;
+            assert!(result.is_ok(), "repeated add should succeed: {result:?}");
+        }
+
+        assert_eq!(
+            streamer.get_epics().await.len(),
+            1,
+            "adding the same EPIC repeatedly must not create duplicates"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_remove_absent_epic_is_noop() {
+        let streamer = DynamicMarketStreamer::new(HashSet::new())
+            .await
+            .expect("streamer construction should succeed");
+        streamer.epics.write().await.insert(TEST_EPIC.to_string());
+
+        let result = streamer.remove(OTHER_EPIC.to_string()).await;
+
+        assert!(
+            result.is_ok(),
+            "removing an absent EPIC should succeed: {result:?}"
+        );
+        assert_eq!(
+            streamer.get_epics().await,
+            vec![TEST_EPIC.to_string()],
+            "removing an absent EPIC must leave the set unchanged"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_remove_existing_epic_when_not_connected_empties_set() {
+        let streamer = DynamicMarketStreamer::new(HashSet::new())
+            .await
+            .expect("streamer construction should succeed");
+        streamer.epics.write().await.insert(TEST_EPIC.to_string());
+
+        let result = streamer.remove(TEST_EPIC.to_string()).await;
+
+        assert!(result.is_ok(), "remove should succeed: {result:?}");
+        assert!(
+            streamer.get_epics().await.is_empty(),
+            "removing the only EPIC must empty the set"
+        );
+    }
+
+    // --- get_receiver() is single-take -------------------------------------
+
+    #[tokio::test]
+    async fn test_get_receiver_can_only_be_taken_once() {
+        let streamer = DynamicMarketStreamer::new(HashSet::new())
+            .await
+            .expect("streamer construction should succeed");
+
+        let first = streamer.get_receiver().await;
+        assert!(
+            first.is_ok(),
+            "first get_receiver should hand out the receiver: {first:?}"
+        );
+
+        let second = streamer.get_receiver().await;
+        assert!(
+            second.is_err(),
+            "second get_receiver must fail once the receiver has been taken"
+        );
+    }
+
+    // --- is_connected transitions & disconnect shutdown handshake ----------
+
+    #[tokio::test]
+    async fn test_is_connected_transitions_on_disconnect() {
+        let mut streamer = DynamicMarketStreamer::new(HashSet::new())
+            .await
+            .expect("streamer construction should succeed");
+
+        // A freshly constructed streamer starts disconnected.
+        assert!(
+            !*streamer.is_connected.read().await,
+            "a new streamer must start disconnected"
+        );
+
+        // Simulate the connected state that `start_internal` establishes on a
+        // successful connection (offline: we set the same internal fields a live
+        // connection would).
+        *streamer.is_connected.write().await = true;
+        let signal = Arc::new(Notify::new());
+        *streamer.shutdown_signal.write().await = Some(Arc::clone(&signal));
+        assert!(
+            *streamer.is_connected.read().await,
+            "streamer should report connected once a connection is live"
+        );
+
+        // Disconnecting transitions it back.
+        let result = streamer.disconnect().await;
+        assert!(result.is_ok(), "disconnect should succeed: {result:?}");
+        assert!(
+            !*streamer.is_connected.read().await,
+            "disconnect must transition the streamer back to disconnected"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_disconnect_signals_shutdown_and_marks_disconnected() {
+        let mut streamer = DynamicMarketStreamer::new(HashSet::new())
+            .await
+            .expect("streamer construction should succeed");
+
+        // Simulate a live connection with a parked shutdown waiter.
+        *streamer.is_connected.write().await = true;
+        let signal = Arc::new(Notify::new());
+        *streamer.shutdown_signal.write().await = Some(Arc::clone(&signal));
+        let waiter = tokio::spawn(async move { signal.notified().await });
+
+        let result = streamer.disconnect().await;
+
+        assert!(result.is_ok(), "disconnect should succeed: {result:?}");
+        assert!(
+            !*streamer.is_connected.read().await,
+            "disconnect must mark the streamer disconnected"
+        );
+        // With a stored permit the waiter wakes deterministically.
+        assert!(
+            tokio::time::timeout(Duration::from_secs(1), waiter)
+                .await
+                .is_ok(),
+            "the parked connection did not observe the shutdown signal from disconnect()"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_remove_last_epic_while_connected_signals_reconnect() {
+        let streamer = DynamicMarketStreamer::new(HashSet::new())
+            .await
+            .expect("streamer construction should succeed");
+
+        // Simulate a live connection subscribed to a single EPIC, with a
+        // shutdown signal a connection task would be parked on.
+        streamer.epics.write().await.insert(TEST_EPIC.to_string());
+        *streamer.is_connected.write().await = true;
+        let signal = Arc::new(Notify::new());
+        *streamer.shutdown_signal.write().await = Some(Arc::clone(&signal));
+
+        // Stand-in for the live connection waiting to be told to reconnect.
+        let waiter = tokio::spawn(async move { signal.notified().await });
+
+        // Removing the last EPIC while connected is an EPIC change: it must
+        // signal the current connection. Because the resulting EPIC set is
+        // empty, `reconnect` no-ops on the restart and never touches the
+        // network, keeping this test fully offline.
+        let result = streamer.remove(TEST_EPIC.to_string()).await;
+
+        assert!(result.is_ok(), "remove should succeed: {result:?}");
+        assert!(
+            streamer.get_epics().await.is_empty(),
+            "removing the last EPIC must empty the subscription set"
+        );
+        // The old connection's signal must have fired. With a stored permit the
+        // waiter wakes deterministically.
+        assert!(
+            tokio::time::timeout(Duration::from_secs(1), waiter)
+                .await
+                .is_ok(),
+            "the live connection did not observe the reconnect signal from remove()"
+        );
+    }
 
     // --- Task 4: clear() must stop data flow when connected ----------------
 

--- a/src/model/responses.rs
+++ b/src/model/responses.rs
@@ -1036,40 +1036,536 @@ pub struct SinglePositionResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serde_json::Value;
-    use std::fs;
+    use crate::model::auth::{SessionResponse, V3Response};
+    use crate::presentation::account::ActivityType;
+
+    /// Round-trips a DTO through `serialize -> deserialize` and returns the
+    /// re-parsed value. The DTOs under test do not all derive `PartialEq`, so
+    /// callers assert the load-bearing fields on the result instead of comparing
+    /// whole structs. This pins each custom `serialize_with` helper to its
+    /// `deserialize_with` counterpart.
+    fn roundtrip<T>(value: &T) -> T
+    where
+        T: serde::Serialize + serde::de::DeserializeOwned,
+    {
+        let json = serde_json::to_string(value).expect("serialize failed");
+        serde_json::from_str(&json).expect("re-deserialize failed")
+    }
 
     #[test]
-    #[ignore = "requires Data/working_orders.json file"]
-    fn test_deserialize_working_orders_from_file() -> Result<(), Box<dyn std::error::Error>> {
-        // Load the JSON file
-        let json_content = fs::read_to_string("Data/working_orders.json")?;
+    fn test_accounts_response_deserialize_and_roundtrip() {
+        let json = r#"{
+            "accounts": [
+                {
+                    "accountId": "ABC12",
+                    "accountName": "Demo CFD",
+                    "accountType": "CFD",
+                    "balance": {
+                        "balance": 10000.0,
+                        "deposit": 2000.0,
+                        "profitLoss": 150.5,
+                        "available": 8000.0
+                    },
+                    "currency": "EUR",
+                    "status": "ENABLED",
+                    "preferred": true
+                }
+            ]
+        }"#;
 
-        // Parse as a generic JSON Value first to inspect the structure
-        let json_value: Value = serde_json::from_str(&json_content)?;
+        let resp: AccountsResponse = serde_json::from_str(json).expect("deserialize failed");
+        assert_eq!(resp.accounts.len(), 1);
+        let acc = &resp.accounts[0];
+        assert_eq!(acc.account_id, "ABC12");
+        assert_eq!(acc.account_type, "CFD");
+        assert!((acc.balance.available - 8000.0).abs() < 1e-9);
+        assert!(acc.preferred);
 
-        println!(
-            "JSON structure:\n{}",
-            serde_json::to_string_pretty(&json_value)?
+        let re = roundtrip(&resp);
+        assert_eq!(re.accounts[0].account_id, "ABC12");
+        assert_eq!(re.accounts[0].currency, "EUR");
+    }
+
+    #[test]
+    fn test_positions_response_deserialize_and_roundtrip() {
+        let json = r#"{
+            "positions": [
+                {
+                    "position": {
+                        "contractSize": 1.0,
+                        "createdDate": "2025/07/01 10:00:00:000",
+                        "createdDateUTC": "2025-07-01T08:00:00",
+                        "dealId": "DIFAKE111",
+                        "dealReference": "REFFAKE111",
+                        "direction": "BUY",
+                        "limitLevel": null,
+                        "level": 100.5,
+                        "size": 2.0,
+                        "stopLevel": null,
+                        "trailingStep": null,
+                        "trailingStopDistance": null,
+                        "currency": "GBP",
+                        "controlledRisk": false,
+                        "limitedRiskPremium": null
+                    },
+                    "market": {
+                        "instrumentName": "FTSE 100",
+                        "expiry": "-",
+                        "epic": "IX.D.FTSE.DAILY.IP",
+                        "instrumentType": "INDICES",
+                        "lotSize": 1.0,
+                        "high": 7600.0,
+                        "low": 7500.0,
+                        "percentageChange": 0.5,
+                        "netChange": 30.0,
+                        "bid": 7550.0,
+                        "offer": 7551.0,
+                        "updateTime": "10:00:00",
+                        "updateTimeUTC": "08:00:00",
+                        "delayTime": 0,
+                        "streamingPricesAvailable": true,
+                        "marketStatus": "TRADEABLE",
+                        "scalingFactor": 1
+                    },
+                    "pnl": null
+                }
+            ]
+        }"#;
+
+        let resp: PositionsResponse = serde_json::from_str(json).expect("deserialize failed");
+        assert_eq!(resp.positions.len(), 1);
+        let pos = &resp.positions[0];
+        assert_eq!(pos.position.deal_id, "DIFAKE111");
+        assert_eq!(pos.position.direction, Direction::Buy);
+        assert!((pos.position.size - 2.0).abs() < 1e-9);
+        assert_eq!(pos.market.epic, "IX.D.FTSE.DAILY.IP");
+        assert_eq!(pos.market.bid, Some(7550.0));
+        assert!(pos.pnl.is_none());
+
+        let re = roundtrip(&resp);
+        assert_eq!(re.positions[0].position.deal_id, "DIFAKE111");
+        assert_eq!(re.positions[0].market.epic, "IX.D.FTSE.DAILY.IP");
+    }
+
+    #[test]
+    fn test_working_orders_response_deserialize_and_roundtrip() {
+        // Inline, sanitized replacement for the former file-dependent test that
+        // required an uncommitted `Data/working_orders.json`. Runs fully offline.
+        let json = r#"{
+            "workingOrders": [
+                {
+                    "workingOrderData": {
+                        "dealId": "DIFAKEWO1",
+                        "direction": "SELL",
+                        "epic": "CS.D.EURUSD.MINI.IP",
+                        "orderSize": 1.5,
+                        "orderLevel": 1.2345,
+                        "timeInForce": "GOOD_TILL_CANCELLED",
+                        "goodTillDate": null,
+                        "goodTillDateISO": null,
+                        "createdDate": "2025/07/01 09:30:00:000",
+                        "createdDateUTC": "2025-07-01T07:30:00",
+                        "guaranteedStop": false,
+                        "orderType": "LIMIT",
+                        "stopDistance": null,
+                        "limitDistance": null,
+                        "currencyCode": "USD",
+                        "dma": false,
+                        "limitedRiskPremium": null,
+                        "limitLevel": null,
+                        "stopLevel": null,
+                        "dealReference": "REFFAKEWO1"
+                    },
+                    "marketData": {
+                        "instrumentName": "EUR/USD Mini",
+                        "exchangeId": "FX",
+                        "expiry": "-",
+                        "marketStatus": "TRADEABLE",
+                        "epic": "CS.D.EURUSD.MINI.IP",
+                        "instrumentType": "CURRENCIES",
+                        "lotSize": 1.0,
+                        "high": 1.24,
+                        "low": 1.23,
+                        "percentageChange": 0.1,
+                        "netChange": 0.001,
+                        "bid": 1.2344,
+                        "offer": 1.2346,
+                        "updateTime": "09:30:00",
+                        "updateTimeUTC": "07:30:00",
+                        "delayTime": 0,
+                        "streamingPricesAvailable": true,
+                        "scalingFactor": 1
+                    }
+                }
+            ]
+        }"#;
+
+        let resp: WorkingOrdersResponse = serde_json::from_str(json).expect("deserialize failed");
+        assert_eq!(resp.working_orders.len(), 1);
+        let order = &resp.working_orders[0];
+        assert_eq!(order.working_order_data.epic, "CS.D.EURUSD.MINI.IP");
+        assert_eq!(order.working_order_data.direction, Direction::Sell);
+        assert!((order.working_order_data.order_size - 1.5).abs() < 1e-9);
+        assert!((order.working_order_data.order_level - 1.2345).abs() < 1e-9);
+        assert_eq!(
+            order.market_data.instrument_type,
+            InstrumentType::Currencies
         );
 
-        // Attempt to deserialize into WorkingOrdersResponse
-        let response: WorkingOrdersResponse = serde_json::from_str(&json_content)?;
+        let re = roundtrip(&resp);
+        assert_eq!(re.working_orders[0].working_order_data.deal_id, "DIFAKEWO1");
+        assert_eq!(re.working_orders[0].market_data.epic, "CS.D.EURUSD.MINI.IP");
+    }
 
-        println!(
-            "Successfully deserialized {} working orders",
-            response.working_orders.len()
+    #[test]
+    fn test_account_activity_response_deserialize_and_roundtrip() {
+        let json = r#"{
+            "activities": [
+                {
+                    "date": "2025-07-01T09:00:00",
+                    "dealId": "DIFAKEACT1",
+                    "epic": "IX.D.FTSE.DAILY.IP",
+                    "period": "DAY",
+                    "dealReference": "REFFAKEACT1",
+                    "type": "POSITION",
+                    "status": "ACCEPTED",
+                    "description": "Position opened",
+                    "channel": "WEB",
+                    "currency": "GBP",
+                    "level": "7550.0"
+                }
+            ],
+            "metadata": { "paging": { "size": 50, "next": null } }
+        }"#;
+
+        let resp: AccountActivityResponse = serde_json::from_str(json).expect("deserialize failed");
+        assert_eq!(resp.activities.len(), 1);
+        let act = &resp.activities[0];
+        assert_eq!(act.deal_id.as_deref(), Some("DIFAKEACT1"));
+        assert_eq!(act.activity_type, ActivityType::Position);
+        assert_eq!(act.status, Some(Status::Accepted));
+        assert!(resp.metadata.is_some());
+
+        let re = roundtrip(&resp);
+        assert_eq!(re.activities[0].activity_type, ActivityType::Position);
+        assert_eq!(
+            re.activities[0].deal_reference.as_deref(),
+            Some("REFFAKEACT1")
         );
-        for (idx, order) in response.working_orders.iter().enumerate() {
-            println!(
-                "Order {}: epic={}, direction={:?}, size={}, level={}",
-                idx + 1,
-                order.working_order_data.epic,
-                order.working_order_data.direction,
-                order.working_order_data.order_size,
-                order.working_order_data.order_level
-            );
-        }
-        Ok(())
+    }
+
+    #[test]
+    fn test_transaction_history_response_deserialize_and_roundtrip() {
+        let json = r#"{
+            "transactions": [
+                {
+                    "date": "01/07/25",
+                    "dateUtc": "2025-07-01T08:00:00",
+                    "openDateUtc": "2025-06-30T08:00:00",
+                    "instrumentName": "FTSE 100",
+                    "period": "DAY",
+                    "profitAndLoss": "E150.50",
+                    "transactionType": "DEAL",
+                    "reference": "REFFAKETX1",
+                    "openLevel": "7500.0",
+                    "closeLevel": "7550.0",
+                    "size": "2",
+                    "currency": "GBP",
+                    "cashTransaction": false
+                }
+            ],
+            "metadata": {
+                "pageData": { "pageNumber": 1, "pageSize": 20, "totalPages": 1 },
+                "size": 1
+            }
+        }"#;
+
+        let resp: TransactionHistoryResponse =
+            serde_json::from_str(json).expect("deserialize failed");
+        assert_eq!(resp.transactions.len(), 1);
+        assert_eq!(resp.transactions[0].reference, "REFFAKETX1");
+        assert_eq!(resp.transactions[0].profit_and_loss, "E150.50");
+        assert_eq!(resp.metadata.size, 1);
+        assert_eq!(resp.metadata.page_data.page_number, 1);
+
+        let re = roundtrip(&resp);
+        assert_eq!(re.transactions[0].reference, "REFFAKETX1");
+        assert_eq!(re.metadata.page_data.total_pages, 1);
+    }
+
+    #[test]
+    fn test_watchlists_response_deserialize_and_roundtrip() {
+        let json = r#"{
+            "watchlists": [
+                {
+                    "id": "WL1",
+                    "name": "My Watchlist",
+                    "editable": true,
+                    "deleteable": true,
+                    "defaultSystemWatchlist": false
+                }
+            ]
+        }"#;
+
+        let resp: WatchlistsResponse = serde_json::from_str(json).expect("deserialize failed");
+        assert_eq!(resp.watchlists.len(), 1);
+        let wl = &resp.watchlists[0];
+        assert_eq!(wl.id, "WL1");
+        assert_eq!(wl.name, "My Watchlist");
+        assert!(wl.editable);
+        assert!(!wl.default_system_watchlist);
+
+        let re = roundtrip(&resp);
+        assert_eq!(re.watchlists[0].id, "WL1");
+        assert!(re.watchlists[0].deleteable);
+    }
+
+    #[test]
+    fn test_client_sentiment_response_deserialize_and_roundtrip() {
+        let json = r#"{
+            "clientSentiments": [
+                {
+                    "marketId": "EURUSD",
+                    "longPositionPercentage": 62.5,
+                    "shortPositionPercentage": 37.5
+                }
+            ]
+        }"#;
+
+        let resp: ClientSentimentResponse = serde_json::from_str(json).expect("deserialize failed");
+        assert_eq!(resp.client_sentiments.len(), 1);
+        let s = &resp.client_sentiments[0];
+        assert_eq!(s.market_id, "EURUSD");
+        assert!((s.long_position_percentage - 62.5).abs() < 1e-9);
+        assert!((s.short_position_percentage - 37.5).abs() < 1e-9);
+
+        let re = roundtrip(&resp);
+        assert_eq!(re.client_sentiments[0].market_id, "EURUSD");
+    }
+
+    #[test]
+    fn test_indicative_costs_response_deserialize_and_roundtrip() {
+        let json = r#"{
+            "indicativeQuoteReference": "QREF-FAKE-1",
+            "costsAndCharges": {
+                "totalCostPercentage": 0.12,
+                "totalCostAmount": 3.45,
+                "currency": "GBP",
+                "oneOffCosts": { "percentage": 0.05, "amount": 1.0 },
+                "ongoingCosts": { "percentage": 0.02, "amount": 0.5 },
+                "transactionCosts": { "percentage": 0.03, "amount": 1.2 },
+                "incidentalCosts": { "percentage": 0.02, "amount": 0.75 }
+            }
+        }"#;
+
+        let resp: IndicativeCostsResponse = serde_json::from_str(json).expect("deserialize failed");
+        assert_eq!(resp.indicative_quote_reference, "QREF-FAKE-1");
+        assert_eq!(resp.costs_and_charges.total_cost_amount, Some(3.45));
+        assert_eq!(resp.costs_and_charges.currency.as_deref(), Some("GBP"));
+        let one_off = resp
+            .costs_and_charges
+            .one_off_costs
+            .as_ref()
+            .expect("oneOffCosts present");
+        assert_eq!(one_off.amount, Some(1.0));
+
+        let re = roundtrip(&resp);
+        assert_eq!(re.indicative_quote_reference, "QREF-FAKE-1");
+        assert_eq!(re.costs_and_charges.total_cost_percentage, Some(0.12));
+    }
+
+    #[test]
+    fn test_costs_and_charges_deserialize_and_roundtrip() {
+        let json = r#"{
+            "totalCostPercentage": 0.20,
+            "totalCostAmount": 5.0,
+            "currency": "USD",
+            "transactionCosts": { "percentage": 0.10, "amount": 2.5 }
+        }"#;
+
+        let costs: CostsAndCharges = serde_json::from_str(json).expect("deserialize failed");
+        assert_eq!(costs.total_cost_amount, Some(5.0));
+        assert_eq!(costs.currency.as_deref(), Some("USD"));
+        // Absent cost categories default to None (not `deny_unknown_fields`).
+        assert!(costs.one_off_costs.is_none());
+        assert!(costs.ongoing_costs.is_none());
+        let txn = costs
+            .transaction_costs
+            .as_ref()
+            .expect("transactionCosts present");
+        assert_eq!(txn.percentage, Some(0.10));
+
+        let re = roundtrip(&costs);
+        assert_eq!(re.total_cost_amount, Some(5.0));
+    }
+
+    #[test]
+    fn test_costs_history_response_deserialize_and_roundtrip() {
+        let json = r#"{
+            "costs": [
+                {
+                    "date": "2025-07-01",
+                    "dealReference": "REFFAKEC1",
+                    "epic": "IX.D.FTSE.DAILY.IP",
+                    "totalCost": 5.5,
+                    "currency": "GBP"
+                }
+            ]
+        }"#;
+
+        let resp: CostsHistoryResponse = serde_json::from_str(json).expect("deserialize failed");
+        assert_eq!(resp.costs.len(), 1);
+        let cost = &resp.costs[0];
+        assert_eq!(cost.date, "2025-07-01");
+        assert_eq!(cost.deal_reference.as_deref(), Some("REFFAKEC1"));
+        assert_eq!(cost.total_cost, Some(5.5));
+
+        let re = roundtrip(&resp);
+        assert_eq!(re.costs[0].epic.as_deref(), Some("IX.D.FTSE.DAILY.IP"));
+    }
+
+    #[test]
+    fn test_durable_medium_response_deserialize_and_roundtrip() {
+        let json = r#"{ "document": "<html>Terms and Conditions</html>" }"#;
+
+        let resp: DurableMediumResponse = serde_json::from_str(json).expect("deserialize failed");
+        assert_eq!(resp.document, "<html>Terms and Conditions</html>");
+
+        let re = roundtrip(&resp);
+        assert_eq!(re.document, "<html>Terms and Conditions</html>");
+    }
+
+    #[test]
+    fn test_account_preferences_response_deserialize_and_roundtrip() {
+        let json = r#"{ "trailingStopsEnabled": true }"#;
+
+        let resp: AccountPreferencesResponse =
+            serde_json::from_str(json).expect("deserialize failed");
+        assert!(resp.trailing_stops_enabled);
+
+        let re = roundtrip(&resp);
+        assert!(re.trailing_stops_enabled);
+    }
+
+    #[test]
+    fn test_application_details_response_deserialize_and_roundtrip() {
+        let json = r#"{
+            "apiKey": "FAKE-API-KEY",
+            "name": "My App",
+            "status": "ENABLED",
+            "allowanceAccountOverall": 10000,
+            "allowanceAccountTrading": 1000,
+            "concurrentSubscriptionsLimit": 40,
+            "createdDate": "2025-01-01"
+        }"#;
+
+        let resp: ApplicationDetailsResponse =
+            serde_json::from_str(json).expect("deserialize failed");
+        assert_eq!(resp.api_key, "FAKE-API-KEY");
+        assert_eq!(resp.name.as_deref(), Some("My App"));
+        assert_eq!(resp.status, "ENABLED");
+        assert_eq!(resp.allowance_account_overall, Some(10000));
+        assert_eq!(resp.concurrent_subscriptions_limit, Some(40));
+
+        let re = roundtrip(&resp);
+        assert_eq!(re.api_key, "FAKE-API-KEY");
+        assert_eq!(re.allowance_account_trading, Some(1000));
+    }
+
+    #[test]
+    fn test_categories_response_deserialize_and_roundtrip() {
+        let json = r#"{
+            "categories": [
+                { "code": "INDICES", "nonTradeable": false },
+                { "code": "CRYPTOCURRENCY", "nonTradeable": true }
+            ]
+        }"#;
+
+        let resp: CategoriesResponse = serde_json::from_str(json).expect("deserialize failed");
+        assert_eq!(resp.len(), 2);
+        assert_eq!(resp.categories[0].code, "INDICES");
+        assert!(!resp.categories[0].non_tradeable);
+        assert!(resp.categories[1].non_tradeable);
+
+        let re = roundtrip(&resp);
+        assert_eq!(re.categories[1].code, "CRYPTOCURRENCY");
+    }
+
+    #[test]
+    fn test_historical_prices_response_deserialize_and_roundtrip() {
+        let json = r#"{
+            "prices": [
+                {
+                    "snapshotTime": "2025:07:01-09:00:00",
+                    "openPrice": { "bid": 1.2340, "ask": 1.2342, "lastTraded": null },
+                    "highPrice": { "bid": 1.2350, "ask": 1.2352, "lastTraded": null },
+                    "lowPrice": { "bid": 1.2330, "ask": 1.2332, "lastTraded": null },
+                    "closePrice": { "bid": 1.2345, "ask": 1.2347, "lastTraded": null },
+                    "lastTradedVolume": 1234
+                }
+            ],
+            "instrumentType": "CURRENCIES",
+            "allowance": {
+                "remainingAllowance": 9950,
+                "totalAllowance": 10000,
+                "allowanceExpiry": 604800
+            }
+        }"#;
+
+        let resp: HistoricalPricesResponse =
+            serde_json::from_str(json).expect("deserialize failed");
+        assert_eq!(resp.len(), 1);
+        assert_eq!(resp.prices[0].snapshot_time, "2025:07:01-09:00:00");
+        assert_eq!(resp.prices[0].close_price.bid, Some(1.2345));
+        assert_eq!(resp.prices[0].last_traded_volume, Some(1234));
+        assert_eq!(resp.instrument_type, InstrumentType::Currencies);
+        let allowance = resp.allowance.as_ref().expect("allowance present");
+        assert_eq!(allowance.remaining_allowance, 9950);
+        assert_eq!(allowance.total_allowance, 10000);
+
+        let re = roundtrip(&resp);
+        assert_eq!(re.prices[0].open_price.ask, Some(1.2342));
+        assert_eq!(
+            re.allowance.as_ref().map(|a| a.allowance_expiry),
+            Some(604800)
+        );
+    }
+
+    #[test]
+    fn test_v3_login_response_deserialize_and_roundtrip() {
+        // Raw v3 (OAuth) login payload. `oauthToken.created_at` is derived at
+        // parse time (serde `skip`), so it is intentionally absent from the wire
+        // payload. No real tokens: obvious `FAKE-*` placeholders only.
+        let json = r#"{
+            "clientId": "FAKE-CLIENT-101",
+            "accountId": "ABC12",
+            "timezoneOffset": 1,
+            "lightstreamerEndpoint": "https://demo-apd.marketdatasystems.com",
+            "oauthToken": {
+                "access_token": "FAKE-ACCESS-TOKEN",
+                "refresh_token": "FAKE-REFRESH-TOKEN",
+                "scope": "profile",
+                "token_type": "Bearer",
+                "expires_in": "60"
+            }
+        }"#;
+
+        let resp: V3Response = serde_json::from_str(json).expect("deserialize failed");
+        assert_eq!(resp.client_id, "FAKE-CLIENT-101");
+        assert_eq!(resp.account_id, "ABC12");
+        assert_eq!(resp.oauth_token.access_token, "FAKE-ACCESS-TOKEN");
+        assert_eq!(resp.oauth_token.refresh_token, "FAKE-REFRESH-TOKEN");
+        assert_eq!(resp.oauth_token.token_type, "Bearer");
+        assert_eq!(resp.oauth_token.expires_in, "60");
+
+        // The untagged `SessionResponse` must land on the V3 variant.
+        let session_resp: SessionResponse =
+            serde_json::from_str(json).expect("session deserialize failed");
+        assert!(session_resp.is_v3());
+        assert!(session_resp.get_session().is_oauth());
+
+        let re = roundtrip(&resp);
+        assert_eq!(re.oauth_token.access_token, "FAKE-ACCESS-TOKEN");
+        assert_eq!(re.account_id, "ABC12");
     }
 }

--- a/src/presentation/trade.rs
+++ b/src/presentation/trade.rs
@@ -272,6 +272,189 @@ impl From<&ItemUpdate> for TradeData {
 mod tests {
     use super::*;
 
+    /// Builds an `ItemUpdate` carrying a single TRADE field, mirroring how the
+    /// Lightstreamer TRADE subscription delivers OPU / WOU / CONFIRMS payloads.
+    ///
+    /// `item_name`, `item_pos` and `is_snapshot` are set to distinctive,
+    /// obviously-synthetic values so tests can assert whether they survive the
+    /// parse (they are dropped on the silent-default path — see the malformed
+    /// test).
+    fn trade_item_update(field_key: &str, field_value: &str) -> ItemUpdate {
+        let mut fields = HashMap::new();
+        fields.insert(field_key.to_string(), Some(field_value.to_string()));
+        ItemUpdate {
+            item_name: Some("TRADE:SYNTHETIC".to_string()),
+            item_pos: 2,
+            fields,
+            changed_fields: HashMap::new(),
+            is_snapshot: true,
+        }
+    }
+
+    // Realistic, sanitized OPU payload. Field names mirror IG's Open Position
+    // Update stream (camelCase); the deal ids are obviously synthetic and carry
+    // no secret material.
+    const SANITIZED_OPU_JSON: &str = r#"{
+        "dealReference": "REF_SYNTHETIC_0001",
+        "dealId": "DIAAAAF00SYNTH01",
+        "dealIdOrigin": "DIAAAAF00SYNTH01",
+        "direction": "BUY",
+        "epic": "IX.D.DAX.DAILY.IP",
+        "status": "OPEN",
+        "dealStatus": "ACCEPTED",
+        "level": "18000.5",
+        "size": "1.0",
+        "currency": "EUR",
+        "timestamp": "2024-01-15T10:30:00.000",
+        "channel": "PublicRestOTC",
+        "expiry": "DFB"
+    }"#;
+
+    // Realistic, sanitized WOU payload. Field names mirror IG's Working Order
+    // Update stream (camelCase); the deal ids are obviously synthetic.
+    const SANITIZED_WOU_JSON: &str = r#"{
+        "dealReference": "REF_SYNTHETIC_0002",
+        "dealId": "DIAAAAF00SYNTH02",
+        "direction": "SELL",
+        "epic": "CS.D.EURUSD.CFD.IP",
+        "status": "OPEN",
+        "dealStatus": "ACCEPTED",
+        "level": "1.1000",
+        "size": "10000",
+        "currency": "USD",
+        "timestamp": "2024-01-15T10:31:00.000",
+        "channel": "PublicRestOTC",
+        "expiry": "-",
+        "stopDistance": "10.5",
+        "limitDistance": "20.0",
+        "guaranteedStop": false,
+        "orderType": "LIMIT",
+        "timeInForce": "GOOD_TILL_CANCELLED",
+        "goodTillDate": ""
+    }"#;
+
+    #[test]
+    fn test_from_item_update_parses_open_position_update() {
+        let item = trade_item_update("OPU", SANITIZED_OPU_JSON);
+
+        let result = TradeData::from_item_update(&item);
+        assert!(result.is_ok(), "OPU payload should parse: {result:?}");
+        let data = result.expect("OPU parse checked ok above");
+
+        // Update metadata is preserved on the success path.
+        assert_eq!(data.item_name, "TRADE:SYNTHETIC");
+        assert_eq!(data.item_pos, 2);
+        assert!(data.is_snapshot);
+
+        let opu = data.fields.opu.expect("OPU should be populated");
+        assert_eq!(opu.deal_reference.as_deref(), Some("REF_SYNTHETIC_0001"));
+        assert_eq!(opu.deal_id.as_deref(), Some("DIAAAAF00SYNTH01"));
+        assert_eq!(opu.deal_id_origin.as_deref(), Some("DIAAAAF00SYNTH01"));
+        assert_eq!(opu.direction, Some(Direction::Buy));
+        assert_eq!(opu.epic.as_deref(), Some("IX.D.DAX.DAILY.IP"));
+        assert_eq!(opu.status, Some(Status::Open));
+        assert_eq!(opu.deal_status, Some(Status::Accepted));
+        assert_eq!(opu.level, Some(18000.5));
+        assert_eq!(opu.size, Some(1.0));
+        assert_eq!(opu.currency.as_deref(), Some("EUR"));
+        assert_eq!(opu.expiry.as_deref(), Some("DFB"));
+
+        // No WOU or CONFIRMS present in this update.
+        assert!(data.fields.wou.is_none());
+        assert!(data.fields.confirms.is_none());
+    }
+
+    #[test]
+    fn test_from_item_update_parses_working_order_update() {
+        let item = trade_item_update("WOU", SANITIZED_WOU_JSON);
+
+        let result = TradeData::from_item_update(&item);
+        assert!(result.is_ok(), "WOU payload should parse: {result:?}");
+        let data = result.expect("WOU parse checked ok above");
+
+        let wou = data.fields.wou.expect("WOU should be populated");
+        assert_eq!(wou.deal_reference.as_deref(), Some("REF_SYNTHETIC_0002"));
+        assert_eq!(wou.deal_id.as_deref(), Some("DIAAAAF00SYNTH02"));
+        assert_eq!(wou.direction, Some(Direction::Sell));
+        assert_eq!(wou.epic.as_deref(), Some("CS.D.EURUSD.CFD.IP"));
+        assert_eq!(wou.status, Some(Status::Open));
+        assert_eq!(wou.deal_status, Some(Status::Accepted));
+        assert_eq!(wou.level, Some(1.1000));
+        assert_eq!(wou.size, Some(10000.0));
+        assert_eq!(wou.currency.as_deref(), Some("USD"));
+        assert_eq!(wou.stop_distance, Some(10.5));
+        assert_eq!(wou.limit_distance, Some(20.0));
+        assert_eq!(wou.guaranteed_stop, Some(false));
+        assert_eq!(wou.order_type, Some(OrderType::Limit));
+        assert_eq!(wou.time_in_force, Some(TimeInForce::GoodTillCancelled));
+        // Empty string good-till-date degrades to None.
+        assert!(wou.good_till_date.is_none());
+
+        // No OPU or CONFIRMS present in this update.
+        assert!(data.fields.opu.is_none());
+        assert!(data.fields.confirms.is_none());
+    }
+
+    #[test]
+    fn test_create_trade_fields_parses_opu_json() {
+        // Exercise the JSON-parse helper directly (independent of ItemUpdate).
+        let mut map: HashMap<String, Option<String>> = HashMap::new();
+        map.insert("OPU".to_string(), Some(SANITIZED_OPU_JSON.to_string()));
+
+        let result = TradeData::create_trade_fields(&map);
+        assert!(
+            result.is_ok(),
+            "create_trade_fields should parse OPU: {result:?}"
+        );
+        let fields = result.expect("OPU parse checked ok above");
+        let opu = fields.opu.expect("OPU should be populated");
+        assert_eq!(opu.deal_id.as_deref(), Some("DIAAAAF00SYNTH01"));
+        assert_eq!(opu.level, Some(18000.5));
+    }
+
+    #[test]
+    fn test_from_item_update_malformed_opu_is_error_on_direct_path() {
+        let item = trade_item_update("OPU", "{ this is not valid json ");
+
+        // The direct parse path surfaces the failure as an Err.
+        let result = TradeData::from_item_update(&item);
+        assert!(
+            result.is_err(),
+            "malformed OPU JSON must surface an error on the direct parse path"
+        );
+    }
+
+    #[test]
+    fn test_from_impl_swallows_malformed_opu_into_default() {
+        // KNOWN GAP (pinned, do not "fix" here): `From<&ItemUpdate>` funnels any
+        // parse failure through `.unwrap_or_default()`, so a malformed TRADE
+        // payload is silently swallowed into `TradeData::default()` instead of
+        // being surfaced. This test PINS that current behavior so a future change
+        // to make the swallow deliberate (e.g. logging, or propagating the error)
+        // is a conscious, reviewed decision rather than an accidental regression.
+        //
+        // TODO(streaming): decide whether `From<&ItemUpdate>` should log the
+        // dropped payload at WARN or expose the parse error instead of defaulting.
+        let item = trade_item_update("OPU", "{ this is not valid json ");
+
+        let data = TradeData::from(&item);
+
+        // Everything degrades to the Default, including the update metadata that
+        // was present on the source ItemUpdate (item_name / item_pos / snapshot).
+        assert!(
+            data.item_name.is_empty(),
+            "silent-default path discards item_name"
+        );
+        assert_eq!(data.item_pos, 0, "silent-default path discards item_pos");
+        assert!(
+            !data.is_snapshot,
+            "silent-default path discards is_snapshot"
+        );
+        assert!(data.fields.opu.is_none());
+        assert!(data.fields.wou.is_none());
+        assert!(data.fields.confirms.is_none());
+    }
+
     #[test]
     fn test_trade_data_default() {
         let data = TradeData::default();

--- a/tests/unit/application/mod.rs
+++ b/tests/unit/application/mod.rs
@@ -1,5 +1,7 @@
 mod models;
 mod services;
 mod test_auth;
+mod test_auth_flow;
 mod test_client;
+mod test_http_request;
 mod test_listener;

--- a/tests/unit/application/test_auth_flow.rs
+++ b/tests/unit/application/test_auth_flow.rs
@@ -1,0 +1,305 @@
+//! Offline auth / session lifecycle tests driving `Auth` and `HttpClient`
+//! against a `wiremock::MockServer`. No live network, no real credentials —
+//! all identifiers are obvious `FAKE-*` / `ABC12` placeholders.
+
+use ig_client::application::auth::Auth;
+use ig_client::application::config::{
+    Config, Credentials, RateLimiterConfig, RestApiConfig, WebSocketConfig,
+};
+use ig_client::error::AppError;
+use ig_client::model::http::HttpClient;
+use ig_client::storage::config::DatabaseConfig;
+use std::sync::Arc;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// Builds a hermetic `Config` pointing at `base_url` with the given API version.
+/// Constructed directly (never via `Config::default`) so the tests do not read
+/// `.env` / environment variables and stay deterministic. The rate limiter is
+/// deliberately permissive so pacing never slows the tests.
+fn test_config(base_url: &str, api_version: u8) -> Config {
+    Config {
+        credentials: Credentials {
+            username: "fake-user".to_string(),
+            password: "fake-pass".to_string(),
+            account_id: "ABC12".to_string(),
+            api_key: "FAKE-API-KEY".to_string(),
+            client_token: None,
+            account_token: None,
+        },
+        rest_api: RestApiConfig {
+            base_url: base_url.to_string(),
+            timeout: 30,
+        },
+        websocket: WebSocketConfig {
+            url: "wss://example.invalid".to_string(),
+            reconnect_interval: 5,
+        },
+        database: DatabaseConfig {
+            url: "postgres://localhost/none".to_string(),
+            max_connections: 1,
+        },
+        rate_limiter: RateLimiterConfig {
+            max_requests: 1000,
+            period_seconds: 1,
+            burst_size: 100,
+        },
+        sleep_hours: 1,
+        page_size: 20,
+        days_to_look_back: 7,
+        api_version: Some(api_version),
+    }
+}
+
+/// Captured-shape v2 `/session` body. `currentAccountId` matches the configured
+/// `ABC12` so `login` does not attempt an account switch.
+const V2_BODY: &str = r#"{
+    "accountType": "CFD",
+    "accountInfo": { "balance": 10000.0, "deposit": 2000.0, "profitLoss": 150.5, "available": 8000.0 },
+    "currencyIsoCode": "EUR",
+    "currencySymbol": "E",
+    "currentAccountId": "ABC12",
+    "lightstreamerEndpoint": "https://demo-apd.marketdatasystems.com",
+    "accounts": [ { "accountId": "ABC12", "accountName": "Demo", "preferred": true, "accountType": "CFD" } ],
+    "clientId": "FAKE-CLIENT-1",
+    "timezoneOffset": 1,
+    "hasActiveDemoAccounts": true,
+    "hasActiveLiveAccounts": false,
+    "trailingStopsEnabled": false,
+    "reroutingEnvironment": null,
+    "dealingEnabled": true
+}"#;
+
+/// v3 (OAuth) `/session` body with a configurable `expires_in`. Fake tokens only.
+fn v3_body(expires_in: &str) -> String {
+    format!(
+        r#"{{
+            "clientId": "FAKE-CLIENT-1",
+            "accountId": "ABC12",
+            "timezoneOffset": 1,
+            "lightstreamerEndpoint": "https://demo-apd.marketdatasystems.com",
+            "oauthToken": {{
+                "access_token": "FAKE-ACCESS",
+                "refresh_token": "FAKE-REFRESH",
+                "scope": "profile",
+                "token_type": "Bearer",
+                "expires_in": "{expires_in}"
+            }}
+        }}"#
+    )
+}
+
+/// IG-shaped 401 body signalling an invalidated OAuth token.
+const OAUTH_INVALID_BODY: &str = r#"{"errorCode":"error.security.oauth-token-invalid"}"#;
+
+/// A `200 OK` response carrying a JSON body with the correct content type.
+fn json_ok(body: impl Into<Vec<u8>>) -> ResponseTemplate {
+    ResponseTemplate::new(200).set_body_raw(body, "application/json")
+}
+
+#[tokio::test]
+async fn test_login_v2_returns_session_with_cst_and_security_token() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/session"))
+        .respond_with(
+            json_ok(V2_BODY)
+                .insert_header("CST", "FAKE-CST")
+                .insert_header("X-SECURITY-TOKEN", "FAKE-XST"),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let auth = Auth::new(Arc::new(test_config(&server.uri(), 2)));
+    let session = auth.login().await.expect("v2 login should succeed");
+
+    assert!(!session.is_oauth());
+    assert_eq!(session.cst.as_deref(), Some("FAKE-CST"));
+    assert_eq!(session.x_security_token.as_deref(), Some("FAKE-XST"));
+    assert_eq!(session.account_id, "ABC12");
+    assert_eq!(session.api_version, 2);
+}
+
+#[tokio::test]
+async fn test_login_v2_missing_cst_header_yields_invalid_input() {
+    let server = MockServer::start().await;
+    // Body present, but the CST response header is missing.
+    Mock::given(method("POST"))
+        .and(path("/session"))
+        .respond_with(json_ok(V2_BODY).insert_header("X-SECURITY-TOKEN", "FAKE-XST"))
+        .mount(&server)
+        .await;
+
+    let auth = Auth::new(Arc::new(test_config(&server.uri(), 2)));
+    match auth.login().await {
+        Err(AppError::InvalidInput(msg)) => assert!(
+            msg.contains("CST"),
+            "error should name the missing CST header, got: {msg}"
+        ),
+        other => panic!("expected InvalidInput for missing CST, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_login_v2_missing_security_token_header_yields_invalid_input() {
+    let server = MockServer::start().await;
+    // CST present, X-SECURITY-TOKEN missing.
+    Mock::given(method("POST"))
+        .and(path("/session"))
+        .respond_with(json_ok(V2_BODY).insert_header("CST", "FAKE-CST"))
+        .mount(&server)
+        .await;
+
+    let auth = Auth::new(Arc::new(test_config(&server.uri(), 2)));
+    match auth.login().await {
+        Err(AppError::InvalidInput(msg)) => assert!(
+            msg.contains("X-SECURITY-TOKEN"),
+            "error should name the missing security token header, got: {msg}"
+        ),
+        other => panic!("expected InvalidInput for missing X-SECURITY-TOKEN, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_login_v3_returns_oauth_session() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/session"))
+        .respond_with(json_ok(v3_body("60")))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let auth = Auth::new(Arc::new(test_config(&server.uri(), 3)));
+    let session = auth.login().await.expect("v3 login should succeed");
+
+    assert!(session.is_oauth());
+    assert_eq!(session.api_version, 3);
+    assert_eq!(session.account_id, "ABC12");
+}
+
+#[tokio::test]
+async fn test_get_session_refreshes_expired_session_with_relogin() {
+    let server = MockServer::start().await;
+    // `expires_in: 0` makes every issued session already expired, so the cached
+    // session is never reused — `get_session` must perform a fresh login.
+    // Hit #1 = the explicit `login`; hit #2 = the refresh-driven re-login.
+    Mock::given(method("POST"))
+        .and(path("/session"))
+        .respond_with(json_ok(v3_body("0")))
+        .expect(2)
+        .mount(&server)
+        .await;
+
+    let auth = Auth::new(Arc::new(test_config(&server.uri(), 3)));
+    let first = auth.login().await.expect("initial login should succeed");
+    assert!(first.is_oauth());
+
+    // The cached session is expired, so this triggers a re-login (2nd hit).
+    let refreshed = auth
+        .get_session()
+        .await
+        .expect("get_session should re-login an expired session");
+    assert!(refreshed.is_oauth());
+    // On drop the MockServer verifies `expect(2)` — exactly one extra re-login.
+}
+
+#[tokio::test]
+async fn test_request_refreshes_once_and_replays_on_oauth_token_expired() {
+    // Mandated contract: a 401 `oauth-token-invalid` triggers exactly one
+    // transparent refresh + replay, and the replayed request succeeds.
+    let server = MockServer::start().await;
+
+    // Session established during construction (a valid 60s OAuth session).
+    Mock::given(method("POST"))
+        .and(path("/session"))
+        .respond_with(json_ok(v3_body("60")))
+        .mount(&server)
+        .await;
+    let client = HttpClient::new(test_config(&server.uri(), 3))
+        .await
+        .expect("client construction (initial login) should succeed");
+
+    // Forget the construction-time login so the refresh below is counted in
+    // isolation: after `reset`, the ONLY `POST /session` is the refresh.
+    server.reset().await;
+    Mock::given(method("POST"))
+        .and(path("/session"))
+        .respond_with(json_ok(v3_body("60")))
+        .expect(1) // exactly one refresh
+        .named("single refresh login")
+        .mount(&server)
+        .await;
+
+    // First business call 401s (token invalid); the replay returns 200.
+    Mock::given(method("GET"))
+        .and(path("/accounts"))
+        .respond_with(
+            ResponseTemplate::new(401).set_body_raw(OAUTH_INVALID_BODY, "application/json"),
+        )
+        .up_to_n_times(1)
+        .with_priority(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/accounts"))
+        .respond_with(json_ok(r#"{"value":42}"#))
+        .with_priority(2)
+        .mount(&server)
+        .await;
+
+    let value: serde_json::Value = client
+        .get("accounts", Some(1))
+        .await
+        .expect("request should succeed after one refresh and replay");
+    assert_eq!(
+        value.get("value").and_then(serde_json::Value::as_i64),
+        Some(42)
+    );
+    // MockServer drop verifies the refresh mock's `expect(1)`: refresh happened
+    // exactly once.
+}
+
+#[tokio::test]
+async fn test_request_does_not_loop_on_repeated_oauth_token_expired() {
+    // A SECOND consecutive 401 after the single refresh must propagate as a
+    // typed error — never an infinite refresh loop.
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/session"))
+        .respond_with(json_ok(v3_body("60")))
+        .mount(&server)
+        .await;
+    let client = HttpClient::new(test_config(&server.uri(), 3))
+        .await
+        .expect("client construction should succeed");
+
+    server.reset().await;
+    // Only ONE refresh is permitted even though the business call keeps 401ing.
+    Mock::given(method("POST"))
+        .and(path("/session"))
+        .respond_with(json_ok(v3_body("60")))
+        .expect(1)
+        .named("single refresh login")
+        .mount(&server)
+        .await;
+    // Business call always 401s: initial attempt + one replay = exactly 2 hits.
+    Mock::given(method("GET"))
+        .and(path("/accounts"))
+        .respond_with(
+            ResponseTemplate::new(401).set_body_raw(OAUTH_INVALID_BODY, "application/json"),
+        )
+        .expect(2)
+        .mount(&server)
+        .await;
+
+    match client.get::<serde_json::Value>("accounts", Some(1)).await {
+        Err(AppError::OAuthTokenExpired) => {}
+        other => panic!(
+            "expected OAuthTokenExpired after the single refresh was exhausted, got {other:?}"
+        ),
+    }
+    // MockServer drop verifies refresh `expect(1)` and business `expect(2)`.
+}

--- a/tests/unit/application/test_http_request.rs
+++ b/tests/unit/application/test_http_request.rs
@@ -1,0 +1,234 @@
+//! Offline tests for `make_http_request` — the single choke point that maps HTTP
+//! status codes and IG error bodies to typed `AppError` variants and applies the
+//! finite retry policy. Driven against a `wiremock::MockServer`; retry delays are
+//! zero so the suite stays fast, and mock `.expect(...)` counts assert the exact
+//! number of attempts (retries + 1).
+
+use ig_client::application::config::RateLimiterConfig;
+use ig_client::application::rate_limiter::RateLimiter;
+use ig_client::error::AppError;
+use ig_client::model::http::make_http_request;
+use ig_client::model::retry::RetryConfig;
+use reqwest::{Client, Method, StatusCode};
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// A permissive rate limiter so pacing never slows the tests. The mock endpoint
+/// path is non-trading, so it is governed by this configured budget.
+fn permissive_rate_limiter() -> Arc<RwLock<RateLimiter>> {
+    Arc::new(RwLock::new(RateLimiter::new(&RateLimiterConfig {
+        max_requests: 1000,
+        period_seconds: 1,
+        burst_size: 100,
+    })))
+}
+
+/// A finite retry config with zero base delay: `max_retries = 2` means up to
+/// three attempts total, and a zero delay keeps retries instantaneous.
+fn fast_retry() -> RetryConfig {
+    RetryConfig {
+        max_retry_count: Some(2),
+        retry_delay_secs: Some(0),
+    }
+}
+
+/// `max_retries` for [`fast_retry`]; the total attempt count on a persistently
+/// retryable status is `RETRIES + 1`.
+const RETRIES: u64 = 2;
+
+/// Issues a GET to `{server}/test-endpoint` through `make_http_request`.
+async fn get_test_endpoint(
+    server: &MockServer,
+    retry: RetryConfig,
+) -> Result<reqwest::Response, AppError> {
+    let client = Client::new();
+    let url = format!("{}/test-endpoint", server.uri());
+    make_http_request(
+        &client,
+        permissive_rate_limiter(),
+        Method::GET,
+        &url,
+        vec![("X-IG-API-KEY", "FAKE-API-KEY")],
+        &None::<()>,
+        retry,
+    )
+    .await
+}
+
+/// Mounts a single response for `GET /test-endpoint`, expecting exactly
+/// `expected_hits` matching requests (verified on server drop).
+async fn mount_get(server: &MockServer, response: ResponseTemplate, expected_hits: u64) {
+    Mock::given(method("GET"))
+        .and(path("/test-endpoint"))
+        .respond_with(response)
+        .expect(expected_hits)
+        .mount(server)
+        .await;
+}
+
+#[tokio::test]
+async fn test_make_http_request_200_returns_ok() {
+    let server = MockServer::start().await;
+    mount_get(
+        &server,
+        ResponseTemplate::new(200).set_body_raw(r#"{"ok":true}"#, "application/json"),
+        1,
+    )
+    .await;
+
+    let response = get_test_endpoint(&server, fast_retry())
+        .await
+        .expect("2xx should return Ok");
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn test_make_http_request_401_oauth_invalid_maps_to_oauth_token_expired() {
+    let server = MockServer::start().await;
+    // 401 carrying the oauth-token-invalid marker is surfaced (not retried) so
+    // the caller can refresh and replay.
+    mount_get(
+        &server,
+        ResponseTemplate::new(401).set_body_raw(
+            r#"{"errorCode":"error.security.oauth-token-invalid"}"#,
+            "application/json",
+        ),
+        1,
+    )
+    .await;
+
+    match get_test_endpoint(&server, fast_retry()).await {
+        Err(AppError::OAuthTokenExpired) => {}
+        other => panic!("expected OAuthTokenExpired, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_make_http_request_401_without_oauth_marker_maps_to_unauthorized() {
+    let server = MockServer::start().await;
+    mount_get(
+        &server,
+        ResponseTemplate::new(401).set_body_raw(
+            r#"{"errorCode":"error.security.client-token-invalid"}"#,
+            "application/json",
+        ),
+        1,
+    )
+    .await;
+
+    match get_test_endpoint(&server, fast_retry()).await {
+        Err(AppError::Unauthorized) => {}
+        other => panic!("expected Unauthorized, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_make_http_request_403_historical_allowance_fails_fast() {
+    let server = MockServer::start().await;
+    // Historical-data allowance is a weekly quota: retrying is pointless, so this
+    // must fail fast (exactly one hit, no retries).
+    mount_get(
+        &server,
+        ResponseTemplate::new(403).set_body_raw(
+            r#"{"errorCode":"error.public-api.exceeded-account-historical-data-allowance"}"#,
+            "application/json",
+        ),
+        1,
+    )
+    .await;
+
+    match get_test_endpoint(&server, fast_retry()).await {
+        Err(AppError::HistoricalDataAllowanceExceeded { allowance_expiry }) => {
+            assert_eq!(allowance_expiry, 0);
+        }
+        other => panic!("expected HistoricalDataAllowanceExceeded, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_make_http_request_403_api_key_allowance_is_rate_limited_and_retried() {
+    let server = MockServer::start().await;
+    // An API-key allowance breach is a rate limit: it maps to RateLimitExceeded
+    // and IS retried, so all RETRIES + 1 attempts are made before giving up.
+    mount_get(
+        &server,
+        ResponseTemplate::new(403).set_body_raw(
+            r#"{"errorCode":"error.public-api.exceeded-api-key-allowance"}"#,
+            "application/json",
+        ),
+        RETRIES + 1,
+    )
+    .await;
+
+    match get_test_endpoint(&server, fast_retry()).await {
+        Err(AppError::RateLimitExceeded) => {}
+        other => panic!("expected RateLimitExceeded, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_make_http_request_403_other_maps_to_unexpected_and_fails_fast() {
+    let server = MockServer::start().await;
+    mount_get(
+        &server,
+        ResponseTemplate::new(403).set_body_raw(
+            r#"{"errorCode":"error.public-api.some-other-forbidden"}"#,
+            "application/json",
+        ),
+        1,
+    )
+    .await;
+
+    match get_test_endpoint(&server, fast_retry()).await {
+        Err(AppError::Unexpected(status)) => assert_eq!(status, StatusCode::FORBIDDEN),
+        other => panic!("expected Unexpected(403), got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_make_http_request_429_is_rate_limited_and_retried() {
+    let server = MockServer::start().await;
+    // 429 is transient: retried with backoff, then terminates as RateLimitExceeded
+    // once the finite budget is exhausted.
+    mount_get(&server, ResponseTemplate::new(429), RETRIES + 1).await;
+
+    match get_test_endpoint(&server, fast_retry()).await {
+        Err(AppError::RateLimitExceeded) => {}
+        other => panic!("expected RateLimitExceeded after retries, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_make_http_request_500_is_retried_then_unexpected() {
+    let server = MockServer::start().await;
+    // 5xx is transient: retried, then the terminal typed error carries the status.
+    mount_get(&server, ResponseTemplate::new(500), RETRIES + 1).await;
+
+    match get_test_endpoint(&server, fast_retry()).await {
+        Err(AppError::Unexpected(status)) => {
+            assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+        }
+        other => panic!("expected Unexpected(500) after retries, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_make_http_request_zero_retries_makes_single_attempt() {
+    let server = MockServer::start().await;
+    // With max_retries = 0 a persistently retryable status is attempted exactly
+    // once (try, never retry) before returning the terminal error.
+    mount_get(&server, ResponseTemplate::new(503), 1).await;
+
+    let retry = RetryConfig {
+        max_retry_count: Some(0),
+        retry_delay_secs: Some(0),
+    };
+    match get_test_endpoint(&server, retry).await {
+        Err(AppError::Unexpected(status)) => {
+            assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+        }
+        other => panic!("expected Unexpected(503) on single attempt, got {other:?}"),
+    }
+}


### PR DESCRIPTION
## Summary

The riskiest paths in the crate had zero offline test coverage: the auth flow (login/refresh/401-replay), `make_http_request` status→error mapping and retry, the streaming state machine, TRADE payload parsing, and most response DTOs. This PR adds ~45 offline tests, introducing `wiremock` as a dev-dependency (approved) to drive HTTP against a mock server.

## Changes

- **Auth flow** (mock server): v2 login header extraction + missing CST/X-SECURITY-TOKEN errors, v3 login, expired-session re-login, and the mandated **401 → refresh-once → replay** contract — plus a test proving no infinite refresh on repeated 401.
- **`make_http_request`** status/retry mapping: 200, 401 (with/without `oauth-token-invalid`), 403 (historical-allowance fail-fast vs api-key-allowance retry vs other), 429, 500 — asserting exact `AppError` variants, retry counts (`wiremock .expect(n)`), and single-attempt on zero retries.
- **Response DTO round-trips** from sanitized IG payloads for 16 DTOs (accounts, positions, working orders, activity, transactions, watchlists, sentiment, costs, prices, v3 login/OAuth, application details, categories, …). The file-dependent `#[ignore]`d working-orders test is replaced by an inline offline one.
- **Streaming state machine**: `DynamicMarketStreamer` add/remove/clear, `get_receiver` once-only, shutdown-signal fires on disconnect, reconnect-on-epic-change; **TRADE parsing**: OPU/WOU payloads through `from_item_update`, plus a test pinning the current swallow-to-`default()` behavior as a documented gap.

## Public API impact

None — no production code changed; `wiremock` is a dev-dependency only. `cargo semver-checks`: no semver update required.

## Testing

- [x] 401 → refresh-once → replay covered against a mock server (asserts exactly one refresh, and no infinite loop)
- [x] Streaming shutdown-path (signal fires on disconnect) covered offline
- [x] Round-trip serde tests for 16 response DTOs from sanitized payloads
- [x] `make pre-push` clean; 230 lib + 274 unit tests pass; clippy/fmt/semver clean

The `market_database.rs` pure-function test cited in the issue was already fixed in #41 (lazy pool, no `#[ignore]`), so no change was needed there.

Closes #42
