### PR TITLE
fix(errors): wire typed errors, preserve context, redact auth bodies (#49)

### DIFF
--- a/src/application/auth.rs
+++ b/src/application/auth.rs
@@ -16,7 +16,7 @@ use crate::application::config::Config;
 use crate::application::http::make_http_request;
 use crate::application::rate_limiter::RateLimiter;
 use crate::constants::USER_AGENT;
-use crate::error::AppError;
+use crate::error::{AppError, AuthError};
 pub(crate) use crate::model::auth::{SecurityHeaders, SessionResponse};
 use crate::model::retry::RetryConfig;
 use reqwest::{Client, Method};
@@ -334,8 +334,10 @@ impl Auth {
         {
             Some(token) => token,
             None => {
-                error!("CST header not found in response");
-                return Err(AppError::InvalidInput("CST missing".to_string()));
+                // A rejected / malformed auth response, not bad caller input:
+                // surface a typed auth error naming the missing header.
+                error!("missing cst header in login response");
+                return Err(AuthError::MissingSessionToken("cst".to_string()).into());
             }
         };
         let x_security_token: String = match response
@@ -346,10 +348,10 @@ impl Auth {
         {
             Some(token) => token,
             None => {
-                error!("X-SECURITY-TOKEN header not found in response");
-                return Err(AppError::InvalidInput(
-                    "X-SECURITY-TOKEN missing".to_string(),
-                ));
+                // A rejected / malformed auth response, not bad caller input:
+                // surface a typed auth error naming the missing header.
+                error!("missing x-security-token header in login response");
+                return Err(AuthError::MissingSessionToken("x-security-token".to_string()).into());
             }
         };
 

--- a/src/application/http.rs
+++ b/src/application/http.rs
@@ -310,9 +310,42 @@ impl HttpClient {
         .await
     }
 
-    /// Parses response
+    /// Deserializes a successful HTTP response body into the target DTO,
+    /// attaching request context when parsing fails.
+    ///
+    /// On a deserialization failure the returned [`AppError::Deserialization`]
+    /// names the endpoint URL, the HTTP status, and the serde error, so DTO
+    /// drift is diagnosable instead of surfacing as a bare serde message.
+    ///
+    /// For non-`/session` endpoints a truncated body snippet is appended to the
+    /// message. The `/session` endpoints are auth-adjacent — their bodies can
+    /// carry credentials / CST / X-SECURITY-TOKEN / OAuth tokens — so their body
+    /// is deliberately never echoed into the error (status + URL + serde error
+    /// only).
+    ///
+    /// # Errors
+    /// Returns [`AppError::Network`] if the body cannot be read, and
+    /// [`AppError::Deserialization`] if the body cannot be parsed into `T`.
     async fn parse_response<T: DeserializeOwned>(&self, response: Response) -> Result<T, AppError> {
-        Ok(response.json().await?)
+        let status = response.status();
+        let url = response.url().clone();
+        // Buffer the body once so a parse failure can be reported with context;
+        // `json()` would consume the body and leave nothing to snippet.
+        let text = response.text().await?;
+
+        serde_json::from_str(&text).map_err(|e| {
+            // `/session` bodies are auth-adjacent and may carry tokens: never
+            // echo them. Every other endpoint gets a truncated snippet to help
+            // diagnose DTO drift against the real IG payload.
+            if is_auth_endpoint(url.path()) {
+                AppError::Deserialization(format!("failed to deserialize {url} ({status}): {e}"))
+            } else {
+                let snippet = truncate_body_snippet(&text);
+                AppError::Deserialization(format!(
+                    "failed to deserialize {url} ({status}): {e}; body: {snippet}"
+                ))
+            }
+        })
     }
 
     /// Switches to a different trading account
@@ -551,6 +584,38 @@ pub async fn make_http_request<B: Serialize>(
     Err(AppError::RateLimitExceeded)
 }
 
+/// Maximum number of characters of a response body echoed into a
+/// deserialization error message.
+///
+/// Long enough to spot the offending field against the real IG payload, short
+/// enough to keep error messages and logs bounded.
+const BODY_SNIPPET_MAX_CHARS: usize = 500;
+
+/// Returns whether `path` targets the auth-adjacent `/session` endpoint, whose
+/// response body can carry credentials / session tokens and must never be
+/// echoed into an error message.
+#[must_use]
+#[inline]
+fn is_auth_endpoint(path: &str) -> bool {
+    path.contains("/session")
+}
+
+/// Truncates a response body to at most [`BODY_SNIPPET_MAX_CHARS`] characters
+/// for inclusion in an error message.
+///
+/// Truncation is on `char` boundaries so it never splits a UTF-8 code point;
+/// a truncation marker is appended when the body was longer than the limit.
+#[must_use]
+#[inline]
+fn truncate_body_snippet(body: &str) -> String {
+    match body.char_indices().nth(BODY_SNIPPET_MAX_CHARS) {
+        // `idx` is the byte offset of the (limit+1)-th char, so `..idx` keeps
+        // exactly `BODY_SNIPPET_MAX_CHARS` chars on a valid boundary.
+        Some((idx, _)) => format!("{}... (truncated)", &body[..idx]),
+        None => body.to_string(),
+    }
+}
+
 /// Classification of an HTTP status code for retry decisions.
 ///
 /// Body-dependent statuses (401, 403) are handled separately in
@@ -705,6 +770,145 @@ mod tests {
         assert_eq!(
             classify_status(StatusCode::CONFLICT),
             StatusClass::Permanent
+        );
+    }
+
+    #[test]
+    fn test_truncate_body_snippet_short_body_is_unchanged() {
+        let body = r#"{"errorCode":"validation.null-not-allowed.request.epic"}"#;
+        assert_eq!(super::truncate_body_snippet(body), body);
+    }
+
+    #[test]
+    fn test_truncate_body_snippet_long_body_is_truncated_on_char_boundary() {
+        // A multi-byte char repeated past the limit must not be split.
+        let body = "é".repeat(super::BODY_SNIPPET_MAX_CHARS + 50);
+        let snippet = super::truncate_body_snippet(&body);
+        assert!(snippet.ends_with("... (truncated)"));
+        // The kept prefix is exactly the char limit (each `é` is 2 bytes).
+        let kept = snippet.trim_end_matches("... (truncated)");
+        assert_eq!(kept.chars().count(), super::BODY_SNIPPET_MAX_CHARS);
+    }
+
+    #[test]
+    fn test_is_auth_endpoint_matches_session_paths_only() {
+        assert!(super::is_auth_endpoint("/gateway/deal/session"));
+        assert!(super::is_auth_endpoint("/session"));
+        assert!(!super::is_auth_endpoint(
+            "/gateway/deal/markets/CS.D.EURUSD.MINI.IP"
+        ));
+    }
+
+    /// A DTO with a required field, used to force a deserialization failure
+    /// against an unexpected IG payload shape.
+    #[derive(Debug, serde::Deserialize)]
+    struct RequiredFieldDto {
+        #[allow(dead_code)]
+        instrument_type: String,
+    }
+
+    #[tokio::test]
+    async fn test_parse_response_malformed_body_includes_status_and_snippet() {
+        use super::HttpClient;
+        use crate::error::AppError;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        // A 200 whose body does not match the target DTO (DTO drift).
+        Mock::given(method("GET"))
+            .and(path("/markets/CS.D.EURUSD.MINI.IP"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(
+                r#"{"unexpectedField":"surprise","another":"drifted"}"#,
+                "application/json",
+            ))
+            .mount(&server)
+            .await;
+
+        let url = format!("{}/markets/CS.D.EURUSD.MINI.IP", server.uri());
+        let response = reqwest::Client::new()
+            .get(&url)
+            .send()
+            .await
+            .expect("request should reach the mock server");
+
+        let client = HttpClient::default();
+        let result: Result<RequiredFieldDto, AppError> = client.parse_response(response).await;
+
+        let msg = match result {
+            Err(AppError::Deserialization(msg)) => msg,
+            other => panic!("expected AppError::Deserialization, got {other:?}"),
+        };
+        // Status, endpoint, and a body snippet all present.
+        assert!(
+            msg.contains("200"),
+            "error should carry the HTTP status: {msg}"
+        );
+        assert!(
+            msg.contains("/markets/"),
+            "error should carry the endpoint URL: {msg}"
+        );
+        assert!(
+            msg.contains("body:"),
+            "error should carry a body snippet: {msg}"
+        );
+        assert!(
+            msg.contains("unexpectedField"),
+            "error should include the malformed body snippet: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_parse_response_session_endpoint_omits_body_snippet() {
+        use super::HttpClient;
+        use crate::error::AppError;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        // A /session body that fails to deserialize into the target DTO but
+        // carries a token-shaped secret. The error must NOT echo the body.
+        const SECRET: &str = "SUPER-SECRET-OAUTH-TOKEN-VALUE";
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/session"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(
+                format!(r#"{{"oauthToken":{{"access_token":"{SECRET}"}}}}"#),
+                "application/json",
+            ))
+            .mount(&server)
+            .await;
+
+        let url = format!("{}/session", server.uri());
+        let response = reqwest::Client::new()
+            .post(&url)
+            .send()
+            .await
+            .expect("request should reach the mock server");
+
+        let client = HttpClient::default();
+        let result: Result<RequiredFieldDto, AppError> = client.parse_response(response).await;
+
+        let msg = match result {
+            Err(AppError::Deserialization(msg)) => msg,
+            other => panic!("expected AppError::Deserialization, got {other:?}"),
+        };
+        // Status and endpoint are present for diagnosis...
+        assert!(
+            msg.contains("200"),
+            "error should carry the HTTP status: {msg}"
+        );
+        assert!(
+            msg.contains("/session"),
+            "error should carry the endpoint URL: {msg}"
+        );
+        // ...but the auth-adjacent body (and any token in it) is NOT echoed.
+        assert!(
+            !msg.contains("body:"),
+            "session errors must not include a body snippet: {msg}"
+        );
+        assert!(
+            !msg.contains(SECRET),
+            "session errors must never leak token material: {msg}"
         );
     }
 }

--- a/src/application/http.rs
+++ b/src/application/http.rs
@@ -608,12 +608,20 @@ fn is_auth_endpoint(path: &str) -> bool {
 #[must_use]
 #[inline]
 fn truncate_body_snippet(body: &str) -> String {
-    match body.char_indices().nth(BODY_SNIPPET_MAX_CHARS) {
+    let truncated = match body.char_indices().nth(BODY_SNIPPET_MAX_CHARS) {
         // `idx` is the byte offset of the (limit+1)-th char, so `..idx` keeps
         // exactly `BODY_SNIPPET_MAX_CHARS` chars on a valid boundary.
         Some((idx, _)) => format!("{}... (truncated)", &body[..idx]),
         None => body.to_string(),
-    }
+    };
+    // Keep the snippet on one line: the error string is logged, so raw
+    // newlines / control characters would fragment the log record and allow
+    // log-injection-style confusion. Escape CR/LF/TAB to their literal forms.
+    truncated
+        .replace('\\', "\\\\")
+        .replace('\r', "\\r")
+        .replace('\n', "\\n")
+        .replace('\t', "\\t")
 }
 
 /// Classification of an HTTP status code for retry decisions.

--- a/src/application/streaming_convert.rs
+++ b/src/application/streaming_convert.rs
@@ -16,6 +16,7 @@
 //! on failure, preserving the previous streaming behaviour) are provided per
 //! type.
 
+use crate::error::AppError;
 use crate::presentation::account::AccountData;
 use crate::presentation::chart::ChartData;
 use crate::presentation::market::{MarketFields, PresentationMarketData};
@@ -38,10 +39,11 @@ fn changed_fields_as_options(changed: &HashMap<String, String>) -> HashMap<Strin
 /// Converts a Lightstreamer `ItemUpdate` into a [`PriceData`].
 ///
 /// # Errors
-/// Returns an error string when a field fails to parse (e.g. a non-numeric
-/// price or an unknown dealing flag).
+/// Returns [`AppError::Deserialization`] when a field fails to parse (e.g. a
+/// non-numeric price or an unknown dealing flag). The message names the
+/// offending field and value.
 #[must_use = "the parse result must be handled"]
-pub fn price_data_from_item_update(item_update: &ItemUpdate) -> Result<PriceData, String> {
+pub fn price_data_from_item_update(item_update: &ItemUpdate) -> Result<PriceData, AppError> {
     let changed_fields = changed_fields_as_options(&item_update.changed_fields);
     PriceData::from_fields(
         item_update.item_name.as_deref(),
@@ -50,6 +52,7 @@ pub fn price_data_from_item_update(item_update: &ItemUpdate) -> Result<PriceData
         &item_update.fields,
         &changed_fields,
     )
+    .map_err(AppError::Deserialization)
 }
 
 impl From<&ItemUpdate> for PriceData {
@@ -64,12 +67,12 @@ impl From<&ItemUpdate> for PriceData {
 /// Converts a Lightstreamer `ItemUpdate` into a [`PresentationMarketData`].
 ///
 /// # Errors
-/// Returns an error string when a field fails to parse (e.g. an unknown market
-/// state or an invalid `MARKET_DELAY` value).
+/// Returns [`AppError::Deserialization`] when a field fails to parse (e.g. an
+/// unknown market state or an invalid `MARKET_DELAY` value).
 #[must_use = "the parse result must be handled"]
 pub fn market_data_from_item_update(
     item_update: &ItemUpdate,
-) -> Result<PresentationMarketData, String> {
+) -> Result<PresentationMarketData, AppError> {
     let changed_fields = changed_fields_as_options(&item_update.changed_fields);
     PresentationMarketData::from_fields(
         item_update.item_name.as_deref(),
@@ -78,6 +81,7 @@ pub fn market_data_from_item_update(
         &item_update.fields,
         &changed_fields,
     )
+    .map_err(AppError::Deserialization)
 }
 
 impl From<&ItemUpdate> for PresentationMarketData {
@@ -95,10 +99,10 @@ impl From<&ItemUpdate> for PresentationMarketData {
 /// Converts a Lightstreamer `ItemUpdate` into a [`ChartData`].
 ///
 /// # Errors
-/// Returns an error string when a field fails to parse (e.g. a non-numeric
-/// candle value).
+/// Returns [`AppError::Deserialization`] when a field fails to parse (e.g. a
+/// non-numeric candle value).
 #[must_use = "the parse result must be handled"]
-pub fn chart_data_from_item_update(item_update: &ItemUpdate) -> Result<ChartData, String> {
+pub fn chart_data_from_item_update(item_update: &ItemUpdate) -> Result<ChartData, AppError> {
     let changed_fields = changed_fields_as_options(&item_update.changed_fields);
     ChartData::from_fields(
         item_update.item_name.as_deref(),
@@ -107,6 +111,7 @@ pub fn chart_data_from_item_update(item_update: &ItemUpdate) -> Result<ChartData
         &item_update.fields,
         &changed_fields,
     )
+    .map_err(AppError::Deserialization)
 }
 
 impl From<&ItemUpdate> for ChartData {
@@ -118,10 +123,10 @@ impl From<&ItemUpdate> for ChartData {
 /// Converts a Lightstreamer `ItemUpdate` into a [`TradeData`].
 ///
 /// # Errors
-/// Returns an error string when the embedded OPU / WOU JSON payload fails to
-/// parse.
+/// Returns [`AppError::Deserialization`] when the embedded OPU / WOU JSON
+/// payload fails to parse.
 #[must_use = "the parse result must be handled"]
-pub fn trade_data_from_item_update(item_update: &ItemUpdate) -> Result<TradeData, String> {
+pub fn trade_data_from_item_update(item_update: &ItemUpdate) -> Result<TradeData, AppError> {
     let changed_fields = changed_fields_as_options(&item_update.changed_fields);
     TradeData::from_fields(
         item_update.item_name.as_deref(),
@@ -130,6 +135,7 @@ pub fn trade_data_from_item_update(item_update: &ItemUpdate) -> Result<TradeData
         &item_update.fields,
         &changed_fields,
     )
+    .map_err(AppError::Deserialization)
 }
 
 impl From<&ItemUpdate> for TradeData {
@@ -141,10 +147,10 @@ impl From<&ItemUpdate> for TradeData {
 /// Converts a Lightstreamer `ItemUpdate` into an [`AccountData`].
 ///
 /// # Errors
-/// Returns an error string when a field fails to parse (e.g. a non-numeric P&L
-/// or margin value).
+/// Returns [`AppError::Deserialization`] when a field fails to parse (e.g. a
+/// non-numeric P&L or margin value).
 #[must_use = "the parse result must be handled"]
-pub fn account_data_from_item_update(item_update: &ItemUpdate) -> Result<AccountData, String> {
+pub fn account_data_from_item_update(item_update: &ItemUpdate) -> Result<AccountData, AppError> {
     let changed_fields = changed_fields_as_options(&item_update.changed_fields);
     AccountData::from_fields(
         item_update.item_name.as_deref(),
@@ -153,6 +159,7 @@ pub fn account_data_from_item_update(item_update: &ItemUpdate) -> Result<Account
         &item_update.fields,
         &changed_fields,
     )
+    .map_err(AppError::Deserialization)
 }
 
 impl From<&ItemUpdate> for AccountData {

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,7 +6,18 @@
 use reqwest::StatusCode;
 use std::io;
 
-/// Error type for fetch operations
+/// Error type for fetch operations.
+///
+/// # Deprecated
+/// This enum is dead: no library code constructs or returns it. Every fetch,
+/// network, database, and parse failure surfaces through [`AppError`] instead
+/// ([`AppError::Network`], [`AppError::Db`], [`AppError::Deserialization`]).
+/// It is kept only for backward compatibility and will be removed in a future
+/// release — migrate to [`AppError`].
+#[deprecated(
+    since = "0.12.0",
+    note = "unused dead enum; use AppError (Network / Db / Deserialization) instead"
+)]
 #[derive(Debug, thiserror::Error)]
 pub enum FetchError {
     /// Network error from reqwest
@@ -44,6 +55,14 @@ pub enum AuthError {
     /// Rate limit exceeded error
     #[error("rate limit exceeded")]
     RateLimitExceeded,
+    /// A login / account-switch response was accepted by IG but omitted a
+    /// required session-token header (CST or X-SECURITY-TOKEN), so no usable
+    /// session could be derived. The payload holds the lowercase header name.
+    ///
+    /// This is a rejected / malformed authentication *response*, not bad caller
+    /// input — it must not be reported as [`AppError::InvalidInput`].
+    #[error("missing {0} header in login response")]
+    MissingSessionToken(String),
 }
 
 impl From<Box<dyn std::error::Error + Send + Sync>> for AuthError {
@@ -86,6 +105,8 @@ impl From<AppError> for AuthError {
             AppError::Io(e) => AuthError::Io(e),
             AppError::Json(e) => AuthError::Json(e),
             AppError::Unexpected(s) => AuthError::Unexpected(s),
+            // Unwrap an already-typed auth error rather than re-stringifying it.
+            AppError::Auth(a) => a,
             _ => AuthError::Other(e.to_string()),
         }
     }
@@ -142,23 +163,17 @@ pub enum AppError {
     /// Invalid input error with a description of the constraint violated
     #[error("invalid input: {0}")]
     InvalidInput(String),
+    /// Authentication failure carrying a typed [`AuthError`].
+    ///
+    /// Login / refresh / account-switch paths surface their typed
+    /// [`AuthError`] through this variant (e.g. a login response missing a
+    /// required session-token header). Wrapping — rather than flattening —
+    /// preserves both the specific auth variant and its contextual message.
+    #[error("auth error: {0}")]
+    Auth(#[from] AuthError),
     /// Generic error for cases that don't fit other categories
     #[error("generic error: {0}")]
     Generic(String),
-}
-
-impl From<AuthError> for AppError {
-    #[cold]
-    fn from(e: AuthError) -> Self {
-        match e {
-            AuthError::Network(e) => AppError::Network(e),
-            AuthError::Io(e) => AppError::Io(e),
-            AuthError::Json(e) => AppError::Json(e),
-            AuthError::BadCredentials => AppError::Unauthorized,
-            AuthError::Unexpected(s) => AppError::Unexpected(s),
-            _ => AppError::Unexpected(StatusCode::INTERNAL_SERVER_ERROR),
-        }
-    }
 }
 
 impl From<Box<dyn std::error::Error>> for AppError {
@@ -170,7 +185,9 @@ impl From<Box<dyn std::error::Error>> for AppError {
                 Ok(js) => AppError::Json(*js),
                 Err(e) => match e.downcast::<std::io::Error>() {
                     Ok(ioe) => AppError::Io(*ioe),
-                    Err(_) => AppError::Unexpected(StatusCode::INTERNAL_SERVER_ERROR),
+                    // Preserve the original error text instead of fabricating a
+                    // fake "unexpected http status: 500" for arbitrary errors.
+                    Err(other) => AppError::Generic(other.to_string()),
                 },
             },
         }

--- a/tests/unit/application/test_auth_flow.rs
+++ b/tests/unit/application/test_auth_flow.rs
@@ -7,7 +7,7 @@ use ig_client::application::config::{
     Config, Credentials, RateLimiterConfig, RestApiConfig, WebSocketConfig,
 };
 use ig_client::application::http::HttpClient;
-use ig_client::error::AppError;
+use ig_client::error::{AppError, AuthError};
 use ig_client::storage::config::DatabaseConfig;
 use std::sync::Arc;
 use wiremock::matchers::{method, path};
@@ -122,7 +122,7 @@ async fn test_login_v2_returns_session_with_cst_and_security_token() {
 }
 
 #[tokio::test]
-async fn test_login_v2_missing_cst_header_yields_invalid_input() {
+async fn test_login_v2_missing_cst_header_yields_missing_session_token() {
     let server = MockServer::start().await;
     // Body present, but the CST response header is missing.
     Mock::given(method("POST"))
@@ -132,17 +132,17 @@ async fn test_login_v2_missing_cst_header_yields_invalid_input() {
         .await;
 
     let auth = Auth::new(Arc::new(test_config(&server.uri(), 2)));
+    // A rejected / malformed auth response maps to a typed auth error naming
+    // the missing header — NOT AppError::InvalidInput (which means bad caller
+    // input).
     match auth.login().await {
-        Err(AppError::InvalidInput(msg)) => assert!(
-            msg.contains("CST"),
-            "error should name the missing CST header, got: {msg}"
-        ),
-        other => panic!("expected InvalidInput for missing CST, got {other:?}"),
+        Err(AppError::Auth(AuthError::MissingSessionToken(header))) => assert_eq!(header, "cst"),
+        other => panic!("expected MissingSessionToken for missing CST, got {other:?}"),
     }
 }
 
 #[tokio::test]
-async fn test_login_v2_missing_security_token_header_yields_invalid_input() {
+async fn test_login_v2_missing_security_token_header_yields_missing_session_token() {
     let server = MockServer::start().await;
     // CST present, X-SECURITY-TOKEN missing.
     Mock::given(method("POST"))
@@ -153,11 +153,10 @@ async fn test_login_v2_missing_security_token_header_yields_invalid_input() {
 
     let auth = Auth::new(Arc::new(test_config(&server.uri(), 2)));
     match auth.login().await {
-        Err(AppError::InvalidInput(msg)) => assert!(
-            msg.contains("X-SECURITY-TOKEN"),
-            "error should name the missing security token header, got: {msg}"
-        ),
-        other => panic!("expected InvalidInput for missing X-SECURITY-TOKEN, got {other:?}"),
+        Err(AppError::Auth(AuthError::MissingSessionToken(header))) => {
+            assert_eq!(header, "x-security-token");
+        }
+        other => panic!("expected MissingSessionToken for missing X-SECURITY-TOKEN, got {other:?}"),
     }
 }
 

--- a/tests/unit/error_tests.rs
+++ b/tests/unit/error_tests.rs
@@ -1,4 +1,4 @@
-use ig_client::error::{AppError, AuthError, FetchError};
+use ig_client::error::{AppError, AuthError};
 use reqwest::StatusCode;
 use serde_json::Error as JsonError;
 use sqlx::Error as SqlxError;
@@ -79,29 +79,61 @@ fn test_app_error_from_sqlx_error() {
 
 #[test]
 fn test_app_error_from_auth_error() {
-    // Create an AuthError
+    // An AuthError is wrapped (not flattened) into AppError::Auth, preserving
+    // both the specific auth variant and its contextual message.
     let auth_error = AuthError::BadCredentials;
-
     let app_error = AppError::from(auth_error);
 
     match app_error {
-        AppError::Unauthorized => {
+        AppError::Auth(AuthError::BadCredentials) => {
             // Test passed
         }
-        _ => panic!("Expected AppError::Unauthorized, got {app_error:?}"),
+        _ => panic!("Expected AppError::Auth(BadCredentials), got {app_error:?}"),
     }
 
-    assert_display_contains(&app_error, "unauthorized");
+    // The wrapped auth message is carried through the AppError Display.
+    assert_display_contains(&app_error, "auth error");
+    assert_display_contains(&app_error, "bad credentials");
 
     // Test another variant
     let auth_error = AuthError::Unexpected(StatusCode::INTERNAL_SERVER_ERROR);
     let app_error = AppError::from(auth_error);
 
     match app_error {
-        AppError::Unexpected(_) => {
+        AppError::Auth(AuthError::Unexpected(_)) => {
             // Test passed
         }
-        _ => panic!("Expected AppError::Unexpected, got {app_error:?}"),
+        _ => panic!("Expected AppError::Auth(Unexpected), got {app_error:?}"),
+    }
+}
+
+#[test]
+fn test_app_error_from_missing_session_token_names_header() {
+    // The concrete wiring that makes AuthError non-dead: a missing session
+    // header maps to a typed auth error whose message names the header, and
+    // survives conversion into AppError.
+    let auth_error = AuthError::MissingSessionToken("cst".to_string());
+    assert_display_contains(&auth_error, "missing cst header in login response");
+
+    let app_error = AppError::from(auth_error);
+    match &app_error {
+        AppError::Auth(AuthError::MissingSessionToken(header)) => assert_eq!(header, "cst"),
+        _ => panic!("Expected AppError::Auth(MissingSessionToken), got {app_error:?}"),
+    }
+    assert_display_contains(&app_error, "missing cst header in login response");
+}
+
+#[test]
+fn test_auth_error_from_app_error_auth_round_trips() {
+    // AppError::Auth unwraps back to the inner AuthError rather than being
+    // re-stringified into AuthError::Other.
+    let app_error = AppError::Auth(AuthError::MissingSessionToken(
+        "x-security-token".to_string(),
+    ));
+    let auth_error = AuthError::from(app_error);
+    match auth_error {
+        AuthError::MissingSessionToken(header) => assert_eq!(header, "x-security-token"),
+        _ => panic!("Expected AuthError::MissingSessionToken, got {auth_error:?}"),
     }
 }
 
@@ -192,15 +224,18 @@ fn test_app_error_from_box_dyn_error() {
     // Create a Box<dyn Error> containing a different error type
     let boxed_error: Box<dyn Error> = Box::new(TestError("test error".to_string()));
 
-    // Convert to AppError - should default to Unexpected
+    // Convert to AppError - the fallback now PRESERVES the original message via
+    // Generic instead of fabricating a fake "unexpected http status: 500".
     let app_error = AppError::from(boxed_error);
 
-    match app_error {
-        AppError::Unexpected(_) => {
+    match &app_error {
+        AppError::Generic(_) => {
             // Test passed
         }
-        _ => panic!("Expected AppError::Unexpected, got {app_error:?}"),
+        _ => panic!("Expected AppError::Generic, got {app_error:?}"),
     }
+    // The original error text is not discarded.
+    assert_display_contains(&app_error, "test error");
 }
 
 #[test]
@@ -311,7 +346,10 @@ fn test_auth_error_from_box_dyn_error_send_sync() {
 }
 
 #[test]
+#[allow(deprecated)] // FetchError is deprecated; this pins its Display until removal.
 fn test_fetch_error_display() {
+    use ig_client::error::FetchError;
+
     let fetch_error = FetchError::Parser("parsing failed".to_string());
     assert_display_contains(&fetch_error, "parser error");
     assert_display_contains(&fetch_error, "parsing failed");

--- a/tests/unit/presentation/test_price.rs
+++ b/tests/unit/presentation/test_price.rs
@@ -150,10 +150,13 @@ fn test_price_data_from_item_update_invalid_float() {
 
     let result = price_data_from_item_update(&item_update);
     // An unparseable float in a numeric field is a hard error: `parse_float`
-    // fails and the error propagates out of `from_item_update`. The message
-    // names the offending field and value.
+    // fails and the error propagates out of `from_item_update` as a typed
+    // `AppError::Deserialization`. The message names the offending field and
+    // value.
     assert!(result.is_err());
-    let err = result.expect_err("invalid float must yield an error");
+    let err = result
+        .expect_err("invalid float must yield an error")
+        .to_string();
     assert!(
         err.contains("BID"),
         "error should name the offending field, got: {err}"


### PR DESCRIPTION
## Summary

The crate documented a typed error design but never exercised it: `AuthError`/`FetchError` were dead public API, missing auth headers were misreported as caller-input errors, deserialization failures dropped all context, `From<Box<dyn Error>>` fabricated a fake 500, and streaming conversions returned bare `Result<_, String>`. This PR wires the typed errors up. Part of 0.12.0.

## Changes

- **`AuthError` is live**: new `MissingSessionToken(header)` variant; `login_v2` returns it (via `AppError::Auth` `#[from]`) with a lowercase contextual message when a CST/X-SECURITY-TOKEN response header is missing — replacing the wrong `AppError::InvalidInput`.
- **`From<Box<dyn Error>>`** now preserves the original message (`AppError::Generic`) instead of fabricating `unexpected http status: 500`.
- **`parse_response` context**: deserialization failures now carry the URL, HTTP status, and a truncated body snippet — **except** for `/session` endpoints, where the body snippet is suppressed so CST/X-SECURITY-TOKEN/OAuth tokens can never reach logs.
- **`*_from_item_update`** conversions return `Result<_, AppError>` instead of bare `Result<_, String>`, with `# Errors` docs.
- **`FetchError` deprecated** (`#[deprecated(since = "0.12.0")]`) — no real construction site; all fetch/deser failures flow through `AppError`.

## Testing

- [x] Malformed-body deserialization error contains the status, URL, and a body snippet (asserted)
- [x] A malformed `/session` body yields status+URL but **omits** the body snippet and never leaks the token-shaped secret (asserted)
- [x] `From<Box<dyn Error>>` preserves the message; no public API returns `Result<_, String>`
- [x] `make pre-push` clean; 245 lib + 208 unit tests; semver passes at 0.12.0

Follow-up noted: the lower-level `PriceData::from_fields` etc. still return `Result<_, String>` — converting them would introduce `AppError` into the pure presentation layer (a purity trade-off), left for a separate decision.

Closes #49
