### PR TITLE
fix(dto): widen IG numerics from i32 to i64/unsigned — 0.12.0 (#34)

### DIFF
--- a/examples/market/src/bin/category_instruments.rs
+++ b/examples/market/src/bin/category_instruments.rs
@@ -29,8 +29,8 @@ async fn main() -> IgResult<()> {
         .unwrap_or_else(|| "VANILLA_OPTIONS".to_string());
 
     // Optional pagination parameters
-    let page_number: Option<i32> = std::env::args().nth(2).and_then(|s| s.parse().ok());
-    let page_size: Option<i32> = std::env::args().nth(3).and_then(|s| s.parse().ok());
+    let page_number: Option<u32> = std::env::args().nth(2).and_then(|s| s.parse().ok());
+    let page_size: Option<u32> = std::env::args().nth(3).and_then(|s| s.parse().ok());
 
     info!(
         "Fetching instruments for category: {} (page: {:?}, size: {:?})",

--- a/examples/market/src/bin/historical_prices_v1.rs
+++ b/examples/market/src/bin/historical_prices_v1.rs
@@ -17,7 +17,7 @@ async fn main() -> IgResult<()> {
         .nth(2)
         .unwrap_or_else(|| "HOUR".to_string());
 
-    let num_points: i32 = std::env::args()
+    let num_points: u32 = std::env::args()
         .nth(3)
         .and_then(|s| s.parse().ok())
         .unwrap_or(10);

--- a/examples/market/src/bin/historical_prices_v2.rs
+++ b/examples/market/src/bin/historical_prices_v2.rs
@@ -17,7 +17,7 @@ async fn main() -> IgResult<()> {
         .nth(2)
         .unwrap_or_else(|| "HOUR".to_string());
 
-    let num_points: i32 = std::env::args()
+    let num_points: u32 = std::env::args()
         .nth(3)
         .and_then(|s| s.parse().ok())
         .unwrap_or(10);

--- a/examples/simples/src/bin/historical_prices_example.rs
+++ b/examples/simples/src/bin/historical_prices_example.rs
@@ -18,7 +18,7 @@ const EPICS: &[&str] = &[
 const RESOLUTION: &str = "HOUR";
 
 /// Number of data points to request per EPIC (API v2).
-const NUM_POINTS: i32 = 10;
+const NUM_POINTS: u32 = 10;
 
 #[tokio::main]
 async fn main() -> Result<(), AppError> {

--- a/src/application/client.rs
+++ b/src/application/client.rs
@@ -376,7 +376,7 @@ impl MarketService for Client {
         &self,
         epic: &str,
         resolution: &str,
-        num_points: i32,
+        num_points: u32,
     ) -> Result<HistoricalPricesResponse, AppError> {
         let path = format!("prices/{}/{}/{}", epic, resolution, num_points);
         info!(
@@ -396,7 +396,7 @@ impl MarketService for Client {
         &self,
         epic: &str,
         resolution: &str,
-        num_points: i32,
+        num_points: u32,
     ) -> Result<HistoricalPricesResponse, AppError> {
         let path = format!("prices/{}/{}/{}", epic, resolution, num_points);
         info!(
@@ -616,8 +616,8 @@ impl MarketService for Client {
     async fn get_category_instruments(
         &self,
         category_id: &str,
-        page_number: Option<i32>,
-        page_size: Option<i32>,
+        page_number: Option<u32>,
+        page_size: Option<u32>,
     ) -> Result<CategoryInstrumentsResponse, AppError> {
         let mut path = format!("categories/{}/instruments", category_id);
 

--- a/src/application/interfaces/market.rs
+++ b/src/application/interfaces/market.rs
@@ -79,7 +79,7 @@ pub trait MarketService: Send + Sync {
 
         epic: &str,
         resolution: &str,
-        num_points: i32,
+        num_points: u32,
     ) -> Result<HistoricalPricesResponse, AppError>;
 
     /// Gets historical prices by number of data points (API v2)
@@ -92,7 +92,7 @@ pub trait MarketService: Send + Sync {
         &self,
         epic: &str,
         resolution: &str,
-        num_points: i32,
+        num_points: u32,
     ) -> Result<HistoricalPricesResponse, AppError>;
 
     /// Gets the top-level market navigation nodes
@@ -162,7 +162,7 @@ pub trait MarketService: Send + Sync {
     async fn get_category_instruments(
         &self,
         category_id: &str,
-        page_number: Option<i32>,
-        page_size: Option<i32>,
+        page_number: Option<u32>,
+        page_size: Option<u32>,
     ) -> Result<CategoryInstrumentsResponse, AppError>;
 }

--- a/src/model/requests.rs
+++ b/src/model/requests.rs
@@ -24,11 +24,14 @@ pub struct RecentPricesRequest<'a> {
     /// Optional end date time (yyyy-MM-dd'T'HH:mm:ss)
     pub to: Option<&'a str>,
     /// Optional max number of price points (default: 10)
-    pub max_points: Option<i32>,
+    #[serde(rename = "max")]
+    pub max_points: Option<i64>,
     /// Optional page size (default: 20, disable paging = 0)
-    pub page_size: Option<i32>,
+    #[serde(rename = "pageSize")]
+    pub page_size: Option<i64>,
     /// Optional page number (default: 1)
-    pub page_number: Option<i32>,
+    #[serde(rename = "pageNumber")]
+    pub page_number: Option<i64>,
 }
 
 impl<'a> RecentPricesRequest<'a> {
@@ -64,21 +67,21 @@ impl<'a> RecentPricesRequest<'a> {
 
     /// Set the max points
     #[must_use]
-    pub fn with_max_points(mut self, max_points: i32) -> Self {
+    pub fn with_max_points(mut self, max_points: i64) -> Self {
         self.max_points = Some(max_points);
         self
     }
 
     /// Set the page size
     #[must_use]
-    pub fn with_page_size(mut self, page_size: i32) -> Self {
+    pub fn with_page_size(mut self, page_size: i64) -> Self {
         self.page_size = Some(page_size);
         self
     }
 
     /// Set the page number
     #[must_use]
-    pub fn with_page_number(mut self, page_number: i32) -> Self {
+    pub fn with_page_number(mut self, page_number: i64) -> Self {
         self.page_number = Some(page_number);
         self
     }

--- a/src/model/requests.rs
+++ b/src/model/requests.rs
@@ -25,13 +25,13 @@ pub struct RecentPricesRequest<'a> {
     pub to: Option<&'a str>,
     /// Optional max number of price points (default: 10)
     #[serde(rename = "max")]
-    pub max_points: Option<i64>,
+    pub max_points: Option<u32>,
     /// Optional page size (default: 20, disable paging = 0)
     #[serde(rename = "pageSize")]
-    pub page_size: Option<i64>,
+    pub page_size: Option<u32>,
     /// Optional page number (default: 1)
     #[serde(rename = "pageNumber")]
-    pub page_number: Option<i64>,
+    pub page_number: Option<u32>,
 }
 
 impl<'a> RecentPricesRequest<'a> {
@@ -67,21 +67,21 @@ impl<'a> RecentPricesRequest<'a> {
 
     /// Set the max points
     #[must_use]
-    pub fn with_max_points(mut self, max_points: i64) -> Self {
+    pub fn with_max_points(mut self, max_points: u32) -> Self {
         self.max_points = Some(max_points);
         self
     }
 
     /// Set the page size
     #[must_use]
-    pub fn with_page_size(mut self, page_size: i64) -> Self {
+    pub fn with_page_size(mut self, page_size: u32) -> Self {
         self.page_size = Some(page_size);
         self
     }
 
     /// Set the page number
     #[must_use]
-    pub fn with_page_number(mut self, page_number: i64) -> Self {
+    pub fn with_page_number(mut self, page_number: u32) -> Self {
         self.page_number = Some(page_number);
         self
     }

--- a/src/model/responses.rs
+++ b/src/model/responses.rs
@@ -985,13 +985,13 @@ pub struct ApplicationDetailsResponse {
     pub status: String,
     /// Overall allowance for the account
     #[serde(rename = "allowanceAccountOverall")]
-    pub allowance_account_overall: Option<i32>,
+    pub allowance_account_overall: Option<i64>,
     /// Trading allowance for the account
     #[serde(rename = "allowanceAccountTrading")]
-    pub allowance_account_trading: Option<i32>,
+    pub allowance_account_trading: Option<i64>,
     /// Concurrent connections allowance
     #[serde(rename = "concurrentSubscriptionsLimit")]
-    pub concurrent_subscriptions_limit: Option<i32>,
+    pub concurrent_subscriptions_limit: Option<i64>,
     /// Creation date
     #[serde(rename = "createdDate")]
     pub created_date: Option<String>,
@@ -1009,13 +1009,13 @@ pub struct ApplicationInfo {
     pub status: String,
     /// Overall allowance for the account
     #[serde(rename = "allowanceAccountOverall")]
-    pub allowance_account_overall: Option<i32>,
+    pub allowance_account_overall: Option<i64>,
     /// Trading allowance for the account
     #[serde(rename = "allowanceAccountTrading")]
-    pub allowance_account_trading: Option<i32>,
+    pub allowance_account_trading: Option<i64>,
     /// Concurrent connections allowance
     #[serde(rename = "concurrentSubscriptionsLimit")]
-    pub concurrent_subscriptions_limit: Option<i32>,
+    pub concurrent_subscriptions_limit: Option<i64>,
     /// Creation date
     #[serde(rename = "createdDate")]
     pub created_date: Option<String>,
@@ -1450,11 +1450,13 @@ mod tests {
 
     #[test]
     fn test_application_details_response_deserialize_and_roundtrip() {
+        // `allowanceAccountOverall` is deliberately > i32::MAX (2_147_483_647)
+        // to prove the field widening to i64 — an i32 field would overflow here.
         let json = r#"{
             "apiKey": "FAKE-API-KEY",
             "name": "My App",
             "status": "ENABLED",
-            "allowanceAccountOverall": 10000,
+            "allowanceAccountOverall": 3000000000,
             "allowanceAccountTrading": 1000,
             "concurrentSubscriptionsLimit": 40,
             "createdDate": "2025-01-01"
@@ -1465,12 +1467,40 @@ mod tests {
         assert_eq!(resp.api_key, "FAKE-API-KEY");
         assert_eq!(resp.name.as_deref(), Some("My App"));
         assert_eq!(resp.status, "ENABLED");
-        assert_eq!(resp.allowance_account_overall, Some(10000));
+        assert!(resp.allowance_account_overall > Some(i64::from(i32::MAX)));
+        assert_eq!(resp.allowance_account_overall, Some(3_000_000_000));
         assert_eq!(resp.concurrent_subscriptions_limit, Some(40));
 
         let re = roundtrip(&resp);
         assert_eq!(re.api_key, "FAKE-API-KEY");
+        assert_eq!(re.allowance_account_overall, Some(3_000_000_000));
         assert_eq!(re.allowance_account_trading, Some(1000));
+    }
+
+    #[test]
+    fn test_application_info_deserialize_and_roundtrip() {
+        // Mirrors `ApplicationDetailsResponse`; the overall allowance again
+        // exceeds i32::MAX to lock in the i64 widening for `ApplicationInfo`.
+        let json = r#"{
+            "apiKey": "FAKE-API-KEY",
+            "name": "My App",
+            "status": "ENABLED",
+            "allowanceAccountOverall": 3000000000,
+            "allowanceAccountTrading": 1000,
+            "concurrentSubscriptionsLimit": 40,
+            "createdDate": "2025-01-01"
+        }"#;
+
+        let resp: ApplicationInfo = serde_json::from_str(json).expect("deserialize failed");
+        assert_eq!(resp.api_key, "FAKE-API-KEY");
+        assert!(resp.allowance_account_overall > Some(i64::from(i32::MAX)));
+        assert_eq!(resp.allowance_account_overall, Some(3_000_000_000));
+        assert_eq!(resp.allowance_account_trading, Some(1000));
+        assert_eq!(resp.concurrent_subscriptions_limit, Some(40));
+
+        let re = roundtrip(&resp);
+        assert_eq!(re.allowance_account_overall, Some(3_000_000_000));
+        assert_eq!(re.concurrent_subscriptions_limit, Some(40));
     }
 
     #[test]

--- a/src/presentation/account.rs
+++ b/src/presentation/account.rs
@@ -61,7 +61,7 @@ pub struct ActivityMetadata {
 #[derive(DebugPretty, DisplaySimple, Clone, Deserialize, Serialize)]
 pub struct ActivityPaging {
     /// Number of items per page
-    pub size: Option<i32>,
+    pub size: Option<i64>,
     /// URL for the next page of results
     pub next: Option<String>,
 }
@@ -713,7 +713,7 @@ pub struct TransactionMetadata {
     #[serde(rename = "pageData")]
     pub page_data: PageData,
     /// Total number of transactions
-    pub size: i32,
+    pub size: i64,
 }
 
 /// Pagination information
@@ -721,13 +721,13 @@ pub struct TransactionMetadata {
 pub struct PageData {
     /// Current page number
     #[serde(rename = "pageNumber")]
-    pub page_number: i32,
+    pub page_number: i64,
     /// Number of items per page
     #[serde(rename = "pageSize")]
-    pub page_size: i32,
+    pub page_size: i64,
     /// Total number of pages
     #[serde(rename = "totalPages")]
-    pub total_pages: i32,
+    pub total_pages: i64,
 }
 
 /// Individual transaction
@@ -808,7 +808,7 @@ pub struct AccountData {
     /// Name of the item this data belongs to
     pub item_name: String,
     /// Position of the item in the subscription
-    pub item_pos: i32,
+    pub item_pos: usize,
     /// All account fields
     pub fields: AccountFields,
     /// Fields that have changed in this update
@@ -910,7 +910,7 @@ impl AccountData {
 
         Ok(AccountData {
             item_name: item_name.unwrap_or_default().to_string(),
-            item_pos: item_pos as i32,
+            item_pos,
             fields,
             changed_fields,
             is_snapshot,
@@ -1127,5 +1127,48 @@ mod tests {
         let net2 = sell + buy;
         assert_eq!(net2.direction, Direction::Sell);
         assert!((net2.size - 1.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn test_transaction_metadata_deserialize_and_roundtrip() {
+        // Sanitized `metadata` object from `history/transactions`. `size` and
+        // all `pageData` fields are i64.
+        let json = r#"{
+            "pageData": { "pageNumber": 1, "pageSize": 20, "totalPages": 3 },
+            "size": 42
+        }"#;
+
+        let meta: TransactionMetadata = serde_json::from_str(json).expect("deserialize failed");
+        assert_eq!(meta.size, 42);
+        assert_eq!(meta.page_data.page_number, 1);
+        assert_eq!(meta.page_data.page_size, 20);
+        assert_eq!(meta.page_data.total_pages, 3);
+
+        let serialized = serde_json::to_string(&meta).expect("serialize failed");
+        let re: TransactionMetadata =
+            serde_json::from_str(&serialized).expect("re-deserialize failed");
+        assert_eq!(re.size, 42);
+        assert_eq!(re.page_data.total_pages, 3);
+        assert!(serialized.contains("\"pageNumber\":1"));
+        assert!(serialized.contains("\"pageSize\":20"));
+        assert!(serialized.contains("\"totalPages\":3"));
+    }
+
+    #[test]
+    fn test_activity_paging_deserialize_and_roundtrip() {
+        // Sanitized `paging` object from `history/activity`. `size` is i64.
+        let json = r#"{ "size": 10, "next": "/history/activity?from=X&to=Y" }"#;
+
+        let paging: ActivityPaging = serde_json::from_str(json).expect("deserialize failed");
+        assert_eq!(paging.size, Some(10));
+        assert_eq!(
+            paging.next.as_deref(),
+            Some("/history/activity?from=X&to=Y")
+        );
+
+        let serialized = serde_json::to_string(&paging).expect("serialize failed");
+        let re: ActivityPaging = serde_json::from_str(&serialized).expect("re-deserialize failed");
+        assert_eq!(re.size, Some(10));
+        assert_eq!(re.next.as_deref(), Some("/history/activity?from=X&to=Y"));
     }
 }

--- a/src/presentation/chart.rs
+++ b/src/presentation/chart.rs
@@ -51,7 +51,7 @@ pub struct ChartData {
     /// The full Lightstreamer item name (e.g., `CHART:EPIC:TIMESCALE`)
     pub item_name: String,
     /// The 1-based position of the item in the subscription
-    pub item_pos: i32,
+    pub item_pos: usize,
     /// Resolved chart scale for this update (derived from item name or `scale`)
     #[serde(default)]
     pub scale: ChartScale, // Derived from the item name or the {scale} field
@@ -277,7 +277,7 @@ impl ChartData {
 
         Ok(ChartData {
             item_name: item_name.unwrap_or_default().to_string(),
-            item_pos: item_pos as i32,
+            item_pos,
             scale,
             fields: parsed_fields,
             changed_fields: parsed_changed_fields,

--- a/src/presentation/market.rs
+++ b/src/presentation/market.rs
@@ -396,7 +396,7 @@ pub struct PresentationMarketData {
     /// Name of the item this data belongs to
     pub item_name: String,
     /// Position of the item in the subscription
-    pub item_pos: i32,
+    pub item_pos: usize,
     /// All market fields
     pub fields: MarketFields,
     /// Fields that have changed in this update
@@ -434,7 +434,7 @@ impl PresentationMarketData {
 
         Ok(PresentationMarketData {
             item_name: item_name.unwrap_or_default().to_string(),
-            item_pos: item_pos as i32,
+            item_pos,
             fields,
             changed_fields,
             is_snapshot,
@@ -612,10 +612,10 @@ pub struct CategoryInstrument {
 pub struct CategoryInstrumentsMetadata {
     /// Current page number
     #[serde(rename = "pageNumber")]
-    pub page_number: i32,
+    pub page_number: i64,
     /// Number of items per page
     #[serde(rename = "pageSize")]
-    pub page_size: i32,
+    pub page_size: i64,
 }
 
 /// Fields containing market price and status information
@@ -745,6 +745,25 @@ mod tests {
         };
         assert!(!market.is_call());
         assert!(!market.is_put());
+    }
+
+    #[test]
+    fn test_category_instruments_metadata_deserialize_and_roundtrip() {
+        // Sanitized shape of the `metadata` object IG returns from
+        // `categories/{id}/instruments`. `pageNumber` / `pageSize` are i64.
+        let json = r#"{ "pageNumber": 2, "pageSize": 1000 }"#;
+
+        let meta: CategoryInstrumentsMetadata =
+            serde_json::from_str(json).expect("deserialize failed");
+        assert_eq!(meta.page_number, 2);
+        assert_eq!(meta.page_size, 1000);
+
+        let serialized = serde_json::to_string(&meta).expect("serialize failed");
+        let re: CategoryInstrumentsMetadata =
+            serde_json::from_str(&serialized).expect("re-deserialize failed");
+        assert_eq!(re, meta);
+        assert!(serialized.contains("\"pageNumber\":2"));
+        assert!(serialized.contains("\"pageSize\":1000"));
     }
 
     #[test]

--- a/src/presentation/price.rs
+++ b/src/presentation/price.rs
@@ -36,7 +36,7 @@ pub struct PriceData {
     /// Name of the item (usually the market ID)
     pub item_name: String,
     /// Position of the item in the subscription
-    pub item_pos: i32,
+    pub item_pos: usize,
     /// All price fields for this market
     pub fields: PriceFields,
     /// Fields that have changed in this update
@@ -630,7 +630,7 @@ impl PriceData {
 
         Ok(PriceData {
             item_name: item_name.unwrap_or_default().to_string(),
-            item_pos: item_pos as i32,
+            item_pos,
             fields,
             changed_fields,
             is_snapshot,

--- a/src/presentation/trade.rs
+++ b/src/presentation/trade.rs
@@ -12,7 +12,7 @@ pub struct TradeData {
     /// Name of the subscribed item
     pub item_name: String,
     /// Position of the item in the subscription
-    pub item_pos: i32,
+    pub item_pos: usize,
     /// Trade fields data
     pub fields: TradeFields,
     /// Changed fields data
@@ -202,7 +202,7 @@ impl TradeData {
 
         Ok(TradeData {
             item_name: item_name.unwrap_or_default().to_string(),
-            item_pos: item_pos as i32,
+            item_pos,
             fields,
             changed_fields,
             is_snapshot,

--- a/tests/unit/model/test_requests.rs
+++ b/tests/unit/model/test_requests.rs
@@ -25,6 +25,23 @@ fn recent_prices_request_builders() {
     assert_eq!(req.max_points, Some(100));
     assert_eq!(req.page_size, Some(50));
     assert_eq!(req.page_number, Some(2));
+
+    // The numeric paging fields must serialize to IG's wire names: the count
+    // fields are renamed to `max` / `pageSize` / `pageNumber`.
+    let json = json_value(&req);
+    assert_eq!(json.get("max").unwrap(), 100);
+    assert_eq!(json.get("pageSize").unwrap(), 50);
+    assert_eq!(json.get("pageNumber").unwrap(), 2);
+    assert!(json.get("max_points").is_none());
+    assert!(json.get("page_size").is_none());
+    assert!(json.get("page_number").is_none());
+
+    // Round-trip through the renamed shape.
+    let raw = serde_json::to_string(&req).unwrap();
+    let re: RecentPricesRequest<'_> = serde_json::from_str(&raw).unwrap();
+    assert_eq!(re.max_points, Some(100));
+    assert_eq!(re.page_size, Some(50));
+    assert_eq!(re.page_number, Some(2));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

`rules/global_rules.md` bans `i32` for IG numeric fields (the crate was bitten when `popularity` overflowed it). Allowance fields, paging metadata, `num_points`, page params, and `item_pos` casts were still `i32`. This PR widens them. Part of 0.12.0 (breaking DTO/param types).

## Changes

- **Request counts** (`client.rs` + `MarketService` trait): `num_points: i32 → u32`; `get_category_instruments` page params `Option<i32> → Option<u32>` — negative values can no longer be interpolated into URLs. Trait and impls change in lockstep; the `pageSize ≤ 1000` bound stays.
- **`RecentPricesRequest`**: `max_points/page_size/page_number → Option<i64>`, plus the previously-missing serde renames (`max`, `pageSize`, `pageNumber`) so its serde shape mirrors IG.
- **`ApplicationDetailsResponse` / `ApplicationInfo`**: six allowance/subscription fields `Option<i32> → Option<i64>`.
- **`CategoryInstrumentsMetadata`**, **`TransactionMetadata.size`**, **`PageData.*`**, **`ActivityPaging.size`** → `i64`.
- **`item_pos`**: `i32 → usize` across the five presentation DTOs, dropping the `item_update.item_pos as i32` cast.

## Testing

- [x] Round-trip tests from sanitized payloads for every changed DTO, using allowance values > `i32::MAX` (e.g. `3_000_000_000`) to prove the widening
- [x] `RecentPricesRequest` test asserts the fields serialize to `max`/`pageSize`/`pageNumber`
- [x] `grep ": i32"` in model/presentation/interfaces shows only the genuinely-bounded `timezone_offset`
- [x] `make pre-push` clean; semver passes at 0.12.0

Closes #34
