### PR TITLE
fix(streaming): consistent field types and single wire-name source — 0.12.0 (#44)

### DIFF
--- a/src/model/streaming.rs
+++ b/src/model/streaming.rs
@@ -380,138 +380,13 @@ impl Display for StreamingPriceField {
 ///
 /// # Returns
 ///
-/// A `Vec<String>` where each `String` is a serialized representation of a `StreamingPriceField` from the input set.
-///
-/// # Panics
-///
-/// This function will panic if the serialization of any `StreamingPriceField` fails.
-///
+/// A `Vec<String>` where each `String` is the exact IG Lightstreamer wire name
+/// of a `StreamingPriceField` from the input set.
 pub(crate) fn get_streaming_price_fields(fields: &HashSet<StreamingPriceField>) -> Vec<String> {
-    // Map each enum variant to the exact IG Lightstreamer field identifier.
-    let map_field = |f: &StreamingPriceField| -> &'static str {
-        match f {
-            // Core prices
-            StreamingPriceField::MidOpen => "MID_OPEN",
-            StreamingPriceField::High => "HIGH",
-            StreamingPriceField::Low => "LOW",
-            StreamingPriceField::BidQuoteId => "BIDQUOTEID",
-            StreamingPriceField::AskQuoteId => "ASKQUOTEID",
-
-            // Bid ladder prices
-            StreamingPriceField::BidPrice1 => "BIDPRICE1",
-            StreamingPriceField::BidPrice2 => "BIDPRICE2",
-            StreamingPriceField::BidPrice3 => "BIDPRICE3",
-            StreamingPriceField::BidPrice4 => "BIDPRICE4",
-            StreamingPriceField::BidPrice5 => "BIDPRICE5",
-
-            // Ask ladder prices
-            StreamingPriceField::AskPrice1 => "ASKPRICE1",
-            StreamingPriceField::AskPrice2 => "ASKPRICE2",
-            StreamingPriceField::AskPrice3 => "ASKPRICE3",
-            StreamingPriceField::AskPrice4 => "ASKPRICE4",
-            StreamingPriceField::AskPrice5 => "ASKPRICE5",
-
-            // Bid sizes
-            StreamingPriceField::BidSize1 => "BIDSIZE1",
-            StreamingPriceField::BidSize2 => "BIDSIZE2",
-            StreamingPriceField::BidSize3 => "BIDSIZE3",
-            StreamingPriceField::BidSize4 => "BIDSIZE4",
-            StreamingPriceField::BidSize5 => "BIDSIZE5",
-
-            // Ask sizes
-            StreamingPriceField::AskSize1 => "ASKSIZE1",
-            StreamingPriceField::AskSize2 => "ASKSIZE2",
-            StreamingPriceField::AskSize3 => "ASKSIZE3",
-            StreamingPriceField::AskSize4 => "ASKSIZE4",
-            StreamingPriceField::AskSize5 => "ASKSIZE5",
-
-            // Currencies
-            StreamingPriceField::Currency0 => "CURRENCY0",
-            StreamingPriceField::Currency1 => "CURRENCY1",
-            StreamingPriceField::Currency2 => "CURRENCY2",
-            StreamingPriceField::Currency3 => "CURRENCY3",
-            StreamingPriceField::Currency4 => "CURRENCY4",
-            StreamingPriceField::Currency5 => "CURRENCY5",
-
-            // Currency 1 bid sizes
-            StreamingPriceField::C1BidSize1 => "C1BIDSIZE1",
-            StreamingPriceField::C1BidSize2 => "C1BIDSIZE2",
-            StreamingPriceField::C1BidSize3 => "C1BIDSIZE3",
-            StreamingPriceField::C1BidSize4 => "C1BIDSIZE4",
-            StreamingPriceField::C1BidSize5 => "C1BIDSIZE5",
-            // Currency 1 ask sizes
-            StreamingPriceField::C1AskSize1 => "C1ASKSIZE1",
-            StreamingPriceField::C1AskSize2 => "C1ASKSIZE2",
-            StreamingPriceField::C1AskSize3 => "C1ASKSIZE3",
-            StreamingPriceField::C1AskSize4 => "C1ASKSIZE4",
-            StreamingPriceField::C1AskSize5 => "C1ASKSIZE5",
-
-            // Currency 2 bid sizes
-            StreamingPriceField::C2BidSize1 => "C2BIDSIZE1",
-            StreamingPriceField::C2BidSize2 => "C2BIDSIZE2",
-            StreamingPriceField::C2BidSize3 => "C2BIDSIZE3",
-            StreamingPriceField::C2BidSize4 => "C2BIDSIZE4",
-            StreamingPriceField::C2BidSize5 => "C2BIDSIZE5",
-            // Currency 2 ask sizes
-            StreamingPriceField::C2AskSize1 => "C2ASKSIZE1",
-            StreamingPriceField::C2AskSize2 => "C2ASKSIZE2",
-            StreamingPriceField::C2AskSize3 => "C2ASKSIZE3",
-            StreamingPriceField::C2AskSize4 => "C2ASKSIZE4",
-            StreamingPriceField::C2AskSize5 => "C2ASKSIZE5",
-
-            // Currency 3 bid sizes
-            StreamingPriceField::C3BidSize1 => "C3BIDSIZE1",
-            StreamingPriceField::C3BidSize2 => "C3BIDSIZE2",
-            StreamingPriceField::C3BidSize3 => "C3BIDSIZE3",
-            StreamingPriceField::C3BidSize4 => "C3BIDSIZE4",
-            StreamingPriceField::C3BidSize5 => "C3BIDSIZE5",
-            // Currency 3 ask sizes
-            StreamingPriceField::C3AskSize1 => "C3ASKSIZE1",
-            StreamingPriceField::C3AskSize2 => "C3ASKSIZE2",
-            StreamingPriceField::C3AskSize3 => "C3ASKSIZE3",
-            StreamingPriceField::C3AskSize4 => "C3ASKSIZE4",
-            StreamingPriceField::C3AskSize5 => "C3ASKSIZE5",
-
-            // Currency 4 bid sizes
-            StreamingPriceField::C4BidSize1 => "C4BIDSIZE1",
-            StreamingPriceField::C4BidSize2 => "C4BIDSIZE2",
-            StreamingPriceField::C4BidSize3 => "C4BIDSIZE3",
-            StreamingPriceField::C4BidSize4 => "C4BIDSIZE4",
-            StreamingPriceField::C4BidSize5 => "C4BIDSIZE5",
-            // Currency 4 ask sizes
-            StreamingPriceField::C4AskSize1 => "C4ASKSIZE1",
-            StreamingPriceField::C4AskSize2 => "C4ASKSIZE2",
-            StreamingPriceField::C4AskSize3 => "C4ASKSIZE3",
-            StreamingPriceField::C4AskSize4 => "C4ASKSIZE4",
-            StreamingPriceField::C4AskSize5 => "C4ASKSIZE5",
-
-            // Currency 5 bid sizes
-            StreamingPriceField::C5BidSize1 => "C5BIDSIZE1",
-            StreamingPriceField::C5BidSize2 => "C5BIDSIZE2",
-            StreamingPriceField::C5BidSize3 => "C5BIDSIZE3",
-            StreamingPriceField::C5BidSize4 => "C5BIDSIZE4",
-            StreamingPriceField::C5BidSize5 => "C5BIDSIZE5",
-            // Currency 5 ask sizes
-            StreamingPriceField::C5AskSize1 => "C5ASKSIZE1",
-            StreamingPriceField::C5AskSize2 => "C5ASKSIZE2",
-            StreamingPriceField::C5AskSize3 => "C5ASKSIZE3",
-            StreamingPriceField::C5AskSize4 => "C5ASKSIZE4",
-            StreamingPriceField::C5AskSize5 => "C5ASKSIZE5",
-
-            // Misc
-            StreamingPriceField::Timestamp => "TIMESTAMP",
-            StreamingPriceField::DlgFlag => "DLG_FLAG",
-            StreamingPriceField::NetChg => "NET_CHG",
-            StreamingPriceField::NetChgPct => "NET_CHG_PCT",
-            StreamingPriceField::Delay => "DELAY",
-        }
-    };
-
-    let mut fields_vec = Vec::with_capacity(fields.len());
-    for field in fields {
-        fields_vec.push(map_field(field).to_string());
-    }
-    fields_vec
+    // `Display` (via the `Debug` impl above) is the single source of truth for
+    // the exact IG Lightstreamer wire field name of every variant, so no
+    // separate mapping table or fallible serialization is needed.
+    fields.iter().map(|field| field.to_string()).collect()
 }
 
 /// Streaming account data fields available for account subscriptions.
@@ -1074,6 +949,204 @@ mod tests {
         ] {
             assert_wire_name(&field, expected);
         }
+    }
+
+    /// Every variant of every streaming field enum, so drift between the serde
+    /// renames and the `Display`/`Debug` wire mapping can be checked
+    /// exhaustively (see [`test_all_streaming_fields_serde_matches_display`]).
+    const ALL_MARKET_FIELDS: &[StreamingMarketField] = &[
+        StreamingMarketField::MidOpen,
+        StreamingMarketField::High,
+        StreamingMarketField::Low,
+        StreamingMarketField::Change,
+        StreamingMarketField::ChangePct,
+        StreamingMarketField::UpdateTime,
+        StreamingMarketField::MarketDelay,
+        StreamingMarketField::MarketState,
+        StreamingMarketField::Bid,
+        StreamingMarketField::Offer,
+    ];
+
+    const ALL_ACCOUNT_FIELDS: &[StreamingAccountDataField] = &[
+        StreamingAccountDataField::Pnl,
+        StreamingAccountDataField::Deposit,
+        StreamingAccountDataField::AvailableCash,
+        StreamingAccountDataField::PnlLr,
+        StreamingAccountDataField::PnlNlr,
+        StreamingAccountDataField::Funds,
+        StreamingAccountDataField::Margin,
+        StreamingAccountDataField::MarginLr,
+        StreamingAccountDataField::MarginNlr,
+        StreamingAccountDataField::AvailableToDeal,
+        StreamingAccountDataField::Equity,
+        StreamingAccountDataField::EquityUsed,
+    ];
+
+    const ALL_CHART_FIELDS: &[StreamingChartField] = &[
+        StreamingChartField::Ltv,
+        StreamingChartField::Ttv,
+        StreamingChartField::Utm,
+        StreamingChartField::DayOpenMid,
+        StreamingChartField::DayNetChgMid,
+        StreamingChartField::DayPercChgMid,
+        StreamingChartField::DayHigh,
+        StreamingChartField::DayLow,
+        StreamingChartField::Bid,
+        StreamingChartField::Ofr,
+        StreamingChartField::Ltp,
+        StreamingChartField::OfrOpen,
+        StreamingChartField::OfrHigh,
+        StreamingChartField::OfrLow,
+        StreamingChartField::OfrClose,
+        StreamingChartField::BidOpen,
+        StreamingChartField::BidHigh,
+        StreamingChartField::BidLow,
+        StreamingChartField::BidClose,
+        StreamingChartField::LtpOpen,
+        StreamingChartField::LtpHigh,
+        StreamingChartField::LtpLow,
+        StreamingChartField::LtpClose,
+        StreamingChartField::ConsEnd,
+        StreamingChartField::ConsTickCount,
+    ];
+
+    const ALL_PRICE_FIELDS: &[StreamingPriceField] = &[
+        StreamingPriceField::MidOpen,
+        StreamingPriceField::High,
+        StreamingPriceField::Low,
+        StreamingPriceField::BidQuoteId,
+        StreamingPriceField::AskQuoteId,
+        StreamingPriceField::BidPrice1,
+        StreamingPriceField::BidPrice2,
+        StreamingPriceField::BidPrice3,
+        StreamingPriceField::BidPrice4,
+        StreamingPriceField::BidPrice5,
+        StreamingPriceField::AskPrice1,
+        StreamingPriceField::AskPrice2,
+        StreamingPriceField::AskPrice3,
+        StreamingPriceField::AskPrice4,
+        StreamingPriceField::AskPrice5,
+        StreamingPriceField::BidSize1,
+        StreamingPriceField::BidSize2,
+        StreamingPriceField::BidSize3,
+        StreamingPriceField::BidSize4,
+        StreamingPriceField::BidSize5,
+        StreamingPriceField::AskSize1,
+        StreamingPriceField::AskSize2,
+        StreamingPriceField::AskSize3,
+        StreamingPriceField::AskSize4,
+        StreamingPriceField::AskSize5,
+        StreamingPriceField::Currency0,
+        StreamingPriceField::Currency1,
+        StreamingPriceField::C1BidSize1,
+        StreamingPriceField::C1BidSize2,
+        StreamingPriceField::C1BidSize3,
+        StreamingPriceField::C1BidSize4,
+        StreamingPriceField::C1BidSize5,
+        StreamingPriceField::C1AskSize1,
+        StreamingPriceField::C1AskSize2,
+        StreamingPriceField::C1AskSize3,
+        StreamingPriceField::C1AskSize4,
+        StreamingPriceField::C1AskSize5,
+        StreamingPriceField::Currency2,
+        StreamingPriceField::C2BidSize1,
+        StreamingPriceField::C2BidSize2,
+        StreamingPriceField::C2BidSize3,
+        StreamingPriceField::C2BidSize4,
+        StreamingPriceField::C2BidSize5,
+        StreamingPriceField::C2AskSize1,
+        StreamingPriceField::C2AskSize2,
+        StreamingPriceField::C2AskSize3,
+        StreamingPriceField::C2AskSize4,
+        StreamingPriceField::C2AskSize5,
+        StreamingPriceField::Currency3,
+        StreamingPriceField::C3BidSize1,
+        StreamingPriceField::C3BidSize2,
+        StreamingPriceField::C3BidSize3,
+        StreamingPriceField::C3BidSize4,
+        StreamingPriceField::C3BidSize5,
+        StreamingPriceField::C3AskSize1,
+        StreamingPriceField::C3AskSize2,
+        StreamingPriceField::C3AskSize3,
+        StreamingPriceField::C3AskSize4,
+        StreamingPriceField::C3AskSize5,
+        StreamingPriceField::Currency4,
+        StreamingPriceField::C4BidSize1,
+        StreamingPriceField::C4BidSize2,
+        StreamingPriceField::C4BidSize3,
+        StreamingPriceField::C4BidSize4,
+        StreamingPriceField::C4BidSize5,
+        StreamingPriceField::C4AskSize1,
+        StreamingPriceField::C4AskSize2,
+        StreamingPriceField::C4AskSize3,
+        StreamingPriceField::C4AskSize4,
+        StreamingPriceField::C4AskSize5,
+        StreamingPriceField::Currency5,
+        StreamingPriceField::C5BidSize1,
+        StreamingPriceField::C5BidSize2,
+        StreamingPriceField::C5BidSize3,
+        StreamingPriceField::C5BidSize4,
+        StreamingPriceField::C5BidSize5,
+        StreamingPriceField::C5AskSize1,
+        StreamingPriceField::C5AskSize2,
+        StreamingPriceField::C5AskSize3,
+        StreamingPriceField::C5AskSize4,
+        StreamingPriceField::C5AskSize5,
+        StreamingPriceField::Timestamp,
+        StreamingPriceField::DlgFlag,
+        StreamingPriceField::NetChg,
+        StreamingPriceField::NetChgPct,
+        StreamingPriceField::Delay,
+    ];
+
+    /// Asserts that the serde wire name (the JSON string a variant serializes
+    /// to) matches the variant's `Display` output. This is the single guard
+    /// that keeps the serde renames and the `Display`/`Debug` mapping — the two
+    /// independent sources for the IG Lightstreamer wire name — from drifting.
+    fn assert_serde_matches_display<T>(field: &T)
+    where
+        T: Serialize + Display,
+    {
+        let value = serde_json::to_value(field).expect("serialize to value failed");
+        let wire = value
+            .as_str()
+            .expect("a streaming field enum variant must serialize to a JSON string");
+        assert_eq!(
+            wire,
+            field.to_string(),
+            "serde wire name and Display disagree for a streaming field variant"
+        );
+    }
+
+    #[test]
+    fn test_all_streaming_fields_serde_matches_display() {
+        for field in ALL_MARKET_FIELDS {
+            assert_serde_matches_display(field);
+        }
+        for field in ALL_ACCOUNT_FIELDS {
+            assert_serde_matches_display(field);
+        }
+        for field in ALL_CHART_FIELDS {
+            assert_serde_matches_display(field);
+        }
+        for field in ALL_PRICE_FIELDS {
+            assert_serde_matches_display(field);
+        }
+    }
+
+    #[test]
+    fn test_get_streaming_price_fields_uses_display_wire_names() {
+        // The price getter now derives wire names from `Display`; pin a couple of
+        // non-obvious ones so a regression to a divergent mapping fails loudly.
+        let mut fields = HashSet::new();
+        fields.insert(StreamingPriceField::MidOpen);
+        fields.insert(StreamingPriceField::C1BidSize1);
+        fields.insert(StreamingPriceField::DlgFlag);
+        let result = get_streaming_price_fields(&fields);
+        assert_eq!(result.len(), 3);
+        assert!(result.contains(&"MID_OPEN".to_string()));
+        assert!(result.contains(&"C1BIDSIZE1".to_string()));
+        assert!(result.contains(&"DLG_FLAG".to_string()));
     }
 
     #[test]

--- a/src/presentation/chart.rs
+++ b/src/presentation/chart.rs
@@ -1,4 +1,6 @@
-use crate::presentation::serialization::string_as_float_opt;
+use crate::presentation::serialization::{
+    string_as_bool_opt, string_as_float_opt, string_as_int_opt,
+};
 use pretty_simple_display::{DebugPretty, DisplaySimple};
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, fmt};
@@ -81,10 +83,13 @@ pub struct ChartFields {
     pub incremental_trading_volume: Option<f64>,
 
     #[serde(rename = "UTM")]
-    #[serde(with = "string_as_float_opt")]
+    #[serde(with = "string_as_int_opt")]
     #[serde(default)]
-    /// Update time timestamp for the data point
-    pub update_time: Option<f64>,
+    /// Update time for the data point, in epoch milliseconds (UTC).
+    ///
+    /// Typed as `i64` to preserve integer epoch-millis exactly (float parsing
+    /// would risk silent rounding on large values).
+    pub update_time: Option<i64>,
 
     #[serde(rename = "DAY_OPEN_MID")]
     #[serde(with = "string_as_float_opt")]
@@ -209,10 +214,12 @@ pub struct ChartFields {
     pub ltp_close: Option<f64>,
 
     #[serde(rename = "CONS_END")]
-    #[serde(with = "string_as_float_opt")]
+    #[serde(with = "string_as_bool_opt")]
     #[serde(default)]
-    /// Candle end timestamp
-    pub candle_end: Option<f64>,
+    /// Candle-completed flag: 1 when the candle has ended, 0 while it is still
+    /// forming. This is IG's `CONS_END` wire field, a 0/1 boolean rather than a
+    /// timestamp.
+    pub candle_end: Option<bool>,
 
     #[serde(rename = "CONS_TICK_COUNT")]
     #[serde(with = "string_as_float_opt")]
@@ -302,11 +309,32 @@ impl ChartData {
             }
         };
 
+        // Helper function to parse integer values (e.g. epoch-millis timestamps).
+        let parse_int = |key: &str| -> Result<Option<i64>, String> {
+            match get_field(key) {
+                Some(val) if !val.is_empty() => val
+                    .parse::<i64>()
+                    .map(Some)
+                    .map_err(|_| format!("Failed to parse {key} as integer: {val}")),
+                _ => Ok(None),
+            }
+        };
+
+        // Parse the CONS_END candle-completed flag: IG sends "0" / "1"
+        // (1 = candle ended, 0 = still forming). An empty string is treated as
+        // None.
+        let candle_end = match get_field("CONS_END").as_deref() {
+            Some("0") => Some(false),
+            Some("1") => Some(true),
+            Some("") | None => None,
+            Some(val) => return Err(format!("Invalid CONS_END value: {val}")),
+        };
+
         Ok(ChartFields {
             // Common fields
             last_traded_volume: parse_float("LTV")?,
             incremental_trading_volume: parse_float("TTV")?,
-            update_time: parse_float("UTM")?,
+            update_time: parse_int("UTM")?,
             day_open_mid: parse_float("DAY_OPEN_MID")?,
             day_net_change_mid: parse_float("DAY_NET_CHG_MID")?,
             day_percentage_change_mid: parse_float("DAY_PERC_CHG_MID")?,
@@ -331,7 +359,7 @@ impl ChartData {
             ltp_high: parse_float("LTP_HIGH")?,
             ltp_low: parse_float("LTP_LOW")?,
             ltp_close: parse_float("LTP_CLOSE")?,
-            candle_end: parse_float("CONS_END")?,
+            candle_end,
             candle_tick_count: parse_float("CONS_TICK_COUNT")?,
         })
     }

--- a/src/presentation/price.rs
+++ b/src/presentation/price.rs
@@ -1,4 +1,6 @@
-use crate::presentation::serialization::string_as_float_opt;
+use crate::presentation::serialization::{
+    string_as_bool_opt, string_as_float_opt, string_as_int_opt,
+};
 use pretty_simple_display::{DebugPretty, DisplaySimple};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -46,7 +48,14 @@ pub struct PriceData {
 }
 
 /// Price field data containing bid, offer, and market status information
+///
+/// Every field carries `skip_serializing_if = "Option::is_none"`, so absent
+/// values are omitted from the serialized output. The struct-level
+/// `#[serde(default)]` makes the reverse direction symmetric: a missing field
+/// deserializes back to `None` instead of failing, so the DTO round-trips its
+/// own output.
 #[derive(DebugPretty, DisplaySimple, Clone, Serialize, Deserialize, Default)]
+#[serde(default)]
 pub struct PriceFields {
     /// The opening price at the middle of the bid-ask spread
     #[serde(rename = "MID_OPEN")]
@@ -90,11 +99,15 @@ pub struct PriceFields {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub change_pct: Option<f64>,
 
-    /// Market data delay in seconds
+    /// Delayed-data flag (1 = delayed).
+    ///
+    /// This is IG's `MARKET_DELAY` wire field: a 0/1 flag, not a duration.
+    /// Kept in sync with [`crate::presentation::market::MarketFields::market_delay`],
+    /// which parses the same field the same way.
     #[serde(rename = "MARKET_DELAY")]
-    #[serde(with = "string_as_float_opt")]
+    #[serde(with = "string_as_bool_opt")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub market_delay: Option<f64>,
+    pub market_delay: Option<bool>,
 
     /// Current market state (e.g., "OPEN", "CLOSED", "SUSPENDED")
     #[serde(rename = "MARKET_STATE")]
@@ -571,11 +584,14 @@ pub struct PriceFields {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub c5_ask_size_5: Option<f64>,
 
-    /// The timestamp of the price update in UTC milliseconds since epoch
+    /// The timestamp of the price update, in epoch milliseconds (UTC).
+    ///
+    /// Typed as `i64` to preserve integer epoch-millis exactly (float parsing
+    /// would risk silent rounding on large values).
     #[serde(rename = "TIMESTAMP")]
-    #[serde(with = "string_as_float_opt")]
+    #[serde(with = "string_as_int_opt")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub timestamp: Option<f64>,
+    pub timestamp: Option<i64>,
 
     /// Dealing status flag indicating trading availability/state of the market
     #[serde(rename = "DLG_FLAG")]
@@ -655,6 +671,26 @@ impl PriceData {
             }
         };
 
+        // Helper function to parse integer values (e.g. epoch-millis timestamps).
+        let parse_int = |key: &str| -> Result<Option<i64>, String> {
+            match get_field(key) {
+                Some(val) if !val.is_empty() => val
+                    .parse::<i64>()
+                    .map(Some)
+                    .map_err(|_| format!("Failed to parse {key} as integer: {val}")),
+                _ => Ok(None),
+            }
+        };
+
+        // Parse the MARKET_DELAY flag: IG sends "0" / "1" (delayed-data flag),
+        // not a duration. An empty string is treated as None.
+        let market_delay = match get_field("MARKET_DELAY").as_deref() {
+            Some("0") => Some(false),
+            Some("1") => Some(true),
+            Some("") | None => None,
+            Some(val) => return Err(format!("Invalid MARKET_DELAY value: {val}")),
+        };
+
         // Parse dealing flag (case-insensitive to handle potential lowercase conversion).
         // An empty string (produced when the server sends '#' for null) is treated as None.
         let dealing_flag = match get_field("DLG_FLAG")
@@ -685,7 +721,7 @@ impl PriceData {
             offer: parse_float("OFFER")?,
             change: parse_float("CHANGE")?,
             change_pct: parse_float("CHANGE_PCT")?,
-            market_delay: parse_float("MARKET_DELAY")?,
+            market_delay,
             market_state: get_field("MARKET_STATE"),
             update_time: get_field("UPDATE_TIME"),
 
@@ -790,7 +826,7 @@ impl PriceData {
             c5_ask_size_4: parse_float("C5ASKSIZE4")?,
             c5_ask_size_5: parse_float("C5ASKSIZE5")?,
 
-            timestamp: parse_float("TIMESTAMP")?,
+            timestamp: parse_int("TIMESTAMP")?,
             dealing_flag,
             net_chg: parse_float("NET_CHG")?,
             net_chg_pct: parse_float("NET_CHG_PCT")?,

--- a/src/presentation/serialization.rs
+++ b/src/presentation/serialization.rs
@@ -59,6 +59,74 @@ pub mod string_as_float_opt {
     }
 }
 
+/// Module for handling the conversion between string and optional integer values
+///
+/// This module provides serialization and deserialization functions for converting
+/// between `Option<i64>` and string representations used in the IG Markets API.
+/// It is the integer counterpart of [`string_as_float_opt`] and is intended for
+/// wire values that are conceptually integers (for example epoch-millisecond
+/// timestamps) where float parsing would risk silent rounding.
+pub mod string_as_int_opt {
+    use serde::{self, Deserialize, Deserializer, Serializer};
+    use serde_json::Value;
+
+    /// Serializes an optional integer value to a JSON number
+    ///
+    /// # Arguments
+    /// * `value` - The optional integer value to serialize
+    /// * `serializer` - The serializer to use
+    ///
+    /// # Returns
+    /// A Result containing the serialized value or an error
+    pub fn serialize<S>(value: &Option<i64>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match value {
+            Some(v) => serializer.serialize_i64(*v), // Serialize as a number
+            None => serializer.serialize_none(),
+        }
+    }
+
+    /// Deserializes a string or number representation to an optional integer value
+    ///
+    /// Accepts a JSON `null` (mapped to `None`), a JSON integer, or a string
+    /// holding an integer (an empty string maps to `None`). A non-integer or
+    /// otherwise malformed value yields a deserialization error.
+    ///
+    /// # Arguments
+    /// * `deserializer` - The deserializer to use
+    ///
+    /// # Returns
+    /// A Result containing the deserialized optional integer value or an error
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<i64>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = Value::deserialize(deserializer)?;
+
+        match value {
+            Value::Null => Ok(None),
+            Value::Number(num) => {
+                if let Some(int) = num.as_i64() {
+                    Ok(Some(int))
+                } else {
+                    Err(serde::de::Error::custom("Expected an integer"))
+                }
+            }
+            Value::String(s) => {
+                if s.is_empty() {
+                    return Ok(None);
+                }
+                s.parse::<i64>().map(Some).map_err(|_| {
+                    serde::de::Error::custom(format!("Failed to parse string as integer: {s}"))
+                })
+            }
+            _ => Err(serde::de::Error::custom("Expected null, number or string")),
+        }
+    }
+}
+
 /// Module for handling the conversion between string and optional boolean values
 ///
 /// This module provides serialization and deserialization functions for converting

--- a/tests/unit/presentation/serialization_tests.rs
+++ b/tests/unit/presentation/serialization_tests.rs
@@ -3,7 +3,7 @@
 #[cfg(test)]
 mod tests {
     use ig_client::presentation::serialization::{
-        option_string_empty_as_none, string_as_bool_opt, string_as_float_opt,
+        option_string_empty_as_none, string_as_bool_opt, string_as_float_opt, string_as_int_opt,
     };
     use serde::{Deserialize, Serialize};
 
@@ -12,6 +12,13 @@ mod tests {
     struct FloatTest {
         #[serde(with = "string_as_float_opt")]
         value: Option<f64>,
+    }
+
+    // Test structs for string_as_int_opt
+    #[derive(Serialize, Deserialize, Debug, PartialEq)]
+    struct IntTest {
+        #[serde(with = "string_as_int_opt")]
+        value: Option<i64>,
     }
 
     // Test structs for string_as_bool_opt
@@ -106,6 +113,89 @@ mod tests {
         // Test deserializing from object
         let json = r#"{"value": {"a": 1}}"#;
         let result: Result<FloatTest, _> = serde_json::from_str(json);
+        assert!(result.is_err());
+    }
+
+    // Tests for string_as_int_opt
+    #[test]
+    fn test_string_as_int_opt_serialize() {
+        // Some(i64) serializes to a JSON number.
+        let test = IntTest {
+            value: Some(1_700_000_000_123),
+        };
+        let serialized = serde_json::to_string(&test).unwrap();
+        assert_eq!(serialized, r#"{"value":1700000000123}"#);
+
+        // None serializes to null.
+        let test = IntTest { value: None };
+        let serialized = serde_json::to_string(&test).unwrap();
+        assert_eq!(serialized, r#"{"value":null}"#);
+    }
+
+    #[test]
+    fn test_string_as_int_opt_deserialize() {
+        // From a JSON number.
+        let json = r#"{"value": 1700000000123}"#;
+        let deserialized: IntTest = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            deserialized,
+            IntTest {
+                value: Some(1_700_000_000_123)
+            }
+        );
+
+        // From a string holding an integer (the IG wire shape).
+        let json = r#"{"value": "1700000000123"}"#;
+        let deserialized: IntTest = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            deserialized,
+            IntTest {
+                value: Some(1_700_000_000_123)
+            }
+        );
+
+        // Negative integers round-trip.
+        let json = r#"{"value": "-42"}"#;
+        let deserialized: IntTest = serde_json::from_str(json).unwrap();
+        assert_eq!(deserialized, IntTest { value: Some(-42) });
+
+        // Null and empty string both map to None.
+        let json = r#"{"value": null}"#;
+        let deserialized: IntTest = serde_json::from_str(json).unwrap();
+        assert_eq!(deserialized, IntTest { value: None });
+
+        let json = r#"{"value": ""}"#;
+        let deserialized: IntTest = serde_json::from_str(json).unwrap();
+        assert_eq!(deserialized, IntTest { value: None });
+    }
+
+    #[test]
+    fn test_string_as_int_opt_preserves_large_epoch_millis() {
+        // A 13-digit epoch-millis value must survive exactly, with no float
+        // rounding.
+        let original = IntTest {
+            value: Some(1_763_000_000_999),
+        };
+        let serialized = serde_json::to_string(&original).unwrap();
+        let restored: IntTest = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(restored, original);
+    }
+
+    #[test]
+    fn test_string_as_int_opt_deserialize_errors() {
+        // A non-integer string is an error.
+        let json = r#"{"value": "not-a-number"}"#;
+        let result: Result<IntTest, _> = serde_json::from_str(json);
+        assert!(result.is_err());
+
+        // A fractional value is not a valid integer.
+        let json = r#"{"value": "42.5"}"#;
+        let result: Result<IntTest, _> = serde_json::from_str(json);
+        assert!(result.is_err());
+
+        // A boolean is not accepted.
+        let json = r#"{"value": true}"#;
+        let result: Result<IntTest, _> = serde_json::from_str(json);
         assert!(result.is_err());
     }
 

--- a/tests/unit/presentation/test_chart.rs
+++ b/tests/unit/presentation/test_chart.rs
@@ -62,3 +62,85 @@ fn test_chart_data_serialization() {
     let json = serde_json::to_string(&chart).unwrap();
     let _deserialized: ChartData = serde_json::from_str(&json).unwrap();
 }
+
+#[test]
+fn test_chart_data_from_item_update_cons_end_is_flag() {
+    // CONS_END is a 0/1 candle-completed flag (1 = ended, 0 = forming), not a
+    // timestamp.
+    let mut fields = HashMap::new();
+    fields.insert("CONS_END".to_string(), Some("1".to_string()));
+    fields.insert("UTM".to_string(), Some("1700000000123".to_string()));
+
+    let item_update = ItemUpdate {
+        item_name: Some("CHART:CS.D.EURUSD.MINI.IP:1MINUTE".to_string()),
+        item_pos: 1,
+        is_snapshot: true,
+        fields,
+        changed_fields: HashMap::new(),
+    };
+
+    let data = chart_data_from_item_update(&item_update).expect("chart update should parse");
+    assert_eq!(data.fields.candle_end, Some(true));
+    // UTM is epoch milliseconds (UTC), parsed as i64.
+    assert_eq!(data.fields.update_time, Some(1_700_000_000_123));
+}
+
+#[test]
+fn test_chart_data_from_item_update_cons_end_zero_is_false() {
+    let mut fields = HashMap::new();
+    fields.insert("CONS_END".to_string(), Some("0".to_string()));
+
+    let item_update = ItemUpdate {
+        item_name: Some("CHART:CS.D.EURUSD.MINI.IP:1MINUTE".to_string()),
+        item_pos: 1,
+        is_snapshot: true,
+        fields,
+        changed_fields: HashMap::new(),
+    };
+
+    let data = chart_data_from_item_update(&item_update).expect("chart update should parse");
+    assert_eq!(data.fields.candle_end, Some(false));
+}
+
+#[test]
+fn test_chart_data_from_item_update_cons_end_invalid_is_error() {
+    let mut fields = HashMap::new();
+    fields.insert("CONS_END".to_string(), Some("2".to_string()));
+
+    let item_update = ItemUpdate {
+        item_name: Some("CHART:CS.D.EURUSD.MINI.IP:1MINUTE".to_string()),
+        item_pos: 1,
+        is_snapshot: true,
+        fields,
+        changed_fields: HashMap::new(),
+    };
+
+    assert!(
+        chart_data_from_item_update(&item_update).is_err(),
+        "a non-0/1 CONS_END value must surface an error"
+    );
+}
+
+#[test]
+fn test_chart_fields_round_trip_with_new_types() {
+    // Round-trips a sparse candle update through serde, pinning that the
+    // retyped fields (`candle_end: bool`, `update_time: i64`) survive.
+    let fields = ChartFields {
+        bid: Some(1.1000),
+        offer: Some(1.1002),
+        update_time: Some(1_700_000_000_123),
+        candle_end: Some(true),
+        candle_tick_count: Some(42.0),
+        ..Default::default()
+    };
+
+    let json = serde_json::to_string(&fields).expect("serialize should succeed");
+    let restored: ChartFields =
+        serde_json::from_str(&json).expect("ChartFields must deserialize its own output");
+    assert_eq!(restored.bid, Some(1.1000));
+    assert_eq!(restored.offer, Some(1.1002));
+    assert_eq!(restored.update_time, Some(1_700_000_000_123));
+    assert_eq!(restored.candle_end, Some(true));
+    assert_eq!(restored.candle_tick_count, Some(42.0));
+    assert!(restored.day_high.is_none());
+}

--- a/tests/unit/presentation/test_price.rs
+++ b/tests/unit/presentation/test_price.rs
@@ -335,6 +335,101 @@ fn test_price_data_from_trait_does_not_panic_on_error() {
 }
 
 #[test]
+fn test_price_fields_round_trip_with_none_fields() {
+    // Regression guard for the skip-without-default asymmetry: `PriceFields`
+    // omits `None` fields on serialize (`skip_serializing_if`), so without a
+    // matching `#[serde(default)]` it could not deserialize its own output.
+    // Build a realistic, sparse update (only a few populated fields) and prove
+    // it round-trips.
+    let fields = PriceFields {
+        bid: Some(18000.5),
+        offer: Some(18001.5),
+        market_delay: Some(false),
+        market_state: Some("TRADEABLE".to_string()),
+        update_time: Some("12:34:56".to_string()),
+        timestamp: Some(1_700_000_000_000),
+        ..Default::default()
+    };
+
+    let json = serde_json::to_string(&fields).expect("serialize should succeed");
+    // The absent fields must not appear in the serialized output.
+    assert!(!json.contains("MID_OPEN"), "None fields must be skipped");
+
+    let restored: PriceFields =
+        serde_json::from_str(&json).expect("PriceFields must deserialize its own output");
+    assert_eq!(restored.bid, Some(18000.5));
+    assert_eq!(restored.offer, Some(18001.5));
+    assert_eq!(restored.market_delay, Some(false));
+    assert_eq!(restored.market_state.as_deref(), Some("TRADEABLE"));
+    assert_eq!(restored.update_time.as_deref(), Some("12:34:56"));
+    assert_eq!(restored.timestamp, Some(1_700_000_000_000));
+    // Absent fields round-trip back to None.
+    assert!(restored.mid_open.is_none());
+    assert!(restored.high.is_none());
+}
+
+#[test]
+fn test_price_data_from_item_update_market_delay_flag() {
+    // MARKET_DELAY is a 0/1 delayed-data flag, parsed as a bool (not seconds).
+    let mut fields = HashMap::new();
+    fields.insert("MARKET_DELAY".to_string(), Some("1".to_string()));
+
+    let item_update = ItemUpdate {
+        item_name: Some("MARKET:TEST".to_string()),
+        item_pos: 1,
+        is_snapshot: true,
+        fields,
+        changed_fields: HashMap::new(),
+    };
+
+    let result = price_data_from_item_update(&item_update);
+    assert!(result.is_ok());
+    let price_data = result.expect("market delay flag should parse");
+    assert_eq!(price_data.fields.market_delay, Some(true));
+}
+
+#[test]
+fn test_price_data_from_item_update_market_delay_invalid_is_error() {
+    let mut fields = HashMap::new();
+    fields.insert("MARKET_DELAY".to_string(), Some("7".to_string()));
+
+    let item_update = ItemUpdate {
+        item_name: Some("MARKET:TEST".to_string()),
+        item_pos: 1,
+        is_snapshot: true,
+        fields,
+        changed_fields: HashMap::new(),
+    };
+
+    let result = price_data_from_item_update(&item_update);
+    assert!(
+        result.is_err(),
+        "a non-0/1 MARKET_DELAY value must surface an error"
+    );
+}
+
+#[test]
+fn test_price_data_from_item_update_timestamp_is_epoch_millis_i64() {
+    // TIMESTAMP is epoch milliseconds (UTC), parsed as i64 to avoid float
+    // rounding on large integer values.
+    let mut fields = HashMap::new();
+    fields.insert("TIMESTAMP".to_string(), Some("1700000000123".to_string()));
+
+    let item_update = ItemUpdate {
+        item_name: Some("MARKET:TEST".to_string()),
+        item_pos: 1,
+        is_snapshot: true,
+        fields,
+        changed_fields: HashMap::new(),
+    };
+
+    let result = price_data_from_item_update(&item_update);
+    assert!(result.is_ok());
+    let price_data = result.expect("timestamp should parse");
+    assert_eq!(price_data.fields.timestamp, Some(1_700_000_000_123));
+}
+
+#[test]
 fn test_price_data_from_item_update_dlg_flag_with_trailing_spaces() {
     let mut fields = HashMap::new();
     // Server sends DLG_FLAG with trailing whitespace padding


### PR DESCRIPTION
## Summary

The same Lightstreamer wire fields were modeled with conflicting types and docs across the streaming DTOs, the wire-name mapping was hand-duplicated per enum, and `PriceFields` couldn't round-trip its own output. Part of 0.12.0 (breaking field types).

## Changes

- **`MARKET_DELAY`** is a delayed-data flag, not seconds: `PriceFields.market_delay` → `Option<bool>` (was `f64`), agreeing with `MarketFields`; doc fixed.
- **`CONS_END`** is a candle-completed flag: `ChartFields.candle_end` → `Option<bool>` (was `f64` "timestamp"), documented as `1 = ended, 0 = forming`.
- **Epoch-millis timestamps** (`PriceFields.timestamp`, `ChartFields` UTM) → `Option<i64>` via a new `string_as_int_opt` helper (were `f64`, inviting float rounding); units documented.
- **Single wire-name source**: `get_streaming_price_fields` derives names from `Display` instead of a third hand-maintained `map_field` closure. A new test iterates **every variant of all four field enums** asserting `serde` wire name == `Display` output — future drift fails loudly (surfaced no current mismatch).
- **`PriceFields` round-trip**: added struct-level `#[serde(default)]`. A test that failed before the fix (`missing field MID_OPEN` on deserializing its own output) now passes.

## Testing

- [x] `MARKET_DELAY`/`CONS_END` one consistent type + correct docs across DTOs
- [x] serde-name == Display for every variant of all four enums (drift guard)
- [x] `PriceFields` round-trip test (failed before, passes after)
- [x] `make pre-push` clean; semver passes at 0.12.0

Tasks 4 (dead chart `"{scale}"` lookup) and 6 (`item_pos` cast) were already resolved in #33 and #34.

Closes #44
