### PR TITLE
refactor: restore module boundaries (I/O out of model/presentation) — 0.12.0 (#47)

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -20,7 +20,7 @@ use std::hint::black_box;
 
 use criterion::{Criterion, criterion_group};
 
-use ig_client::model::utils::extract_markets_from_hierarchy;
+use ig_client::application::market_hierarchy::extract_markets_from_hierarchy;
 use ig_client::prelude::DBEntryResponse;
 use ig_client::presentation::instrument::InstrumentType;
 use ig_client::presentation::market::{MarketData, MarketNode};

--- a/examples/market/src/bin/market_hierarchy.rs
+++ b/examples/market/src/bin/market_hierarchy.rs
@@ -1,4 +1,4 @@
-use ig_client::model::utils::build_market_hierarchy;
+use ig_client::application::market_hierarchy::build_market_hierarchy;
 use ig_client::prelude::*;
 use tracing::{error, info};
 

--- a/examples/other/src/bin/tx_loop.rs
+++ b/examples/other/src/bin/tx_loop.rs
@@ -29,14 +29,14 @@ async fn main() -> Result<(), ig_client::error::AppError> {
     debug!("Loaded config: database={}", config.database);
 
     // Build the Postgres pool once at startup
-    let pool = match config.pg_pool().await {
+    let pool = match create_connection_pool(&config.database).await {
         Ok(pool) => {
             info!("Postgres pool established");
             pool
         }
         Err(e) => {
             error!("Failed to establish database connection: {}", e);
-            return Err(e.into());
+            return Err(e);
         }
     };
 

--- a/examples/other/src/bin/tx_loop.rs
+++ b/examples/other/src/bin/tx_loop.rs
@@ -26,7 +26,10 @@ async fn main() -> Result<(), ig_client::error::AppError> {
         "Configuration: interval={} hours, page_size={}, lookback={} days",
         config.sleep_hours, config.page_size, config.days_to_look_back
     );
-    debug!("Loaded config: database={}", config.database);
+    debug!(
+        "Loaded config: database max_connections={}",
+        config.database.max_connections
+    );
 
     // Build the Postgres pool once at startup
     let pool = match create_connection_pool(&config.database).await {

--- a/examples/transactions/src/bin/transactions_example.rs
+++ b/examples/transactions/src/bin/transactions_example.rs
@@ -44,7 +44,7 @@ async fn main() -> Result<(), ig_client::error::AppError> {
         }
     }
     // Store the transactions in database if configured
-    if let Ok(pool) = config.pg_pool().await {
+    if let Ok(pool) = create_connection_pool(&config.database).await {
         let tx_list = TransactionList::from(&transactions.transactions);
         let inserted = store_transactions(&pool, tx_list.as_ref()).await?;
         info!("Inserted {} rows into database", inserted);

--- a/src/application/auth.rs
+++ b/src/application/auth.rs
@@ -13,227 +13,31 @@
 //! - Automatic re-authentication when tokens expire
 
 use crate::application::config::Config;
+use crate::application::http::make_http_request;
 use crate::application::rate_limiter::RateLimiter;
 use crate::constants::USER_AGENT;
 use crate::error::AppError;
-pub(crate) use crate::model::auth::{OAuthToken, SecurityHeaders, SessionResponse};
-use crate::model::http::make_http_request;
+pub(crate) use crate::model::auth::{SecurityHeaders, SessionResponse};
 use crate::model::retry::RetryConfig;
-use chrono::Utc;
 use reqwest::{Client, Method};
-use serde::{Deserialize, Serialize};
-use std::fmt;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use tracing::{debug, error, info, warn};
+// `OAuthToken` and `chrono::Utc` are only referenced from the unit tests below
+// (the `Session` data type that used them in production moved to
+// `crate::model::auth`), so they are imported under `cfg(test)` to keep the
+// non-test build free of unused-import warnings.
+#[cfg(test)]
+use crate::model::auth::OAuthToken;
+#[cfg(test)]
+use chrono::Utc;
 
-/// WebSocket connection information for Lightstreamer
-///
-/// Contains the necessary credentials and endpoint information
-/// to establish a WebSocket connection to IG's Lightstreamer service.
-#[derive(Clone, Default, Serialize, Deserialize)]
-pub struct WebsocketInfo {
-    /// Lightstreamer endpoint URL
-    pub server: String,
-    /// CST token for authentication (API v2)
-    pub cst: Option<String>,
-    /// X-SECURITY-TOKEN for authentication (API v2)
-    pub x_security_token: Option<String>,
-    /// Account ID for the WebSocket connection
-    pub account_id: String,
-}
-
-/// Renders an optional secret as `Some(<redacted>)` / `None`, never exposing
-/// the underlying token value in `Debug` / `Display` output or logs.
-struct RedactedOption<'a>(&'a Option<String>);
-
-impl fmt::Debug for RedactedOption<'_> {
-    #[inline]
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self.0 {
-            Some(_) => f.write_str("Some(<redacted>)"),
-            None => f.write_str("None"),
-        }
-    }
-}
-
-// Manual redacting `Debug` — `cst` / `x_security_token` are credentials and
-// must never reach logs or panics. All non-secret fields stay visible.
-impl fmt::Debug for WebsocketInfo {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("WebsocketInfo")
-            .field("server", &self.server)
-            .field("cst", &RedactedOption(&self.cst))
-            .field("x_security_token", &RedactedOption(&self.x_security_token))
-            .field("account_id", &self.account_id)
-            .finish()
-    }
-}
-
-// Manual redacting `Display` — the derived `DisplaySimple` serializes via serde
-// and would leak the tokens, so it is replaced with a masking implementation.
-impl fmt::Display for WebsocketInfo {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "WebsocketInfo {{ server: {}, cst: {:?}, x_security_token: {:?}, account_id: {} }}",
-            self.server,
-            RedactedOption(&self.cst),
-            RedactedOption(&self.x_security_token),
-            self.account_id,
-        )
-    }
-}
-
-impl WebsocketInfo {
-    /// Generates the WebSocket password for Lightstreamer authentication
-    ///
-    /// # Returns
-    /// * Password in format "CST-{cst}|XST-{token}" if both tokens are available
-    /// * Empty string if tokens are not available
-    #[must_use]
-    pub fn get_ws_password(&self) -> String {
-        match (&self.cst, &self.x_security_token) {
-            (Some(cst), Some(x_security_token)) => {
-                format!("CST-{}|XST-{}", cst, x_security_token)
-            }
-            _ => String::new(),
-        }
-    }
-}
-
-/// Session information for authenticated requests
-#[derive(Clone)]
-pub struct Session {
-    /// Account ID
-    pub account_id: String,
-    /// Client ID (for OAuth)
-    pub client_id: String,
-    /// Lightstreamer endpoint
-    pub lightstreamer_endpoint: String,
-    /// CST token (API v2)
-    pub cst: Option<String>,
-    /// X-SECURITY-TOKEN (API v2)
-    pub x_security_token: Option<String>,
-    /// OAuth token (API v3)
-    pub oauth_token: Option<OAuthToken>,
-    /// API version used
-    pub api_version: u8,
-    /// Unix timestamp when session expires (seconds since epoch)
-    /// - OAuth (v3): expires in 30 seconds
-    /// - API v2: expires in 6 hours (21600 seconds)
-    pub expires_at: u64,
-}
-
-// Manual redacting `Debug` — `cst`, `x_security_token` and the OAuth token are
-// credentials. The `OAuthToken` `Debug` impl is itself redacting, so printing
-// `oauth_token` here stays safe. All non-secret fields remain visible.
-impl fmt::Debug for Session {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Session")
-            .field("account_id", &self.account_id)
-            .field("client_id", &self.client_id)
-            .field("lightstreamer_endpoint", &self.lightstreamer_endpoint)
-            .field("cst", &RedactedOption(&self.cst))
-            .field("x_security_token", &RedactedOption(&self.x_security_token))
-            .field("oauth_token", &self.oauth_token)
-            .field("api_version", &self.api_version)
-            .field("expires_at", &self.expires_at)
-            .finish()
-    }
-}
-
-impl Session {
-    /// Checks if this session uses OAuth authentication
-    #[must_use]
-    #[inline]
-    pub fn is_oauth(&self) -> bool {
-        self.oauth_token.is_some()
-    }
-
-    /// Checks if session is expired or will expire soon
-    ///
-    /// # Arguments
-    /// * `margin_seconds` - Safety margin in seconds (default: 60 = 1 minute)
-    ///
-    /// # Returns
-    /// * `true` if session is expired or will expire within margin
-    /// * `false` if session is still valid
-    #[must_use]
-    #[inline]
-    pub fn is_expired(&self, margin_seconds: Option<u64>) -> bool {
-        let margin = margin_seconds.unwrap_or(60);
-        let now = u64::try_from(Utc::now().timestamp()).unwrap_or(0);
-        // Saturating: a large margin against a small `expires_at` must not
-        // underflow (debug panic / bogus huge threshold in release).
-        now >= self.expires_at.saturating_sub(margin)
-    }
-
-    /// Gets the number of whole seconds until the session expires.
-    ///
-    /// # Returns
-    /// * The number of seconds remaining before expiry.
-    /// * `0` when the session is already expired — the result saturates at zero
-    ///   (a `u64` cannot be negative), so an expired session never reports a
-    ///   spuriously large remaining time.
-    #[must_use]
-    #[inline]
-    pub fn seconds_until_expiry(&self) -> u64 {
-        let now = u64::try_from(Utc::now().timestamp()).unwrap_or(0);
-        self.expires_at.saturating_sub(now)
-    }
-
-    /// Returns the time remaining until the session expires as a
-    /// [`std::time::Duration`].
-    ///
-    /// # Returns
-    /// * The remaining time before expiry.
-    /// * [`std::time::Duration::ZERO`] when the session is already expired.
-    #[must_use]
-    #[inline]
-    pub fn time_until_expiry(&self) -> std::time::Duration {
-        std::time::Duration::from_secs(self.seconds_until_expiry())
-    }
-
-    /// Checks if OAuth token needs refresh (alias for is_expired for backwards compatibility)
-    ///
-    /// # Arguments
-    /// * `margin_seconds` - Safety margin in seconds (default: 60 = 1 minute)
-    #[must_use]
-    #[inline]
-    pub fn needs_token_refresh(&self, margin_seconds: Option<u64>) -> bool {
-        self.is_expired(margin_seconds)
-    }
-
-    /// Extracts WebSocket connection information from the session
-    ///
-    /// # Returns
-    /// * `WebsocketInfo` containing endpoint and authentication tokens
-    #[must_use]
-    pub fn get_websocket_info(&self) -> WebsocketInfo {
-        // Ensure the server URL has the https:// prefix
-        let server = if self.lightstreamer_endpoint.starts_with("http://")
-            || self.lightstreamer_endpoint.starts_with("https://")
-        {
-            format!("{}/lightstreamer", self.lightstreamer_endpoint)
-        } else {
-            format!("https://{}/lightstreamer", self.lightstreamer_endpoint)
-        };
-
-        WebsocketInfo {
-            server,
-            cst: self.cst.clone(),
-            x_security_token: self.x_security_token.clone(),
-            account_id: self.account_id.clone(),
-        }
-    }
-}
-
-impl From<SessionResponse> for Session {
-    fn from(v: SessionResponse) -> Self {
-        v.get_session()
-    }
-}
+// `Session` and `WebsocketInfo` are pure data types and live in the model
+// layer (`crate::model::auth`). They are re-exported here so the historical
+// public paths `crate::application::auth::Session` /
+// `crate::application::auth::WebsocketInfo` keep resolving, and so the auth
+// I/O manager below can reference them unqualified.
+pub use crate::model::auth::{Session, WebsocketInfo};
 
 /// Merges freshly-issued v2 security tokens into a session after an account
 /// switch.
@@ -683,7 +487,7 @@ impl Auth {
     /// It cannot loop back through the 401 handler: [`login`](Self::login) issues
     /// its HTTP requests through
     /// [`make_http_request`] directly, not
-    /// through the [`HttpClient`](crate::model::http::HttpClient) refresh-and-replay
+    /// through the [`HttpClient`](crate::application::http::HttpClient) refresh-and-replay
     /// path, so a 401 encountered *during* login surfaces as a typed error rather
     /// than recursing into `force_refresh`.
     ///

--- a/src/application/client.rs
+++ b/src/application/client.rs
@@ -5,6 +5,7 @@
 ******************************************************************************/
 use crate::application::auth::WebsocketInfo;
 use crate::application::config::Config;
+use crate::application::http::HttpClient;
 use crate::application::interfaces::account::AccountService;
 use crate::application::interfaces::costs::CostsService;
 use crate::application::interfaces::market::MarketService;
@@ -13,7 +14,6 @@ use crate::application::interfaces::order::OrderService;
 use crate::application::interfaces::sentiment::SentimentService;
 use crate::application::interfaces::watchlist::WatchlistService;
 use crate::error::AppError;
-use crate::model::http::HttpClient;
 use crate::model::requests::RecentPricesRequest;
 use crate::model::requests::{
     AddToWatchlistRequest, CloseCostsRequest, CreateWatchlistRequest, EditCostsRequest,
@@ -21,6 +21,10 @@ use crate::model::requests::{
 };
 use crate::model::requests::{
     ClosePositionRequest, CreateOrderRequest, CreateWorkingOrderRequest, UpdatePositionRequest,
+};
+use crate::model::responses::{
+    AccountActivityResponse, AccountsResponse, OrderConfirmationResponse, PositionsResponse,
+    TransactionHistoryResponse, WorkingOrdersResponse,
 };
 use crate::model::responses::{
     AccountPreferencesResponse, ApplicationDetailsResponse, CategoriesResponse,
@@ -39,13 +43,11 @@ use crate::model::streaming::{
     get_streaming_account_data_fields, get_streaming_chart_fields, get_streaming_market_fields,
     get_streaming_price_fields,
 };
-use crate::prelude::{
-    AccountActivityResponse, AccountFields, AccountsResponse, ChartData, ChartScale,
-    OrderConfirmationResponse, PositionsResponse, TradeFields, TransactionHistoryResponse,
-    WorkingOrdersResponse,
-};
+use crate::presentation::account::AccountFields;
+use crate::presentation::chart::{ChartData, ChartScale};
 use crate::presentation::market::{MarketData, MarketDetails};
 use crate::presentation::price::PriceData;
+use crate::presentation::trade::TradeFields;
 use async_trait::async_trait;
 use futures::StreamExt;
 use lightstreamer_rs::client::{LightstreamerClient, LogType, Transport};

--- a/src/application/config.rs
+++ b/src/application/config.rs
@@ -1,13 +1,26 @@
 use crate::constants::{DAYS_TO_BACK_LOOK, DEFAULT_PAGE_SIZE, DEFAULT_SLEEP_TIME};
-use crate::storage::config::DatabaseConfig;
 use crate::utils::config::get_env_or_default;
 use dotenv::dotenv;
 use pretty_simple_display::{DebugPretty, DisplaySimple};
 use serde::{Deserialize, Serialize};
-use sqlx::postgres::PgPoolOptions;
 use std::env;
 use tracing::error;
 use tracing::log::debug;
+
+/// Configuration for database connections
+///
+/// This is a pure configuration DTO with no I/O. It lives in the application
+/// config module (alongside the other `*Config` types) so the application layer
+/// can embed it in [`Config`] without depending on the storage layer. The
+/// storage layer re-exports it (see `storage::config`) and owns the actual pool
+/// construction (`storage::utils::create_connection_pool`).
+#[derive(Debug, DisplaySimple, Serialize, Deserialize, Clone)]
+pub struct DatabaseConfig {
+    /// Database connection URL
+    pub url: String,
+    /// Maximum number of connections in the connection pool
+    pub max_connections: u32,
+}
 
 #[derive(DebugPretty, DisplaySimple, Serialize, Deserialize, Clone)]
 /// Authentication credentials for the IG Markets API
@@ -168,17 +181,5 @@ impl Config {
                 .filter(|&v| v == 2 || v == 3)
                 .or(Some(3)), // Default to API v3 (OAuth) if not specified
         }
-    }
-
-    /// Creates a PostgreSQL connection pool using the database configuration
-    ///
-    /// # Returns
-    ///
-    /// A Result containing either a PostgreSQL connection pool or an error
-    pub async fn pg_pool(&self) -> Result<sqlx::Pool<sqlx::Postgres>, sqlx::Error> {
-        PgPoolOptions::new()
-            .max_connections(self.database.max_connections)
-            .connect(&self.database.url)
-            .await
     }
 }

--- a/src/application/config.rs
+++ b/src/application/config.rs
@@ -14,12 +14,33 @@ use tracing::log::debug;
 /// can embed it in [`Config`] without depending on the storage layer. The
 /// storage layer re-exports it (see `storage::config`) and owns the actual pool
 /// construction (`storage::utils::create_connection_pool`).
-#[derive(Debug, DisplaySimple, Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct DatabaseConfig {
     /// Database connection URL
     pub url: String,
     /// Maximum number of connections in the connection pool
     pub max_connections: u32,
+}
+
+// The connection `url` commonly embeds a password, so `Debug`/`Display` must
+// never print it — they redact the URL and show only `max_connections`.
+impl std::fmt::Debug for DatabaseConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DatabaseConfig")
+            .field("url", &"<redacted>")
+            .field("max_connections", &self.max_connections)
+            .finish()
+    }
+}
+
+impl std::fmt::Display for DatabaseConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "DatabaseConfig {{ url: <redacted>, max_connections: {} }}",
+            self.max_connections
+        )
+    }
 }
 
 #[derive(DebugPretty, DisplaySimple, Serialize, Deserialize, Clone)]

--- a/src/application/http.rs
+++ b/src/application/http.rs
@@ -4,6 +4,14 @@
    Date: 20/10/25
 ******************************************************************************/
 
+//! HTTP client and request execution for the IG Markets API.
+//!
+//! This module owns all outbound HTTP I/O: the shared `reqwest` client, rate
+//! limiting, finite retry with backoff, and the automatic token
+//! refresh-and-replay contract. It lives in the `application` layer because it
+//! depends on `Auth`, `Session`, `Config` and `RateLimiter` — the pure `model`
+//! layer must not perform I/O.
+
 use crate::application::auth::{Auth, Session, WebsocketInfo};
 use crate::application::config::Config;
 use crate::application::rate_limiter::{RateLimitClass, RateLimiter};
@@ -382,7 +390,7 @@ impl Default for HttpClient {
 /// # Example
 ///
 /// ```ignore
-/// use ig_client::model::http::make_http_request;
+/// use ig_client::application::http::make_http_request;
 /// use ig_client::model::retry::RetryConfig;
 /// use reqwest::{Client, Method};
 ///

--- a/src/application/interfaces/account.rs
+++ b/src/application/interfaces/account.rs
@@ -1,8 +1,7 @@
 use crate::error::AppError;
-use crate::model::responses::AccountPreferencesResponse;
-use crate::prelude::{
-    AccountActivityResponse, AccountsResponse, PositionsResponse, TransactionHistoryResponse,
-    WorkingOrdersResponse,
+use crate::model::responses::{
+    AccountActivityResponse, AccountPreferencesResponse, AccountsResponse, PositionsResponse,
+    TransactionHistoryResponse, WorkingOrdersResponse,
 };
 use async_trait::async_trait;
 

--- a/src/application/market_hierarchy.rs
+++ b/src/application/market_hierarchy.rs
@@ -3,9 +3,19 @@
    Email: jb@taunais.com
    Date: 20/10/25
 ******************************************************************************/
-use crate::prelude::{
-    AppError, Client, IgResult, MarketData, MarketNavigationResponse, MarketNode, MarketService,
-};
+
+//! Market navigation hierarchy traversal.
+//!
+//! These helpers drive HTTP calls through `Client` (via the
+//! [`MarketService`](crate::application::interfaces::market::MarketService)
+//! trait), so they live in the application layer rather than the pure `model`
+//! layer.
+
+use crate::application::client::Client;
+use crate::application::interfaces::market::MarketService;
+use crate::error::AppError;
+use crate::model::responses::MarketNavigationResponse;
+use crate::presentation::market::{MarketData, MarketNode};
 use std::future::Future;
 use std::pin::Pin;
 use tracing::{debug, error, info};
@@ -19,11 +29,15 @@ use tracing::{debug, error, info};
 ///
 /// # Returns
 /// Vector of MarketNode representing the hierarchy at this level
+///
+/// # Errors
+/// Returns [`AppError`] when a navigation request fails with a non-recoverable
+/// error (rate limits and generic API errors degrade to partial results).
 pub fn build_market_hierarchy<'a>(
     client: &'a Client,
     node_id: Option<&'a str>,
     depth: usize,
-) -> Pin<Box<dyn Future<Output = IgResult<Vec<MarketNode>>> + 'a>> {
+) -> Pin<Box<dyn Future<Output = Result<Vec<MarketNode>, AppError>> + 'a>> {
     Box::pin(async move {
         // Limit the depth to avoid infinite loops
         if depth > 7 {

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -6,7 +6,13 @@ pub mod client;
 pub mod config;
 /// Dynamic market streamer with thread-safe subscription management
 pub mod dynamic_streamer;
+/// HTTP client and request execution with rate limiting and finite retry
+pub mod http;
 /// Service interfaces and traits
 pub mod interfaces;
+/// Market navigation hierarchy traversal helpers
+pub mod market_hierarchy;
 /// Rate limiter module for API request throttling
 pub mod rate_limiter;
+/// Adapters from Lightstreamer `ItemUpdate` to presentation-layer DTOs
+pub mod streaming_convert;

--- a/src/application/streaming_convert.rs
+++ b/src/application/streaming_convert.rs
@@ -1,0 +1,358 @@
+/******************************************************************************
+   Author: Joaquín Béjar García
+   Email: jb@taunais.com
+   Date: 20/10/25
+******************************************************************************/
+
+//! Adapters from Lightstreamer `ItemUpdate` to the presentation-layer DTOs.
+//!
+//! The presentation DTOs stay transport-agnostic: they expose pure
+//! `from_fields(..)` constructors that take plain field maps. This module is the
+//! only place that depends on `lightstreamer_rs`; it reads an `ItemUpdate` and
+//! feeds the extracted metadata / field maps into those pure constructors.
+//!
+//! Both a `Result`-returning function (for callers that want to observe parse
+//! failures) and the `From<&ItemUpdate>` conversions (which degrade to a default
+//! on failure, preserving the previous streaming behaviour) are provided per
+//! type.
+
+use crate::presentation::account::AccountData;
+use crate::presentation::chart::ChartData;
+use crate::presentation::market::{MarketFields, PresentationMarketData};
+use crate::presentation::price::PriceData;
+use crate::presentation::trade::TradeData;
+use lightstreamer_rs::subscription::ItemUpdate;
+use std::collections::HashMap;
+
+/// Converts Lightstreamer's `changed_fields` (`HashMap<String, String>`) into the
+/// `HashMap<String, Option<String>>` shape the pure field parsers consume, so a
+/// changed value is treated identically to a present full-snapshot value.
+#[must_use]
+fn changed_fields_as_options(changed: &HashMap<String, String>) -> HashMap<String, Option<String>> {
+    changed
+        .iter()
+        .map(|(key, value)| (key.clone(), Some(value.clone())))
+        .collect()
+}
+
+/// Converts a Lightstreamer `ItemUpdate` into a [`PriceData`].
+///
+/// # Errors
+/// Returns an error string when a field fails to parse (e.g. a non-numeric
+/// price or an unknown dealing flag).
+#[must_use = "the parse result must be handled"]
+pub fn price_data_from_item_update(item_update: &ItemUpdate) -> Result<PriceData, String> {
+    let changed_fields = changed_fields_as_options(&item_update.changed_fields);
+    PriceData::from_fields(
+        item_update.item_name.as_deref(),
+        item_update.item_pos,
+        item_update.is_snapshot,
+        &item_update.fields,
+        &changed_fields,
+    )
+}
+
+impl From<&ItemUpdate> for PriceData {
+    fn from(item_update: &ItemUpdate) -> Self {
+        price_data_from_item_update(item_update).unwrap_or_else(|e| {
+            tracing::warn!(error = %e, "failed to convert ItemUpdate to PriceData, returning default");
+            PriceData::default()
+        })
+    }
+}
+
+/// Converts a Lightstreamer `ItemUpdate` into a [`PresentationMarketData`].
+///
+/// # Errors
+/// Returns an error string when a field fails to parse (e.g. an unknown market
+/// state or an invalid `MARKET_DELAY` value).
+#[must_use = "the parse result must be handled"]
+pub fn market_data_from_item_update(
+    item_update: &ItemUpdate,
+) -> Result<PresentationMarketData, String> {
+    let changed_fields = changed_fields_as_options(&item_update.changed_fields);
+    PresentationMarketData::from_fields(
+        item_update.item_name.as_deref(),
+        item_update.item_pos,
+        item_update.is_snapshot,
+        &item_update.fields,
+        &changed_fields,
+    )
+}
+
+impl From<&ItemUpdate> for PresentationMarketData {
+    fn from(item_update: &ItemUpdate) -> Self {
+        market_data_from_item_update(item_update).unwrap_or_else(|_| PresentationMarketData {
+            item_name: String::new(),
+            item_pos: 0,
+            fields: MarketFields::default(),
+            changed_fields: MarketFields::default(),
+            is_snapshot: false,
+        })
+    }
+}
+
+/// Converts a Lightstreamer `ItemUpdate` into a [`ChartData`].
+///
+/// # Errors
+/// Returns an error string when a field fails to parse (e.g. a non-numeric
+/// candle value).
+#[must_use = "the parse result must be handled"]
+pub fn chart_data_from_item_update(item_update: &ItemUpdate) -> Result<ChartData, String> {
+    let changed_fields = changed_fields_as_options(&item_update.changed_fields);
+    ChartData::from_fields(
+        item_update.item_name.as_deref(),
+        item_update.item_pos,
+        item_update.is_snapshot,
+        &item_update.fields,
+        &changed_fields,
+    )
+}
+
+impl From<&ItemUpdate> for ChartData {
+    fn from(item_update: &ItemUpdate) -> Self {
+        chart_data_from_item_update(item_update).unwrap_or_default()
+    }
+}
+
+/// Converts a Lightstreamer `ItemUpdate` into a [`TradeData`].
+///
+/// # Errors
+/// Returns an error string when the embedded OPU / WOU JSON payload fails to
+/// parse.
+#[must_use = "the parse result must be handled"]
+pub fn trade_data_from_item_update(item_update: &ItemUpdate) -> Result<TradeData, String> {
+    let changed_fields = changed_fields_as_options(&item_update.changed_fields);
+    TradeData::from_fields(
+        item_update.item_name.as_deref(),
+        item_update.item_pos,
+        item_update.is_snapshot,
+        &item_update.fields,
+        &changed_fields,
+    )
+}
+
+impl From<&ItemUpdate> for TradeData {
+    fn from(item_update: &ItemUpdate) -> Self {
+        trade_data_from_item_update(item_update).unwrap_or_default()
+    }
+}
+
+/// Converts a Lightstreamer `ItemUpdate` into an [`AccountData`].
+///
+/// # Errors
+/// Returns an error string when a field fails to parse (e.g. a non-numeric P&L
+/// or margin value).
+#[must_use = "the parse result must be handled"]
+pub fn account_data_from_item_update(item_update: &ItemUpdate) -> Result<AccountData, String> {
+    let changed_fields = changed_fields_as_options(&item_update.changed_fields);
+    AccountData::from_fields(
+        item_update.item_name.as_deref(),
+        item_update.item_pos,
+        item_update.is_snapshot,
+        &item_update.fields,
+        &changed_fields,
+    )
+}
+
+impl From<&ItemUpdate> for AccountData {
+    fn from(item_update: &ItemUpdate) -> Self {
+        account_data_from_item_update(item_update).unwrap_or_else(|_| AccountData::default())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::presentation::order::{Direction, OrderType, Status, TimeInForce};
+
+    /// Builds an `ItemUpdate` carrying a single TRADE field, mirroring how the
+    /// Lightstreamer TRADE subscription delivers OPU / WOU / CONFIRMS payloads.
+    ///
+    /// `item_name`, `item_pos` and `is_snapshot` are set to distinctive,
+    /// obviously-synthetic values so tests can assert whether they survive the
+    /// parse (they are dropped on the silent-default path — see the malformed
+    /// test).
+    fn trade_item_update(field_key: &str, field_value: &str) -> ItemUpdate {
+        let mut fields = HashMap::new();
+        fields.insert(field_key.to_string(), Some(field_value.to_string()));
+        ItemUpdate {
+            item_name: Some("TRADE:SYNTHETIC".to_string()),
+            item_pos: 2,
+            fields,
+            changed_fields: HashMap::new(),
+            is_snapshot: true,
+        }
+    }
+
+    // Realistic, sanitized OPU payload. Field names mirror IG's Open Position
+    // Update stream (camelCase); the deal ids are obviously synthetic and carry
+    // no secret material.
+    const SANITIZED_OPU_JSON: &str = r#"{
+        "dealReference": "REF_SYNTHETIC_0001",
+        "dealId": "DIAAAAF00SYNTH01",
+        "dealIdOrigin": "DIAAAAF00SYNTH01",
+        "direction": "BUY",
+        "epic": "IX.D.DAX.DAILY.IP",
+        "status": "OPEN",
+        "dealStatus": "ACCEPTED",
+        "level": "18000.5",
+        "size": "1.0",
+        "currency": "EUR",
+        "timestamp": "2024-01-15T10:30:00.000",
+        "channel": "PublicRestOTC",
+        "expiry": "DFB"
+    }"#;
+
+    // Realistic, sanitized WOU payload. Field names mirror IG's Working Order
+    // Update stream (camelCase); the deal ids are obviously synthetic.
+    const SANITIZED_WOU_JSON: &str = r#"{
+        "dealReference": "REF_SYNTHETIC_0002",
+        "dealId": "DIAAAAF00SYNTH02",
+        "direction": "SELL",
+        "epic": "CS.D.EURUSD.CFD.IP",
+        "status": "OPEN",
+        "dealStatus": "ACCEPTED",
+        "level": "1.1000",
+        "size": "10000",
+        "currency": "USD",
+        "timestamp": "2024-01-15T10:31:00.000",
+        "channel": "PublicRestOTC",
+        "expiry": "-",
+        "stopDistance": "10.5",
+        "limitDistance": "20.0",
+        "guaranteedStop": false,
+        "orderType": "LIMIT",
+        "timeInForce": "GOOD_TILL_CANCELLED",
+        "goodTillDate": ""
+    }"#;
+
+    #[test]
+    fn test_trade_data_from_item_update_parses_open_position_update() {
+        let item = trade_item_update("OPU", SANITIZED_OPU_JSON);
+
+        let result = trade_data_from_item_update(&item);
+        assert!(result.is_ok(), "OPU payload should parse: {result:?}");
+        let data = result.expect("OPU parse checked ok above");
+
+        // Update metadata is preserved on the success path.
+        assert_eq!(data.item_name, "TRADE:SYNTHETIC");
+        assert_eq!(data.item_pos, 2);
+        assert!(data.is_snapshot);
+
+        let opu = data.fields.opu.expect("OPU should be populated");
+        assert_eq!(opu.deal_reference.as_deref(), Some("REF_SYNTHETIC_0001"));
+        assert_eq!(opu.deal_id.as_deref(), Some("DIAAAAF00SYNTH01"));
+        assert_eq!(opu.deal_id_origin.as_deref(), Some("DIAAAAF00SYNTH01"));
+        assert_eq!(opu.direction, Some(Direction::Buy));
+        assert_eq!(opu.epic.as_deref(), Some("IX.D.DAX.DAILY.IP"));
+        assert_eq!(opu.status, Some(Status::Open));
+        assert_eq!(opu.deal_status, Some(Status::Accepted));
+        assert_eq!(opu.level, Some(18000.5));
+        assert_eq!(opu.size, Some(1.0));
+        assert_eq!(opu.currency.as_deref(), Some("EUR"));
+        assert_eq!(opu.expiry.as_deref(), Some("DFB"));
+
+        // No WOU or CONFIRMS present in this update.
+        assert!(data.fields.wou.is_none());
+        assert!(data.fields.confirms.is_none());
+    }
+
+    #[test]
+    fn test_trade_data_from_item_update_parses_working_order_update() {
+        let item = trade_item_update("WOU", SANITIZED_WOU_JSON);
+
+        let result = trade_data_from_item_update(&item);
+        assert!(result.is_ok(), "WOU payload should parse: {result:?}");
+        let data = result.expect("WOU parse checked ok above");
+
+        let wou = data.fields.wou.expect("WOU should be populated");
+        assert_eq!(wou.deal_reference.as_deref(), Some("REF_SYNTHETIC_0002"));
+        assert_eq!(wou.deal_id.as_deref(), Some("DIAAAAF00SYNTH02"));
+        assert_eq!(wou.direction, Some(Direction::Sell));
+        assert_eq!(wou.epic.as_deref(), Some("CS.D.EURUSD.CFD.IP"));
+        assert_eq!(wou.status, Some(Status::Open));
+        assert_eq!(wou.deal_status, Some(Status::Accepted));
+        assert_eq!(wou.level, Some(1.1000));
+        assert_eq!(wou.size, Some(10000.0));
+        assert_eq!(wou.currency.as_deref(), Some("USD"));
+        assert_eq!(wou.stop_distance, Some(10.5));
+        assert_eq!(wou.limit_distance, Some(20.0));
+        assert_eq!(wou.guaranteed_stop, Some(false));
+        assert_eq!(wou.order_type, Some(OrderType::Limit));
+        assert_eq!(wou.time_in_force, Some(TimeInForce::GoodTillCancelled));
+        // Empty string good-till-date degrades to None.
+        assert!(wou.good_till_date.is_none());
+
+        // No OPU or CONFIRMS present in this update.
+        assert!(data.fields.opu.is_none());
+        assert!(data.fields.confirms.is_none());
+    }
+
+    #[test]
+    fn test_trade_data_from_item_update_malformed_opu_is_error_on_direct_path() {
+        let item = trade_item_update("OPU", "{ this is not valid json ");
+
+        // The direct parse path surfaces the failure as an Err.
+        let result = trade_data_from_item_update(&item);
+        assert!(
+            result.is_err(),
+            "malformed OPU JSON must surface an error on the direct parse path"
+        );
+    }
+
+    #[test]
+    fn test_trade_data_from_impl_swallows_malformed_opu_into_default() {
+        // KNOWN GAP (pinned, do not "fix" here): `From<&ItemUpdate>` funnels any
+        // parse failure through `.unwrap_or_default()`, so a malformed TRADE
+        // payload is silently swallowed into `TradeData::default()` instead of
+        // being surfaced. This test PINS that current behavior so a future change
+        // to make the swallow deliberate (e.g. logging, or propagating the error)
+        // is a conscious, reviewed decision rather than an accidental regression.
+        //
+        // TODO(streaming): decide whether `From<&ItemUpdate>` should log the
+        // dropped payload at WARN or expose the parse error instead of defaulting.
+        let item = trade_item_update("OPU", "{ this is not valid json ");
+
+        let data = TradeData::from(&item);
+
+        // Everything degrades to the Default, including the update metadata that
+        // was present on the source ItemUpdate (item_name / item_pos / snapshot).
+        assert!(
+            data.item_name.is_empty(),
+            "silent-default path discards item_name"
+        );
+        assert_eq!(data.item_pos, 0, "silent-default path discards item_pos");
+        assert!(
+            !data.is_snapshot,
+            "silent-default path discards is_snapshot"
+        );
+        assert!(data.fields.opu.is_none());
+        assert!(data.fields.wou.is_none());
+        assert!(data.fields.confirms.is_none());
+    }
+
+    #[test]
+    fn test_price_data_from_item_update_defaults_on_unknown_dealing_flag() {
+        // An unknown dealing flag makes the pure parser fail; the `From` impl
+        // degrades to `PriceData::default()` while the direct fn surfaces the Err.
+        let mut fields = HashMap::new();
+        fields.insert("DLG_FLAG".to_string(), Some("NOT_A_FLAG".to_string()));
+        let item = ItemUpdate {
+            item_name: Some("PRICE:CS.D.EURUSD.MINI.IP".to_string()),
+            item_pos: 1,
+            fields,
+            changed_fields: HashMap::new(),
+            is_snapshot: true,
+        };
+
+        assert!(price_data_from_item_update(&item).is_err());
+        // The `From` impl degrades to the default: metadata from the source
+        // update is discarded (matching the pre-refactor silent-default path).
+        let data = PriceData::from(&item);
+        assert!(data.item_name.is_empty());
+        assert_eq!(data.item_pos, 0);
+        assert!(!data.is_snapshot);
+        assert!(data.fields.dealing_flag.is_none());
+    }
+}

--- a/src/model/auth.rs
+++ b/src/model/auth.rs
@@ -3,12 +3,219 @@
    Email: jb@taunais.com
    Date: 19/10/25
 ******************************************************************************/
-use crate::application::auth::Session;
 use crate::constants::V2_SESSION_LIFETIME_SECS;
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use tracing::warn;
+
+/// WebSocket connection information for Lightstreamer
+///
+/// Contains the necessary credentials and endpoint information
+/// to establish a WebSocket connection to IG's Lightstreamer service.
+#[derive(Clone, Default, Serialize, Deserialize)]
+pub struct WebsocketInfo {
+    /// Lightstreamer endpoint URL
+    pub server: String,
+    /// CST token for authentication (API v2)
+    pub cst: Option<String>,
+    /// X-SECURITY-TOKEN for authentication (API v2)
+    pub x_security_token: Option<String>,
+    /// Account ID for the WebSocket connection
+    pub account_id: String,
+}
+
+/// Renders an optional secret as `Some(<redacted>)` / `None`, never exposing
+/// the underlying token value in `Debug` / `Display` output or logs.
+struct RedactedOption<'a>(&'a Option<String>);
+
+impl fmt::Debug for RedactedOption<'_> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.0 {
+            Some(_) => f.write_str("Some(<redacted>)"),
+            None => f.write_str("None"),
+        }
+    }
+}
+
+// Manual redacting `Debug` — `cst` / `x_security_token` are credentials and
+// must never reach logs or panics. All non-secret fields stay visible.
+impl fmt::Debug for WebsocketInfo {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("WebsocketInfo")
+            .field("server", &self.server)
+            .field("cst", &RedactedOption(&self.cst))
+            .field("x_security_token", &RedactedOption(&self.x_security_token))
+            .field("account_id", &self.account_id)
+            .finish()
+    }
+}
+
+// Manual redacting `Display` — the derived `DisplaySimple` serializes via serde
+// and would leak the tokens, so it is replaced with a masking implementation.
+impl fmt::Display for WebsocketInfo {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "WebsocketInfo {{ server: {}, cst: {:?}, x_security_token: {:?}, account_id: {} }}",
+            self.server,
+            RedactedOption(&self.cst),
+            RedactedOption(&self.x_security_token),
+            self.account_id,
+        )
+    }
+}
+
+impl WebsocketInfo {
+    /// Generates the WebSocket password for Lightstreamer authentication
+    ///
+    /// # Returns
+    /// * Password in format "CST-{cst}|XST-{token}" if both tokens are available
+    /// * Empty string if tokens are not available
+    #[must_use]
+    pub fn get_ws_password(&self) -> String {
+        match (&self.cst, &self.x_security_token) {
+            (Some(cst), Some(x_security_token)) => {
+                format!("CST-{}|XST-{}", cst, x_security_token)
+            }
+            _ => String::new(),
+        }
+    }
+}
+
+/// Session information for authenticated requests
+#[derive(Clone)]
+pub struct Session {
+    /// Account ID
+    pub account_id: String,
+    /// Client ID (for OAuth)
+    pub client_id: String,
+    /// Lightstreamer endpoint
+    pub lightstreamer_endpoint: String,
+    /// CST token (API v2)
+    pub cst: Option<String>,
+    /// X-SECURITY-TOKEN (API v2)
+    pub x_security_token: Option<String>,
+    /// OAuth token (API v3)
+    pub oauth_token: Option<OAuthToken>,
+    /// API version used
+    pub api_version: u8,
+    /// Unix timestamp when session expires (seconds since epoch)
+    /// - OAuth (v3): expires in 30 seconds
+    /// - API v2: expires in 6 hours (21600 seconds)
+    pub expires_at: u64,
+}
+
+// Manual redacting `Debug` — `cst`, `x_security_token` and the OAuth token are
+// credentials. The `OAuthToken` `Debug` impl is itself redacting, so printing
+// `oauth_token` here stays safe. All non-secret fields remain visible.
+impl fmt::Debug for Session {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Session")
+            .field("account_id", &self.account_id)
+            .field("client_id", &self.client_id)
+            .field("lightstreamer_endpoint", &self.lightstreamer_endpoint)
+            .field("cst", &RedactedOption(&self.cst))
+            .field("x_security_token", &RedactedOption(&self.x_security_token))
+            .field("oauth_token", &self.oauth_token)
+            .field("api_version", &self.api_version)
+            .field("expires_at", &self.expires_at)
+            .finish()
+    }
+}
+
+impl Session {
+    /// Checks if this session uses OAuth authentication
+    #[must_use]
+    #[inline]
+    pub fn is_oauth(&self) -> bool {
+        self.oauth_token.is_some()
+    }
+
+    /// Checks if session is expired or will expire soon
+    ///
+    /// # Arguments
+    /// * `margin_seconds` - Safety margin in seconds (default: 60 = 1 minute)
+    ///
+    /// # Returns
+    /// * `true` if session is expired or will expire within margin
+    /// * `false` if session is still valid
+    #[must_use]
+    #[inline]
+    pub fn is_expired(&self, margin_seconds: Option<u64>) -> bool {
+        let margin = margin_seconds.unwrap_or(60);
+        let now = u64::try_from(Utc::now().timestamp()).unwrap_or(0);
+        // Saturating: a large margin against a small `expires_at` must not
+        // underflow (debug panic / bogus huge threshold in release).
+        now >= self.expires_at.saturating_sub(margin)
+    }
+
+    /// Gets the number of whole seconds until the session expires.
+    ///
+    /// # Returns
+    /// * The number of seconds remaining before expiry.
+    /// * `0` when the session is already expired — the result saturates at zero
+    ///   (a `u64` cannot be negative), so an expired session never reports a
+    ///   spuriously large remaining time.
+    #[must_use]
+    #[inline]
+    pub fn seconds_until_expiry(&self) -> u64 {
+        let now = u64::try_from(Utc::now().timestamp()).unwrap_or(0);
+        self.expires_at.saturating_sub(now)
+    }
+
+    /// Returns the time remaining until the session expires as a
+    /// [`std::time::Duration`].
+    ///
+    /// # Returns
+    /// * The remaining time before expiry.
+    /// * [`std::time::Duration::ZERO`] when the session is already expired.
+    #[must_use]
+    #[inline]
+    pub fn time_until_expiry(&self) -> std::time::Duration {
+        std::time::Duration::from_secs(self.seconds_until_expiry())
+    }
+
+    /// Checks if OAuth token needs refresh (alias for is_expired for backwards compatibility)
+    ///
+    /// # Arguments
+    /// * `margin_seconds` - Safety margin in seconds (default: 60 = 1 minute)
+    #[must_use]
+    #[inline]
+    pub fn needs_token_refresh(&self, margin_seconds: Option<u64>) -> bool {
+        self.is_expired(margin_seconds)
+    }
+
+    /// Extracts WebSocket connection information from the session
+    ///
+    /// # Returns
+    /// * `WebsocketInfo` containing endpoint and authentication tokens
+    #[must_use]
+    pub fn get_websocket_info(&self) -> WebsocketInfo {
+        // Ensure the server URL has the https:// prefix
+        let server = if self.lightstreamer_endpoint.starts_with("http://")
+            || self.lightstreamer_endpoint.starts_with("https://")
+        {
+            format!("{}/lightstreamer", self.lightstreamer_endpoint)
+        } else {
+            format!("https://{}/lightstreamer", self.lightstreamer_endpoint)
+        };
+
+        WebsocketInfo {
+            server,
+            cst: self.cst.clone(),
+            x_security_token: self.x_security_token.clone(),
+            account_id: self.account_id.clone(),
+        }
+    }
+}
+
+impl From<SessionResponse> for Session {
+    fn from(v: SessionResponse) -> Self {
+        v.get_session()
+    }
+}
 
 /// Reports whether the effective expiry (`created_at + lifetime - margin`) has
 /// been reached as of `now`, using checked `chrono` arithmetic throughout.

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -5,8 +5,6 @@
 ******************************************************************************/
 /// Authentication models and session management
 pub mod auth;
-/// HTTP request utilities with rate limiting and retry
-pub mod http;
 /// Request models for API calls
 pub mod requests;
 /// Response models from API calls
@@ -15,5 +13,3 @@ pub mod responses;
 pub mod retry;
 /// Streaming data field definitions for real-time subscriptions
 pub mod streaming;
-/// Utility functions for models
-pub mod utils;

--- a/src/model/requests.rs
+++ b/src/model/requests.rs
@@ -4,10 +4,11 @@
    Date: 19/10/25
 ******************************************************************************/
 use crate::constants::{DEFAULT_ORDER_BUY_LEVEL, DEFAULT_ORDER_SELL_LEVEL};
-use crate::prelude::{Deserialize, Serialize, WorkingOrder};
+use crate::presentation::account::WorkingOrder;
 use crate::presentation::order::{Direction, OrderType, TimeInForce};
 use chrono::{Duration, Utc};
 use pretty_simple_display::{DebugPretty, DisplaySimple};
+use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::fmt::{Debug, Display};
 

--- a/src/model/responses.rs
+++ b/src/model/responses.rs
@@ -3,14 +3,14 @@
    Email: jb@taunais.com
    Date: 19/10/25
 ******************************************************************************/
-use crate::prelude::{Account, Activity, MarketDetails};
 use crate::presentation::account::{
-    AccountTransaction, ActivityMetadata, Position, TransactionMetadata, WorkingOrder,
+    Account, AccountTransaction, Activity, ActivityMetadata, Position, TransactionMetadata,
+    WorkingOrder,
 };
 use crate::presentation::instrument::InstrumentType;
 use crate::presentation::market::{
     Category, CategoryInstrument, CategoryInstrumentsMetadata, HistoricalPrice, MarketData,
-    MarketNavigationNode, MarketNode, PriceAllowance,
+    MarketDetails, MarketNavigationNode, MarketNode, PriceAllowance,
 };
 use crate::presentation::order::{Direction, Status};
 use crate::utils::parsing::{deserialize_null_as_empty_vec, deserialize_nullable_status};

--- a/src/model/retry.rs
+++ b/src/model/retry.rs
@@ -7,9 +7,9 @@ use crate::constants::{
     DEFAULT_MAX_RETRIES, DEFAULT_RETRY_DELAY_SECS, DEPRECATED_INFINITE_RETRY_CAP,
     MAX_RETRY_DELAY_SECS,
 };
-use crate::prelude::{Deserialize, Serialize};
 use crate::utils::config::get_env_or_none;
 use pretty_simple_display::{DebugPretty, DisplaySimple};
+use serde::{Deserialize, Serialize};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 /// Configuration for HTTP request retry behavior.

--- a/src/model/streaming.rs
+++ b/src/model/streaming.rs
@@ -12,7 +12,7 @@
 //! - Price data (detailed bid/ask levels)
 //! - Account data (P&L, margin, equity)
 
-use crate::prelude::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::fmt::{Debug, Display};
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -21,7 +21,7 @@
 pub use crate::application::client::Client;
 
 // HTTP client
-pub use crate::model::http::HttpClient;
+pub use crate::application::http::HttpClient;
 
 // Authentication
 pub use crate::application::auth::{Auth, Session};
@@ -64,7 +64,9 @@ pub use crate::utils::*;
 pub use async_trait::async_trait;
 pub use serde::{Deserialize, Serialize};
 
-pub use crate::model::utils::{build_market_hierarchy, extract_markets_from_hierarchy};
+pub use crate::application::market_hierarchy::{
+    build_market_hierarchy, extract_markets_from_hierarchy,
+};
 pub use crate::presentation::order::{Direction, Status};
 pub use crate::storage::market_database::MarketDatabaseService;
 

--- a/src/presentation/account.rs
+++ b/src/presentation/account.rs
@@ -2,7 +2,6 @@ use crate::presentation::instrument::InstrumentType;
 use crate::presentation::market::MarketState;
 use crate::presentation::order::{Direction, OrderType, Status, TimeInForce};
 use crate::presentation::serialization::string_as_float_opt;
-use lightstreamer_rs::subscription::ItemUpdate;
 use pretty_simple_display::{DebugPretty, DisplaySimple};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -883,36 +882,35 @@ pub struct AccountFields {
 }
 
 impl AccountData {
-    /// Converts an ItemUpdate from the Lightstreamer API to an AccountData object
+    /// Builds an [`AccountData`] from pre-extracted streaming fields.
+    ///
+    /// This is transport-agnostic: it takes plain field maps rather than a
+    /// Lightstreamer `ItemUpdate`, so the presentation layer carries no
+    /// dependency on the streaming transport. The `ItemUpdate` adapter lives in
+    /// [`crate::application::streaming_convert`].
     ///
     /// # Arguments
-    /// * `item_update` - The ItemUpdate received from the Lightstreamer API
+    /// * `item_name` - Subscription item name (`None` when subscribed by position)
+    /// * `item_pos` - 1-based position of the item in the subscription
+    /// * `is_snapshot` - Whether this update is a snapshot
+    /// * `fields` - Current field values for the item
+    /// * `changed_fields` - Field values that changed in this update
     ///
     /// # Returns
     /// * `Result<Self, String>` - The converted AccountData or an error message
-    pub fn from_item_update(item_update: &ItemUpdate) -> Result<Self, String> {
-        // Extract the item_name, defaulting to an empty string if None
-        let item_name = item_update.item_name.clone().unwrap_or_default();
-
-        // Convert item_pos from usize to i32
-        let item_pos = item_update.item_pos as i32;
-
-        // Extract is_snapshot
-        let is_snapshot = item_update.is_snapshot;
-
-        // Convert fields
-        let fields = Self::create_account_fields(&item_update.fields)?;
-
-        // Convert changed_fields by first creating a HashMap<String, Option<String>>
-        let mut changed_fields_map: HashMap<String, Option<String>> = HashMap::new();
-        for (key, value) in &item_update.changed_fields {
-            changed_fields_map.insert(key.clone(), Some(value.clone()));
-        }
-        let changed_fields = Self::create_account_fields(&changed_fields_map)?;
+    pub fn from_fields(
+        item_name: Option<&str>,
+        item_pos: usize,
+        is_snapshot: bool,
+        fields: &HashMap<String, Option<String>>,
+        changed_fields: &HashMap<String, Option<String>>,
+    ) -> Result<Self, String> {
+        let fields = Self::create_account_fields(fields)?;
+        let changed_fields = Self::create_account_fields(changed_fields)?;
 
         Ok(AccountData {
-            item_name,
-            item_pos,
+            item_name: item_name.unwrap_or_default().to_string(),
+            item_pos: item_pos as i32,
             fields,
             changed_fields,
             is_snapshot,
@@ -957,12 +955,6 @@ impl AccountData {
             equity: parse_float("EQUITY")?,
             equity_used: parse_float("EQUITY_USED")?,
         })
-    }
-}
-
-impl From<&ItemUpdate> for AccountData {
-    fn from(item_update: &ItemUpdate) -> Self {
-        Self::from_item_update(item_update).unwrap_or_else(|_| AccountData::default())
     }
 }
 

--- a/src/presentation/chart.rs
+++ b/src/presentation/chart.rs
@@ -1,5 +1,4 @@
 use crate::presentation::serialization::string_as_float_opt;
-use lightstreamer_rs::subscription::ItemUpdate;
 use pretty_simple_display::{DebugPretty, DisplaySimple};
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, fmt};
@@ -222,34 +221,45 @@ pub struct ChartFields {
 }
 
 impl ChartData {
-    /// Converts a Lightstreamer ItemUpdate to a ChartData object
+    /// Builds a [`ChartData`] from pre-extracted streaming fields.
+    ///
+    /// This is transport-agnostic: it takes plain field maps rather than a
+    /// Lightstreamer `ItemUpdate`, so the presentation layer carries no
+    /// dependency on the streaming transport. The `ItemUpdate` adapter lives in
+    /// [`crate::application::streaming_convert`]. The chart scale is derived from
+    /// the item name suffix (or the `{scale}` field as a fallback).
     ///
     /// # Arguments
-    ///
-    /// * `item_update` - The ItemUpdate from Lightstreamer containing chart data
+    /// * `item_name` - Subscription item name (`None` when subscribed by position)
+    /// * `item_pos` - 1-based position of the item in the subscription
+    /// * `is_snapshot` - Whether this update is a snapshot
+    /// * `fields` - Current field values for the item
+    /// * `changed_fields` - Field values that changed in this update
     ///
     /// # Returns
-    ///
     /// A Result containing either the parsed ChartData or an error message
-    pub fn from_item_update(item_update: &ItemUpdate) -> Result<Self, String> {
-        // Extract the item_name, defaulting to an empty string if None
-        let item_name = item_update.item_name.clone().unwrap_or_default();
-
+    pub fn from_fields(
+        item_name: Option<&str>,
+        item_pos: usize,
+        is_snapshot: bool,
+        fields: &HashMap<String, Option<String>>,
+        changed_fields: &HashMap<String, Option<String>>,
+    ) -> Result<Self, String> {
         // Determine the chart scale from the item name
-        let scale = if let Some(item_name) = &item_update.item_name {
-            if item_name.ends_with(":TICK") {
+        let scale = if let Some(name) = item_name {
+            if name.ends_with(":TICK") {
                 ChartScale::Tick
-            } else if item_name.ends_with(":SECOND") {
+            } else if name.ends_with(":SECOND") {
                 ChartScale::Second
-            } else if item_name.ends_with(":1MINUTE") {
+            } else if name.ends_with(":1MINUTE") {
                 ChartScale::OneMinute
-            } else if item_name.ends_with(":5MINUTE") {
+            } else if name.ends_with(":5MINUTE") {
                 ChartScale::FiveMinute
-            } else if item_name.ends_with(":HOUR") {
+            } else if name.ends_with(":HOUR") {
                 ChartScale::Hour
             } else {
                 // Try to determine the scale from a {scale} field if it exists
-                match item_update.fields.get("{scale}").and_then(|s| s.as_ref()) {
+                match fields.get("{scale}").and_then(|s| s.as_ref()) {
                     Some(s) if s == "SECOND" => ChartScale::Second,
                     Some(s) if s == "1MINUTE" => ChartScale::OneMinute,
                     Some(s) if s == "5MINUTE" => ChartScale::FiveMinute,
@@ -261,28 +271,16 @@ impl ChartData {
             ChartScale::default()
         };
 
-        // Convert item_pos from usize to i32
-        let item_pos = item_update.item_pos as i32;
-
-        // Extract is_snapshot
-        let is_snapshot = item_update.is_snapshot;
-
         // Convert fields
-        let fields = Self::create_chart_fields(&item_update.fields)?;
-
-        // Convert changed_fields by first creating a HashMap<String, Option<String>>
-        let mut changed_fields_map: HashMap<String, Option<String>> = HashMap::new();
-        for (key, value) in &item_update.changed_fields {
-            changed_fields_map.insert(key.clone(), Some(value.clone()));
-        }
-        let changed_fields = Self::create_chart_fields(&changed_fields_map)?;
+        let parsed_fields = Self::create_chart_fields(fields)?;
+        let parsed_changed_fields = Self::create_chart_fields(changed_fields)?;
 
         Ok(ChartData {
-            item_name,
-            item_pos,
+            item_name: item_name.unwrap_or_default().to_string(),
+            item_pos: item_pos as i32,
             scale,
-            fields,
-            changed_fields,
+            fields: parsed_fields,
+            changed_fields: parsed_changed_fields,
             is_snapshot,
         })
     }
@@ -352,12 +350,6 @@ impl ChartData {
     /// Gets the time scale of the data
     pub fn get_scale(&self) -> &ChartScale {
         &self.scale
-    }
-}
-
-impl From<&ItemUpdate> for ChartData {
-    fn from(item_update: &ItemUpdate) -> Self {
-        Self::from_item_update(item_update).unwrap_or_default()
     }
 }
 

--- a/src/presentation/market.rs
+++ b/src/presentation/market.rs
@@ -1,6 +1,5 @@
 use crate::presentation::instrument::InstrumentType;
 use crate::presentation::serialization::{string_as_bool_opt, string_as_float_opt};
-use lightstreamer_rs::subscription::ItemUpdate;
 use pretty_simple_display::{DebugPretty, DisplaySimple};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -407,36 +406,35 @@ pub struct PresentationMarketData {
 }
 
 impl PresentationMarketData {
-    /// Converts an ItemUpdate from the Lightstreamer API to a MarketData object
+    /// Builds a [`PresentationMarketData`] from pre-extracted streaming fields.
+    ///
+    /// This is transport-agnostic: it takes plain field maps rather than a
+    /// Lightstreamer `ItemUpdate`, so the presentation layer carries no
+    /// dependency on the streaming transport. The `ItemUpdate` adapter lives in
+    /// [`crate::application::streaming_convert`].
     ///
     /// # Arguments
-    /// * `item_update` - The ItemUpdate received from the Lightstreamer API
+    /// * `item_name` - Subscription item name (`None` when subscribed by position)
+    /// * `item_pos` - 1-based position of the item in the subscription
+    /// * `is_snapshot` - Whether this update is a snapshot
+    /// * `fields` - Current field values for the item
+    /// * `changed_fields` - Field values that changed in this update
     ///
     /// # Returns
     /// * `Result<Self, String>` - The converted MarketData or an error message
-    pub fn from_item_update(item_update: &ItemUpdate) -> Result<Self, String> {
-        // Extract the item_name, defaulting to an empty string if None
-        let item_name = item_update.item_name.clone().unwrap_or_default();
-
-        // Convert item_pos from usize to i32
-        let item_pos = item_update.item_pos as i32;
-
-        // Extract is_snapshot
-        let is_snapshot = item_update.is_snapshot;
-
-        // Convert fields
-        let fields = Self::create_market_fields(&item_update.fields)?;
-
-        // Convert changed_fields by first creating a HashMap<String, Option<String>>
-        let mut changed_fields_map: HashMap<String, Option<String>> = HashMap::new();
-        for (key, value) in &item_update.changed_fields {
-            changed_fields_map.insert(key.clone(), Some(value.clone()));
-        }
-        let changed_fields = Self::create_market_fields(&changed_fields_map)?;
+    pub fn from_fields(
+        item_name: Option<&str>,
+        item_pos: usize,
+        is_snapshot: bool,
+        fields: &HashMap<String, Option<String>>,
+        changed_fields: &HashMap<String, Option<String>>,
+    ) -> Result<Self, String> {
+        let fields = Self::create_market_fields(fields)?;
+        let changed_fields = Self::create_market_fields(changed_fields)?;
 
         Ok(PresentationMarketData {
-            item_name,
-            item_pos,
+            item_name: item_name.unwrap_or_default().to_string(),
+            item_pos: item_pos as i32,
             fields,
             changed_fields,
             is_snapshot,
@@ -501,18 +499,6 @@ impl PresentationMarketData {
             change_pct: parse_float("CHANGE_PCT")?,
             market_state,
             update_time: get_field("UPDATE_TIME"),
-        })
-    }
-}
-
-impl From<&ItemUpdate> for PresentationMarketData {
-    fn from(item_update: &ItemUpdate) -> Self {
-        Self::from_item_update(item_update).unwrap_or_else(|_| PresentationMarketData {
-            item_name: String::new(),
-            item_pos: 0,
-            fields: MarketFields::default(),
-            changed_fields: MarketFields::default(),
-            is_snapshot: false,
         })
     }
 }

--- a/src/presentation/price.rs
+++ b/src/presentation/price.rs
@@ -1,5 +1,4 @@
 use crate::presentation::serialization::string_as_float_opt;
-use lightstreamer_rs::subscription::ItemUpdate;
 use pretty_simple_display::{DebugPretty, DisplaySimple};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -603,38 +602,35 @@ pub struct PriceFields {
 }
 
 impl PriceData {
-    /// Converts a Lightstreamer ItemUpdate to a PriceData object
+    /// Builds a [`PriceData`] from pre-extracted streaming fields.
+    ///
+    /// This is transport-agnostic: it takes plain field maps rather than a
+    /// Lightstreamer `ItemUpdate`, so the presentation layer carries no
+    /// dependency on the streaming transport. The `ItemUpdate` adapter lives in
+    /// [`crate::application::streaming_convert`].
     ///
     /// # Arguments
-    ///
-    /// * `item_update` - The ItemUpdate from Lightstreamer containing price data
+    /// * `item_name` - Subscription item name (`None` when subscribed by position)
+    /// * `item_pos` - 1-based position of the item in the subscription
+    /// * `is_snapshot` - Whether this update is a snapshot
+    /// * `fields` - Current field values for the item
+    /// * `changed_fields` - Field values that changed in this update
     ///
     /// # Returns
-    ///
     /// A Result containing either the parsed PriceData or an error message
-    pub fn from_item_update(item_update: &ItemUpdate) -> Result<Self, String> {
-        // Extract the item_name, defaulting to an empty string if None
-        let item_name = item_update.item_name.clone().unwrap_or_default();
-
-        // Convert item_pos from usize to i32
-        let item_pos = item_update.item_pos as i32;
-
-        // Extract is_snapshot
-        let is_snapshot = item_update.is_snapshot;
-
-        // Convert fields
-        let fields = Self::create_price_fields(&item_update.fields)?;
-
-        // Convert changed_fields by first creating a HashMap<String, Option<String>>
-        let mut changed_fields_map: HashMap<String, Option<String>> = HashMap::new();
-        for (key, value) in &item_update.changed_fields {
-            changed_fields_map.insert(key.clone(), Some(value.clone()));
-        }
-        let changed_fields = Self::create_price_fields(&changed_fields_map)?;
+    pub fn from_fields(
+        item_name: Option<&str>,
+        item_pos: usize,
+        is_snapshot: bool,
+        fields: &HashMap<String, Option<String>>,
+        changed_fields: &HashMap<String, Option<String>>,
+    ) -> Result<Self, String> {
+        let fields = Self::create_price_fields(fields)?;
+        let changed_fields = Self::create_price_fields(changed_fields)?;
 
         Ok(PriceData {
-            item_name,
-            item_pos,
+            item_name: item_name.unwrap_or_default().to_string(),
+            item_pos: item_pos as i32,
             fields,
             changed_fields,
             is_snapshot,
@@ -799,15 +795,6 @@ impl PriceData {
             net_chg: parse_float("NET_CHG")?,
             net_chg_pct: parse_float("NET_CHG_PCT")?,
             delay: parse_float("DELAY")?,
-        })
-    }
-}
-
-impl From<&ItemUpdate> for PriceData {
-    fn from(item_update: &ItemUpdate) -> Self {
-        PriceData::from_item_update(item_update).unwrap_or_else(|e| {
-            tracing::warn!(error = %e, "failed to convert ItemUpdate to PriceData, returning default");
-            PriceData::default()
         })
     }
 }

--- a/src/presentation/trade.rs
+++ b/src/presentation/trade.rs
@@ -1,6 +1,5 @@
 use crate::presentation::order::{Direction, OrderType, Status, TimeInForce};
 use crate::presentation::serialization::{option_string_empty_as_none, string_as_float_opt};
-use lightstreamer_rs::subscription::ItemUpdate;
 use pretty_simple_display::{DebugPretty, DisplaySimple};
 use serde::{Deserialize, Serialize};
 use serde_json;
@@ -175,38 +174,35 @@ pub struct WorkingOrderUpdate {
 }
 
 impl TradeData {
-    /// Converts a Lightstreamer ItemUpdate to a TradeData object
+    /// Builds a [`TradeData`] from pre-extracted streaming fields.
+    ///
+    /// This is transport-agnostic: it takes plain field maps rather than a
+    /// Lightstreamer `ItemUpdate`, so the presentation layer carries no
+    /// dependency on the streaming transport. The `ItemUpdate` adapter lives in
+    /// [`crate::application::streaming_convert`].
     ///
     /// # Arguments
-    ///
-    /// * `item_update` - The ItemUpdate from Lightstreamer containing trade data
+    /// * `item_name` - Subscription item name (`None` when subscribed by position)
+    /// * `item_pos` - 1-based position of the item in the subscription
+    /// * `is_snapshot` - Whether this update is a snapshot
+    /// * `fields` - Current field values for the item
+    /// * `changed_fields` - Field values that changed in this update
     ///
     /// # Returns
-    ///
     /// A Result containing either the parsed TradeData or an error message
-    pub fn from_item_update(item_update: &ItemUpdate) -> Result<Self, String> {
-        // Extract the item_name, defaulting to an empty string if None
-        let item_name = item_update.item_name.clone().unwrap_or_default();
-
-        // Convert item_pos from usize to i32
-        let item_pos = item_update.item_pos as i32;
-
-        // Extract is_snapshot
-        let is_snapshot = item_update.is_snapshot;
-
-        // Convert fields
-        let fields = Self::create_trade_fields(&item_update.fields)?;
-
-        // Convert changed_fields by first creating a HashMap<String, Option<String>>
-        let mut changed_fields_map: HashMap<String, Option<String>> = HashMap::new();
-        for (key, value) in &item_update.changed_fields {
-            changed_fields_map.insert(key.clone(), Some(value.clone()));
-        }
-        let changed_fields = Self::create_trade_fields(&changed_fields_map)?;
+    pub fn from_fields(
+        item_name: Option<&str>,
+        item_pos: usize,
+        is_snapshot: bool,
+        fields: &HashMap<String, Option<String>>,
+        changed_fields: &HashMap<String, Option<String>>,
+    ) -> Result<Self, String> {
+        let fields = Self::create_trade_fields(fields)?;
+        let changed_fields = Self::create_trade_fields(changed_fields)?;
 
         Ok(TradeData {
-            item_name,
-            item_pos,
+            item_name: item_name.unwrap_or_default().to_string(),
+            item_pos: item_pos as i32,
             fields,
             changed_fields,
             is_snapshot,
@@ -262,34 +258,9 @@ impl TradeData {
     }
 }
 
-impl From<&ItemUpdate> for TradeData {
-    fn from(item_update: &ItemUpdate) -> Self {
-        Self::from_item_update(item_update).unwrap_or_default()
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    /// Builds an `ItemUpdate` carrying a single TRADE field, mirroring how the
-    /// Lightstreamer TRADE subscription delivers OPU / WOU / CONFIRMS payloads.
-    ///
-    /// `item_name`, `item_pos` and `is_snapshot` are set to distinctive,
-    /// obviously-synthetic values so tests can assert whether they survive the
-    /// parse (they are dropped on the silent-default path — see the malformed
-    /// test).
-    fn trade_item_update(field_key: &str, field_value: &str) -> ItemUpdate {
-        let mut fields = HashMap::new();
-        fields.insert(field_key.to_string(), Some(field_value.to_string()));
-        ItemUpdate {
-            item_name: Some("TRADE:SYNTHETIC".to_string()),
-            item_pos: 2,
-            fields,
-            changed_fields: HashMap::new(),
-            is_snapshot: true,
-        }
-    }
 
     // Realistic, sanitized OPU payload. Field names mirror IG's Open Position
     // Update stream (camelCase); the deal ids are obviously synthetic and carry
@@ -310,91 +281,6 @@ mod tests {
         "expiry": "DFB"
     }"#;
 
-    // Realistic, sanitized WOU payload. Field names mirror IG's Working Order
-    // Update stream (camelCase); the deal ids are obviously synthetic.
-    const SANITIZED_WOU_JSON: &str = r#"{
-        "dealReference": "REF_SYNTHETIC_0002",
-        "dealId": "DIAAAAF00SYNTH02",
-        "direction": "SELL",
-        "epic": "CS.D.EURUSD.CFD.IP",
-        "status": "OPEN",
-        "dealStatus": "ACCEPTED",
-        "level": "1.1000",
-        "size": "10000",
-        "currency": "USD",
-        "timestamp": "2024-01-15T10:31:00.000",
-        "channel": "PublicRestOTC",
-        "expiry": "-",
-        "stopDistance": "10.5",
-        "limitDistance": "20.0",
-        "guaranteedStop": false,
-        "orderType": "LIMIT",
-        "timeInForce": "GOOD_TILL_CANCELLED",
-        "goodTillDate": ""
-    }"#;
-
-    #[test]
-    fn test_from_item_update_parses_open_position_update() {
-        let item = trade_item_update("OPU", SANITIZED_OPU_JSON);
-
-        let result = TradeData::from_item_update(&item);
-        assert!(result.is_ok(), "OPU payload should parse: {result:?}");
-        let data = result.expect("OPU parse checked ok above");
-
-        // Update metadata is preserved on the success path.
-        assert_eq!(data.item_name, "TRADE:SYNTHETIC");
-        assert_eq!(data.item_pos, 2);
-        assert!(data.is_snapshot);
-
-        let opu = data.fields.opu.expect("OPU should be populated");
-        assert_eq!(opu.deal_reference.as_deref(), Some("REF_SYNTHETIC_0001"));
-        assert_eq!(opu.deal_id.as_deref(), Some("DIAAAAF00SYNTH01"));
-        assert_eq!(opu.deal_id_origin.as_deref(), Some("DIAAAAF00SYNTH01"));
-        assert_eq!(opu.direction, Some(Direction::Buy));
-        assert_eq!(opu.epic.as_deref(), Some("IX.D.DAX.DAILY.IP"));
-        assert_eq!(opu.status, Some(Status::Open));
-        assert_eq!(opu.deal_status, Some(Status::Accepted));
-        assert_eq!(opu.level, Some(18000.5));
-        assert_eq!(opu.size, Some(1.0));
-        assert_eq!(opu.currency.as_deref(), Some("EUR"));
-        assert_eq!(opu.expiry.as_deref(), Some("DFB"));
-
-        // No WOU or CONFIRMS present in this update.
-        assert!(data.fields.wou.is_none());
-        assert!(data.fields.confirms.is_none());
-    }
-
-    #[test]
-    fn test_from_item_update_parses_working_order_update() {
-        let item = trade_item_update("WOU", SANITIZED_WOU_JSON);
-
-        let result = TradeData::from_item_update(&item);
-        assert!(result.is_ok(), "WOU payload should parse: {result:?}");
-        let data = result.expect("WOU parse checked ok above");
-
-        let wou = data.fields.wou.expect("WOU should be populated");
-        assert_eq!(wou.deal_reference.as_deref(), Some("REF_SYNTHETIC_0002"));
-        assert_eq!(wou.deal_id.as_deref(), Some("DIAAAAF00SYNTH02"));
-        assert_eq!(wou.direction, Some(Direction::Sell));
-        assert_eq!(wou.epic.as_deref(), Some("CS.D.EURUSD.CFD.IP"));
-        assert_eq!(wou.status, Some(Status::Open));
-        assert_eq!(wou.deal_status, Some(Status::Accepted));
-        assert_eq!(wou.level, Some(1.1000));
-        assert_eq!(wou.size, Some(10000.0));
-        assert_eq!(wou.currency.as_deref(), Some("USD"));
-        assert_eq!(wou.stop_distance, Some(10.5));
-        assert_eq!(wou.limit_distance, Some(20.0));
-        assert_eq!(wou.guaranteed_stop, Some(false));
-        assert_eq!(wou.order_type, Some(OrderType::Limit));
-        assert_eq!(wou.time_in_force, Some(TimeInForce::GoodTillCancelled));
-        // Empty string good-till-date degrades to None.
-        assert!(wou.good_till_date.is_none());
-
-        // No OPU or CONFIRMS present in this update.
-        assert!(data.fields.opu.is_none());
-        assert!(data.fields.confirms.is_none());
-    }
-
     #[test]
     fn test_create_trade_fields_parses_opu_json() {
         // Exercise the JSON-parse helper directly (independent of ItemUpdate).
@@ -410,49 +296,6 @@ mod tests {
         let opu = fields.opu.expect("OPU should be populated");
         assert_eq!(opu.deal_id.as_deref(), Some("DIAAAAF00SYNTH01"));
         assert_eq!(opu.level, Some(18000.5));
-    }
-
-    #[test]
-    fn test_from_item_update_malformed_opu_is_error_on_direct_path() {
-        let item = trade_item_update("OPU", "{ this is not valid json ");
-
-        // The direct parse path surfaces the failure as an Err.
-        let result = TradeData::from_item_update(&item);
-        assert!(
-            result.is_err(),
-            "malformed OPU JSON must surface an error on the direct parse path"
-        );
-    }
-
-    #[test]
-    fn test_from_impl_swallows_malformed_opu_into_default() {
-        // KNOWN GAP (pinned, do not "fix" here): `From<&ItemUpdate>` funnels any
-        // parse failure through `.unwrap_or_default()`, so a malformed TRADE
-        // payload is silently swallowed into `TradeData::default()` instead of
-        // being surfaced. This test PINS that current behavior so a future change
-        // to make the swallow deliberate (e.g. logging, or propagating the error)
-        // is a conscious, reviewed decision rather than an accidental regression.
-        //
-        // TODO(streaming): decide whether `From<&ItemUpdate>` should log the
-        // dropped payload at WARN or expose the parse error instead of defaulting.
-        let item = trade_item_update("OPU", "{ this is not valid json ");
-
-        let data = TradeData::from(&item);
-
-        // Everything degrades to the Default, including the update metadata that
-        // was present on the source ItemUpdate (item_name / item_pos / snapshot).
-        assert!(
-            data.item_name.is_empty(),
-            "silent-default path discards item_name"
-        );
-        assert_eq!(data.item_pos, 0, "silent-default path discards item_pos");
-        assert!(
-            !data.is_snapshot,
-            "silent-default path discards is_snapshot"
-        );
-        assert!(data.fields.opu.is_none());
-        assert!(data.fields.wou.is_none());
-        assert!(data.fields.confirms.is_none());
     }
 
     #[test]

--- a/src/storage/config.rs
+++ b/src/storage/config.rs
@@ -1,11 +1,10 @@
-use pretty_simple_display::DisplaySimple;
-use serde::{Deserialize, Serialize};
+//! Database configuration for the storage layer.
+//!
+//! The `DatabaseConfig` data type is defined in `crate::application::config`
+//! (alongside the other `*Config` types, so [`crate::application::config::Config`]
+//! can embed it without an application → storage dependency). It is re-exported
+//! here to preserve the historical `crate::storage::config::DatabaseConfig`
+//! public path and to keep the storage-layer's pool construction co-located with
+//! the config it consumes.
 
-/// Configuration for database connections
-#[derive(Debug, DisplaySimple, Serialize, Deserialize, Clone)]
-pub struct DatabaseConfig {
-    /// Database connection URL
-    pub url: String,
-    /// Maximum number of connections in the connection pool
-    pub max_connections: u32,
-}
+pub use crate::application::config::DatabaseConfig;

--- a/src/storage/market_database.rs
+++ b/src/storage/market_database.rs
@@ -1,4 +1,4 @@
-use crate::prelude::{MarketData, MarketNode};
+use crate::presentation::market::{MarketData, MarketNode};
 use crate::storage::market_persistence::{MarketHierarchyNode, MarketInstrument};
 use chrono::{DateTime, Utc};
 use sqlx::{AssertSqlSafe, Executor, PgPool, Row};

--- a/tests/unit/application/test_auth_flow.rs
+++ b/tests/unit/application/test_auth_flow.rs
@@ -6,8 +6,8 @@ use ig_client::application::auth::Auth;
 use ig_client::application::config::{
     Config, Credentials, RateLimiterConfig, RestApiConfig, WebSocketConfig,
 };
+use ig_client::application::http::HttpClient;
 use ig_client::error::AppError;
-use ig_client::model::http::HttpClient;
 use ig_client::storage::config::DatabaseConfig;
 use std::sync::Arc;
 use wiremock::matchers::{method, path};

--- a/tests/unit/application/test_http_request.rs
+++ b/tests/unit/application/test_http_request.rs
@@ -5,9 +5,9 @@
 //! number of attempts (retries + 1).
 
 use ig_client::application::config::RateLimiterConfig;
+use ig_client::application::http::make_http_request;
 use ig_client::application::rate_limiter::RateLimiter;
 use ig_client::error::AppError;
-use ig_client::model::http::make_http_request;
 use ig_client::model::retry::RetryConfig;
 use reqwest::{Client, Method, StatusCode};
 use wiremock::matchers::{method, path};

--- a/tests/unit/presentation/test_account.rs
+++ b/tests/unit/presentation/test_account.rs
@@ -1,3 +1,4 @@
+use ig_client::application::streaming_convert::account_data_from_item_update;
 use ig_client::presentation::account::{AccountData, AccountFields};
 use lightstreamer_rs::subscription::ItemUpdate;
 use std::collections::HashMap;
@@ -24,7 +25,7 @@ fn test_account_data_from_item_update_empty() {
         changed_fields: HashMap::new(),
     };
 
-    let result = AccountData::from_item_update(&item_update);
+    let result = account_data_from_item_update(&item_update);
     assert!(result.is_ok());
 }
 
@@ -44,7 +45,7 @@ fn test_account_data_from_item_update_with_fields() {
         changed_fields: HashMap::new(),
     };
 
-    let result = AccountData::from_item_update(&item_update);
+    let result = account_data_from_item_update(&item_update);
     assert!(result.is_ok());
 }
 

--- a/tests/unit/presentation/test_chart.rs
+++ b/tests/unit/presentation/test_chart.rs
@@ -1,3 +1,4 @@
+use ig_client::application::streaming_convert::chart_data_from_item_update;
 use ig_client::presentation::chart::{ChartData, ChartFields};
 use lightstreamer_rs::subscription::ItemUpdate;
 use std::collections::HashMap;
@@ -24,7 +25,7 @@ fn test_chart_data_from_item_update_empty() {
         changed_fields: HashMap::new(),
     };
 
-    let result = ChartData::from_item_update(&item_update);
+    let result = chart_data_from_item_update(&item_update);
     assert!(result.is_ok());
 }
 
@@ -45,7 +46,7 @@ fn test_chart_data_from_item_update_with_fields() {
         changed_fields: HashMap::new(),
     };
 
-    let result = ChartData::from_item_update(&item_update);
+    let result = chart_data_from_item_update(&item_update);
     assert!(result.is_ok());
 }
 

--- a/tests/unit/presentation/test_price.rs
+++ b/tests/unit/presentation/test_price.rs
@@ -1,3 +1,4 @@
+use ig_client::application::streaming_convert::price_data_from_item_update;
 use ig_client::presentation::price::{DealingFlag, PriceData, PriceFields};
 use lightstreamer_rs::subscription::ItemUpdate;
 use std::collections::HashMap;
@@ -82,7 +83,7 @@ fn test_price_data_from_item_update_empty() {
         changed_fields: HashMap::new(),
     };
 
-    let result = PriceData::from_item_update(&item_update);
+    let result = price_data_from_item_update(&item_update);
     assert!(result.is_ok());
 }
 
@@ -100,7 +101,7 @@ fn test_price_data_from_item_update_with_bid_offer() {
         changed_fields: HashMap::new(),
     };
 
-    let result = PriceData::from_item_update(&item_update);
+    let result = price_data_from_item_update(&item_update);
     assert!(result.is_ok());
 
     let price_data = result.unwrap();
@@ -130,7 +131,7 @@ fn test_price_data_from_item_update_with_all_fields() {
         changed_fields: HashMap::new(),
     };
 
-    let result = PriceData::from_item_update(&item_update);
+    let result = price_data_from_item_update(&item_update);
     assert!(result.is_ok());
 }
 
@@ -147,7 +148,7 @@ fn test_price_data_from_item_update_invalid_float() {
         changed_fields: HashMap::new(),
     };
 
-    let result = PriceData::from_item_update(&item_update);
+    let result = price_data_from_item_update(&item_update);
     // An unparseable float in a numeric field is a hard error: `parse_float`
     // fails and the error propagates out of `from_item_update`. The message
     // names the offending field and value.
@@ -177,7 +178,7 @@ fn test_price_data_from_item_update_empty_strings() {
         changed_fields: HashMap::new(),
     };
 
-    let result = PriceData::from_item_update(&item_update);
+    let result = price_data_from_item_update(&item_update);
     assert!(result.is_ok());
 }
 
@@ -197,7 +198,7 @@ fn test_price_data_from_item_update_with_changed_fields() {
         changed_fields,
     };
 
-    let result = PriceData::from_item_update(&item_update);
+    let result = price_data_from_item_update(&item_update);
     assert!(result.is_ok());
 }
 
@@ -231,7 +232,7 @@ fn test_price_data_from_item_update_empty_dlg_flag_is_none() {
         changed_fields: HashMap::new(),
     };
 
-    let result = PriceData::from_item_update(&item_update);
+    let result = price_data_from_item_update(&item_update);
     assert!(result.is_ok(), "empty DLG_FLAG should not cause an error");
     let price_data = result.unwrap();
     assert!(
@@ -253,7 +254,7 @@ fn test_price_data_from_item_update_closingsonly_flag() {
         changed_fields: HashMap::new(),
     };
 
-    let result = PriceData::from_item_update(&item_update);
+    let result = price_data_from_item_update(&item_update);
     assert!(result.is_ok());
     let price_data = result.unwrap();
     assert_eq!(
@@ -276,7 +277,7 @@ fn test_price_data_from_item_update_closingonly_backward_compat() {
         changed_fields: HashMap::new(),
     };
 
-    let result = PriceData::from_item_update(&item_update);
+    let result = price_data_from_item_update(&item_update);
     assert!(result.is_ok());
     let price_data = result.unwrap();
     assert_eq!(
@@ -301,7 +302,7 @@ fn test_price_data_from_item_update_with_net_chg_fields() {
         changed_fields: HashMap::new(),
     };
 
-    let result = PriceData::from_item_update(&item_update);
+    let result = price_data_from_item_update(&item_update);
     assert!(result.is_ok());
 
     let price_data = result.unwrap();
@@ -344,7 +345,7 @@ fn test_price_data_from_item_update_dlg_flag_with_trailing_spaces() {
         changed_fields: HashMap::new(),
     };
 
-    let result = PriceData::from_item_update(&item_update);
+    let result = price_data_from_item_update(&item_update);
     assert!(
         result.is_ok(),
         "DLG_FLAG with trailing spaces should not error"

--- a/tests/unit/presentation/test_trade.rs
+++ b/tests/unit/presentation/test_trade.rs
@@ -1,3 +1,4 @@
+use ig_client::application::streaming_convert::trade_data_from_item_update;
 use ig_client::presentation::trade::{TradeData, TradeFields};
 use lightstreamer_rs::subscription::ItemUpdate;
 use std::collections::HashMap;
@@ -36,7 +37,7 @@ fn test_trade_data_from_item_update_empty() {
         changed_fields: HashMap::new(),
     };
 
-    let result = TradeData::from_item_update(&item_update);
+    let result = trade_data_from_item_update(&item_update);
     assert!(result.is_ok());
 }
 
@@ -53,7 +54,7 @@ fn test_trade_data_from_item_update_with_confirms() {
         changed_fields: HashMap::new(),
     };
 
-    let result = TradeData::from_item_update(&item_update);
+    let result = trade_data_from_item_update(&item_update);
     assert!(result.is_ok());
 }
 

--- a/tests/unit/utils/test_model_utils.rs
+++ b/tests/unit/utils/test_model_utils.rs
@@ -1,4 +1,4 @@
-use ig_client::model::utils::extract_markets_from_hierarchy;
+use ig_client::application::market_hierarchy::extract_markets_from_hierarchy;
 use ig_client::prelude::{MarketData, MarketNode};
 use ig_client::presentation::instrument::InstrumentType;
 


### PR DESCRIPTION
## Summary

CLAUDE.md declares `model/` and `presentation/` pure DTO layers, forbids `application/` → `storage/`, and bans internal `crate::prelude` imports. Every one of those boundaries was violated: the full `HttpClient` lived in `model/`, `model/utils.rs` did REST calls, `model/auth.rs` imported the application layer, `application/config.rs` depended on sqlx/storage, five presentation modules imported `lightstreamer_rs`, and nine files imported through the prelude. This PR restores the boundaries. Part of 0.12.0 (breaking, via re-exports where cheap).

## Changes

- `HttpClient` + `make_http_request` moved `model/http.rs` → `application/http.rs` (re-exported, public path unchanged).
- `build/extract_market_hierarchy` moved `model/utils.rs` → `application/market_hierarchy.rs`; `model/utils.rs` deleted.
- `Session` / `WebsocketInfo` (plain data) moved `application/auth.rs` → `model/auth.rs`, re-exported from `application::auth` so `ig_client::application::auth::Session` still resolves.
- `DatabaseConfig` moved into `application/config.rs` (`storage::config` re-exports it); `Config::pg_pool()` removed (was `application` → `sqlx`) — callers use `storage::utils::create_connection_pool`.
- The five `From<&ItemUpdate>` impls moved out of `presentation/*` into `application/streaming_convert.rs`; presentation DTOs expose pure `from_fields` constructors and no longer import `lightstreamer_rs`.
- Nine files switched from `crate::prelude` to direct module paths.

## Verification

- `grep crate::prelude src/` (excl prelude.rs/lib.rs) → **empty**
- `grep reqwest|sqlx|lightstreamer` in `model/` + `presentation/` → **empty**
- `grep storage` imports in `application/` + `model/` → **empty**
- `cargo semver-checks` passes at 0.12.0; `make pre-push` clean; 240 lib + 206 unit tests pass; workspace builds.

## Public API impact (breaking — 0.12.0, mostly preserved)

Types stay reachable at their public paths via re-exports. `Config::pg_pool()` removed; presentation types no longer implement `From<&ItemUpdate>` (the conversion moved to `application`). CLAUDE.md architecture listing updated.

Closes #47
