### PR TITLE
refactor: remove panicking constructors; try_new/new_lazy only — 0.12.0 (#58)

### DIFF
--- a/examples/chart/src/bin/chart_lightstreamer.rs
+++ b/examples/chart/src/bin/chart_lightstreamer.rs
@@ -45,7 +45,7 @@ async fn main() -> Result<(), ig_client::error::AppError> {
     subscription.set_requested_snapshot(Some(Snapshot::Yes))?;
     subscription.add_listener(Box::new(listener));
 
-    let client = Client::default();
+    let client = Client::try_new()?;
     let ws_info = client.ws_info().await?;
     let password = ws_info.get_ws_password();
 

--- a/examples/costs/src/bin/costs_close.rs
+++ b/examples/costs/src/bin/costs_close.rs
@@ -27,7 +27,7 @@ async fn main() -> Result<(), AppError> {
 
     info!("Starting costs close example");
 
-    let client = Client::new();
+    let client = Client::try_new()?;
 
     let deal_id = std::env::args()
         .nth(1)

--- a/examples/costs/src/bin/costs_history.rs
+++ b/examples/costs/src/bin/costs_history.rs
@@ -25,7 +25,7 @@ async fn main() -> Result<(), AppError> {
 
     info!("Starting costs history example");
 
-    let client = Client::new();
+    let client = Client::try_new()?;
 
     let from = "2024-01-01";
     let to = "2024-12-31";

--- a/examples/costs/src/bin/costs_open.rs
+++ b/examples/costs/src/bin/costs_open.rs
@@ -27,7 +27,7 @@ async fn main() -> Result<(), AppError> {
 
     info!("Starting costs open example");
 
-    let client = Client::new();
+    let client = Client::try_new()?;
 
     let request = OpenCostsRequest::new("CS.D.EURUSD.CFD.IP", Direction::Buy, 1.0, "EUR");
 

--- a/examples/market/src/bin/categories.rs
+++ b/examples/market/src/bin/categories.rs
@@ -20,7 +20,7 @@ use tracing::info;
 async fn main() -> IgResult<()> {
     setup_logger();
 
-    let client = Client::default();
+    let client = Client::try_new()?;
 
     info!("Fetching all categories of instruments...");
 

--- a/examples/market/src/bin/category_instruments.rs
+++ b/examples/market/src/bin/category_instruments.rs
@@ -21,7 +21,7 @@ use tracing::info;
 async fn main() -> IgResult<()> {
     setup_logger();
 
-    let client = Client::default();
+    let client = Client::try_new()?;
 
     // Get the category ID from command line arguments or use VANILLA_OPTIONS as default
     let category_id = std::env::args()

--- a/examples/market/src/bin/get_all_markets.rs
+++ b/examples/market/src/bin/get_all_markets.rs
@@ -6,7 +6,7 @@ use tracing::info;
 async fn main() -> IgResult<()> {
     setup_logger();
 
-    let client = Client::default();
+    let client = Client::try_new()?;
 
     info!("\n=== Getting All Markets from Hierarchy ===");
 

--- a/examples/market/src/bin/historical_prices_date_range.rs
+++ b/examples/market/src/bin/historical_prices_date_range.rs
@@ -5,7 +5,7 @@ use tracing::info;
 async fn main() -> IgResult<()> {
     setup_logger();
 
-    let client = Client::default();
+    let client = Client::try_new()?;
 
     // Get parameters from command line or use defaults
     let epic = std::env::args()

--- a/examples/market/src/bin/historical_prices_v1.rs
+++ b/examples/market/src/bin/historical_prices_v1.rs
@@ -6,7 +6,7 @@ use tracing::info;
 async fn main() -> IgResult<()> {
     setup_logger();
 
-    let client = Client::default();
+    let client = Client::try_new()?;
 
     // Get EPIC from command line or use default
     let epic = std::env::args()

--- a/examples/market/src/bin/historical_prices_v2.rs
+++ b/examples/market/src/bin/historical_prices_v2.rs
@@ -6,7 +6,7 @@ use tracing::info;
 async fn main() -> IgResult<()> {
     setup_logger();
 
-    let client = Client::default();
+    let client = Client::try_new()?;
 
     // Get EPIC from command line or use default
     let epic = std::env::args()

--- a/examples/market/src/bin/market_details.rs
+++ b/examples/market/src/bin/market_details.rs
@@ -9,7 +9,7 @@ const BATCH_SIZE: usize = 25; // Number of EPICs to process before saving result
 async fn main() -> IgResult<()> {
     // Set up logging
     setup_logger();
-    let client = Client::default();
+    let client = Client::try_new()?;
 
     // Get the EPICs from command line arguments or use the default range
     let epics_arg = std::env::args().nth(1);

--- a/examples/market/src/bin/market_hierarchy.rs
+++ b/examples/market/src/bin/market_hierarchy.rs
@@ -7,7 +7,7 @@ async fn main() -> Result<(), ig_client::error::AppError> {
     // Configure logger with more detail for debugging
     setup_logger();
 
-    let client = Client::default();
+    let client = Client::try_new()?;
 
     match client.get_market_navigation().await {
         Ok(response) => {

--- a/examples/market/src/bin/market_lightstreamer.rs
+++ b/examples/market/src/bin/market_lightstreamer.rs
@@ -21,7 +21,7 @@ fn callback(update: &PriceData) -> Result<(), AppError> {
 #[tokio::main]
 async fn main() -> Result<(), ig_client::error::AppError> {
     setup_logger();
-    let http_client = Client::default();
+    let http_client = Client::try_new()?;
     let ws_info = http_client.ws_info().await?;
     let password = ws_info.get_ws_password();
 

--- a/examples/market/src/bin/market_lightstreamer_channel.rs
+++ b/examples/market/src/bin/market_lightstreamer_channel.rs
@@ -70,7 +70,7 @@ async fn process_updates(mut receiver: mpsc::Receiver<ItemUpdate>) {
 async fn main() -> Result<(), ig_client::error::AppError> {
     setup_logger();
 
-    let http_client = Client::default();
+    let http_client = Client::try_new()?;
     let ws_info = http_client.ws_info().await?;
     let password = ws_info.get_ws_password();
     debug!(

--- a/examples/market/src/bin/market_search.rs
+++ b/examples/market/src/bin/market_search.rs
@@ -6,7 +6,7 @@ use tracing::info;
 async fn main() -> IgResult<()> {
     setup_logger();
 
-    let client = Client::default();
+    let client = Client::try_new()?;
 
     // Get the search term from command line arguments or use a default
     let search_term = std::env::args()

--- a/examples/market/src/bin/market_table.rs
+++ b/examples/market/src/bin/market_table.rs
@@ -9,7 +9,7 @@ async fn main() -> Result<(), ig_client::error::AppError> {
     info!("=== IG Market Table Example ===");
 
     // Create client
-    let client = Client::default();
+    let client = Client::try_new()?;
 
     // Create a directory for the output file if it doesn't exist
     std::fs::create_dir_all("Data")?;

--- a/examples/market/src/bin/prices_display_example.rs
+++ b/examples/market/src/bin/prices_display_example.rs
@@ -6,7 +6,7 @@ use tracing::info;
 async fn main() -> IgResult<()> {
     setup_logger();
 
-    let client = Client::default();
+    let client = Client::try_new()?;
 
     info!("=== Historical Prices Display Example ===\n");
 

--- a/examples/market/src/bin/recent_prices.rs
+++ b/examples/market/src/bin/recent_prices.rs
@@ -6,7 +6,7 @@ use tracing::info;
 async fn main() -> IgResult<()> {
     setup_logger();
 
-    let client = Client::default();
+    let client = Client::try_new()?;
 
     // Get EPIC from command line or use default
     let epic = std::env::args()

--- a/examples/market/src/bin/vec_db_entries_table.rs
+++ b/examples/market/src/bin/vec_db_entries_table.rs
@@ -28,7 +28,7 @@ async fn main() -> Result<(), ig_client::error::AppError> {
     info!("=== IG Vec DB Entries Table Example ===");
 
     // Create client
-    let client = Client::default();
+    let client = Client::try_new()?;
 
     // Get vec DB entries
     info!("\n=== Fetching Vec DB Entries ===");

--- a/examples/orders/src/bin/cfd_order_example.rs
+++ b/examples/orders/src/bin/cfd_order_example.rs
@@ -10,7 +10,7 @@ async fn main() -> Result<(), ig_client::error::AppError> {
     info!("=== IG CFD Order Example ===");
 
     // Create client
-    let client = Client::default();
+    let client = Client::try_new()?;
 
     let epic = "CS.D.EURUSD.CEEM.IP"; // Example epic for testing
     let _expiry = Some(

--- a/examples/orders/src/bin/option_orders_example.rs
+++ b/examples/orders/src/bin/option_orders_example.rs
@@ -9,7 +9,7 @@ async fn main() -> Result<(), ig_client::error::AppError> {
     info!("=== IG Option Orders Example ===");
 
     // Create client
-    let client = Client::default();
+    let client = Client::try_new()?;
 
     let epic = "DO.D.OTCDDAX.68.IP"; // Example epic for testing
     let expiry = Some(

--- a/examples/orders/src/bin/working_order_update.rs
+++ b/examples/orders/src/bin/working_order_update.rs
@@ -26,7 +26,7 @@ async fn main() -> Result<(), AppError> {
 
     info!("Starting working order update example");
 
-    let client = Client::new();
+    let client = Client::try_new()?;
 
     let args: Vec<String> = std::env::args().collect();
 

--- a/examples/orders/src/bin/workingorders_example.rs
+++ b/examples/orders/src/bin/workingorders_example.rs
@@ -8,7 +8,7 @@ async fn main() -> Result<(), ig_client::error::AppError> {
     info!("=== IG Working Orders Example ===");
 
     // Create client
-    let client = Client::default();
+    let client = Client::try_new()?;
     let epic = "DO.D.OTCDDAX.107.IP";
     let epic_info = client.get_market_details(epic).await?;
     let currency: String = epic_info

--- a/examples/other/src/bin/activity_debug.rs
+++ b/examples/other/src/bin/activity_debug.rs
@@ -8,8 +8,8 @@ async fn main() -> Result<(), ig_client::error::AppError> {
     info!("=== Activity Debug Example ===");
 
     // Create HTTP client and config
-    let http_client = HttpClient::default();
     let config = Config::default();
+    let http_client = HttpClient::new_lazy(config.clone())?;
     let session = http_client.get_session().await?;
     info!("Session started successfully");
 

--- a/examples/other/src/bin/activity_example.rs
+++ b/examples/other/src/bin/activity_example.rs
@@ -8,7 +8,7 @@ async fn main() -> Result<(), ig_client::error::AppError> {
     info!("=== Activity Example ===");
 
     // Create client
-    let client = Client::default();
+    let client = Client::try_new()?;
 
     // Get account activity with detailed information
     info!("Fetching account activity with details...");

--- a/examples/other/src/bin/operations_example.rs
+++ b/examples/other/src/bin/operations_example.rs
@@ -24,7 +24,7 @@ async fn main() -> Result<(), AppError> {
 
     info!("Starting operations example");
 
-    let client = Client::new();
+    let client = Client::try_new()?;
 
     println!("\n=== API Application Details ===\n");
 

--- a/examples/other/src/bin/preferences_example.rs
+++ b/examples/other/src/bin/preferences_example.rs
@@ -24,7 +24,7 @@ async fn main() -> Result<(), AppError> {
 
     info!("Starting preferences example");
 
-    let client = Client::new();
+    let client = Client::try_new()?;
 
     println!("\n=== Account Preferences ===\n");
 

--- a/examples/other/src/bin/tx_loop.rs
+++ b/examples/other/src/bin/tx_loop.rs
@@ -67,7 +67,7 @@ async fn main() -> Result<(), ig_client::error::AppError> {
                 info!("Starting scheduled transaction fetch");
 
                 // Create client
-                let client = Client::default();
+                let client = Client::try_new()?;
 
                 // Calculate date range
                 let to = Utc::now().format("%Y-%m-%dT%H:%M:%S").to_string();

--- a/examples/positions/src/bin/position_single.rs
+++ b/examples/positions/src/bin/position_single.rs
@@ -24,7 +24,7 @@ async fn main() -> Result<(), AppError> {
 
     info!("Starting position single example");
 
-    let client = Client::new();
+    let client = Client::try_new()?;
 
     let deal_id = std::env::args().nth(1).unwrap_or_else(|| {
         eprintln!("Usage: cargo run --bin position_single -- <DEAL_ID>");

--- a/examples/positions/src/bin/positions_example.rs
+++ b/examples/positions/src/bin/positions_example.rs
@@ -9,7 +9,7 @@ async fn main() -> Result<(), ig_client::error::AppError> {
     info!("=== IG Positions Example ===");
 
     // Create client
-    let client = Client::default();
+    let client = Client::try_new()?;
 
     // Get open positions
     info!("Fetching open positions...");

--- a/examples/positions/src/bin/positions_switch_account.rs
+++ b/examples/positions/src/bin/positions_switch_account.rs
@@ -38,7 +38,7 @@ async fn main() -> Result<(), ig_client::error::AppError> {
 
     // Create HTTP client and main client
     let http_client = Arc::new(HttpClient::new(config).await?);
-    let client = Client::default();
+    let client = Client::try_new()?;
 
     // Step 1: Login
     info!("\n1. Logging in...");

--- a/examples/positions/src/bin/positions_switch_account_v2.rs
+++ b/examples/positions/src/bin/positions_switch_account_v2.rs
@@ -21,7 +21,7 @@ async fn main() -> Result<(), ig_client::error::AppError> {
 
     // Create HTTP client and main client
     let http_client = Arc::new(HttpClient::new(config).await?);
-    let client = Client::default();
+    let client = Client::try_new()?;
 
     // Step 1: Login
     info!("\n1. Logging in with API v2...");

--- a/examples/prices/src/bin/price_lightstreamer.rs
+++ b/examples/prices/src/bin/price_lightstreamer.rs
@@ -21,7 +21,7 @@ fn callback(update: &PriceData) -> Result<(), AppError> {
 #[tokio::main]
 async fn main() -> Result<(), ig_client::error::AppError> {
     setup_logger();
-    let http_client = Client::default();
+    let http_client = Client::try_new()?;
     let ws_info = http_client.ws_info().await?;
     let password = ws_info.get_ws_password();
     debug!(

--- a/examples/prices/src/bin/price_lightstreamer_channel.rs
+++ b/examples/prices/src/bin/price_lightstreamer_channel.rs
@@ -79,7 +79,7 @@ async fn main() -> Result<(), ig_client::error::AppError> {
     setup_logger();
 
     // Initialize the IG client and get WebSocket credentials
-    let http_client = Client::default();
+    let http_client = Client::try_new()?;
     let ws_info = http_client.ws_info().await?;
     let password = ws_info.get_ws_password();
     debug!(

--- a/examples/sentiment/src/bin/sentiment_multiple.rs
+++ b/examples/sentiment/src/bin/sentiment_multiple.rs
@@ -25,7 +25,7 @@ async fn main() -> Result<(), AppError> {
 
     info!("Starting sentiment multiple markets example");
 
-    let client = Client::new();
+    let client = Client::try_new()?;
 
     let market_ids = vec![
         "EURUSD".to_string(),

--- a/examples/sentiment/src/bin/sentiment_related.rs
+++ b/examples/sentiment/src/bin/sentiment_related.rs
@@ -25,7 +25,7 @@ async fn main() -> Result<(), AppError> {
 
     info!("Starting sentiment related markets example");
 
-    let client = Client::new();
+    let client = Client::try_new()?;
 
     let market_id = "EURUSD";
 

--- a/examples/sentiment/src/bin/sentiment_single.rs
+++ b/examples/sentiment/src/bin/sentiment_single.rs
@@ -25,7 +25,7 @@ async fn main() -> Result<(), AppError> {
 
     info!("Starting sentiment single market example");
 
-    let client = Client::new();
+    let client = Client::try_new()?;
 
     let market_id = "EURUSD";
 

--- a/examples/simples/src/bin/historical_prices_example.rs
+++ b/examples/simples/src/bin/historical_prices_example.rs
@@ -32,7 +32,7 @@ async fn main() -> Result<(), AppError> {
         EPICS.len()
     );
 
-    let client = Client::default();
+    let client = Client::try_new()?;
     info!("Client created and authenticated");
 
     for epic in EPICS {

--- a/examples/simples/src/bin/simple_client_example.rs
+++ b/examples/simples/src/bin/simple_client_example.rs
@@ -13,7 +13,7 @@ async fn main() -> Result<(), ig_client::error::AppError> {
 
     // Create client - authentication happens automatically
     info!("Creating client and authenticating...");
-    let client = Client::default();
+    let client = Client::try_new()?;
     info!("✓ Client created and authenticated");
 
     let epic = "OP.D.OTCGC3.4050C.IP";

--- a/examples/simples/src/bin/simple_rate_limiter.rs
+++ b/examples/simples/src/bin/simple_rate_limiter.rs
@@ -31,7 +31,7 @@ async fn main() -> Result<(), ig_client::error::AppError> {
 
     // Create client - authentication happens automatically
     info!("Creating client and authenticating...");
-    let client = Client::default();
+    let client = Client::try_new()?;
     let epic = "OP.D.OTCGC3.4050C.IP";
     let start = Instant::now();
     let num_requests = 20;

--- a/examples/trade/src/bin/close_position_test.rs
+++ b/examples/trade/src/bin/close_position_test.rs
@@ -9,7 +9,7 @@ async fn main() -> Result<(), ig_client::error::AppError> {
     info!("=== IG Close Position Test ===");
 
     // Create client
-    let client = Client::default();
+    let client = Client::try_new()?;
 
     let epic = "DO.D.OTCDSTXE.GG.IP"; // Example epic for testing
     let expiry = Some(

--- a/examples/trade/src/bin/trade_lightstreamer.rs
+++ b/examples/trade/src/bin/trade_lightstreamer.rs
@@ -19,7 +19,7 @@ fn callback(update: &TradeData) -> Result<(), AppError> {
 #[tokio::main]
 async fn main() -> Result<(), ig_client::error::AppError> {
     setup_logger();
-    let client = Client::default();
+    let client = Client::try_new()?;
     let ws_info = client.ws_info().await?;
     let password = ws_info.get_ws_password();
 

--- a/examples/trade/src/bin/trade_lightstreamer_channel.rs
+++ b/examples/trade/src/bin/trade_lightstreamer_channel.rs
@@ -68,7 +68,7 @@ async fn process_updates(mut receiver: mpsc::Receiver<ItemUpdate>) {
 async fn main() -> Result<(), ig_client::error::AppError> {
     setup_logger();
 
-    let client = Client::default();
+    let client = Client::try_new()?;
     let ws_info = client.ws_info().await?;
     let password = ws_info.get_ws_password();
 

--- a/examples/transactions/src/bin/transactions_example.rs
+++ b/examples/transactions/src/bin/transactions_example.rs
@@ -10,7 +10,7 @@ async fn main() -> Result<(), ig_client::error::AppError> {
     info!("=== IG Transactions Example ===");
 
     // Create client
-    let client = Client::default();
+    let client = Client::try_new()?;
 
     // Get config for database connection
     let config = Config::default();

--- a/examples/watchlist/src/bin/watchlist_create.rs
+++ b/examples/watchlist/src/bin/watchlist_create.rs
@@ -24,7 +24,7 @@ async fn main() -> Result<(), AppError> {
 
     info!("Starting watchlist create example");
 
-    let client = Client::new();
+    let client = Client::try_new()?;
 
     let watchlist_name = "My API Watchlist";
     let initial_epics = vec![

--- a/examples/watchlist/src/bin/watchlist_crud.rs
+++ b/examples/watchlist/src/bin/watchlist_crud.rs
@@ -25,7 +25,7 @@ async fn main() -> Result<(), AppError> {
 
     info!("Starting watchlist CRUD example");
 
-    let client = Client::new();
+    let client = Client::try_new()?;
 
     println!("\n=== Step 1: Create Watchlist ===");
     let result = client.create_watchlist("CRUD Test Watchlist", None).await?;

--- a/examples/watchlist/src/bin/watchlist_list.rs
+++ b/examples/watchlist/src/bin/watchlist_list.rs
@@ -24,7 +24,7 @@ async fn main() -> Result<(), AppError> {
 
     info!("Starting watchlist list example");
 
-    let client = Client::new();
+    let client = Client::try_new()?;
 
     let watchlists = client.get_watchlists().await?;
 

--- a/src/application/auth.rs
+++ b/src/application/auth.rs
@@ -141,26 +141,10 @@ pub struct Auth {
 }
 
 impl Auth {
-    /// Creates a new Auth instance
-    ///
-    /// # Arguments
-    /// * `config` - Configuration containing credentials and API settings
-    ///
-    /// # Panics
-    /// Panics if the underlying `reqwest` client cannot be constructed at
-    /// startup — typically a missing TLS backend, but also invalid proxy or
-    /// certificate configuration. This is an unrecoverable environment
-    /// invariant at construction time. For graceful handling use
-    /// [`Auth::try_new`], which returns a typed [`AppError`] instead of
-    /// panicking.
-    pub fn new(config: Arc<Config>) -> Self {
-        Self::try_new(config).expect("Failed to create HTTP client")
-    }
-
     /// Creates a new Auth instance, returning an error if the HTTP client
     /// cannot be constructed.
     ///
-    /// This is the fallible counterpart to [`Auth::new`]: it surfaces a TLS /
+    /// This is the sole constructor for [`Auth`]: it surfaces a TLS /
     /// client-builder failure as a typed [`AppError`] instead of panicking, so
     /// callers can handle a broken TLS backend gracefully.
     ///
@@ -802,7 +786,8 @@ mod session_lifecycle_tests {
 
     #[tokio::test]
     async fn test_ws_info_uses_cached_session_without_login() {
-        let auth = Auth::new(Arc::new(Config::default()));
+        let auth =
+            Auth::try_new(Arc::new(Config::default())).expect("auth construction should succeed");
 
         // Seed a valid (non-expired) v2 session with known tokens. Because the
         // session is valid, `ws_info` -> `get_session` must return it without a
@@ -942,7 +927,8 @@ mod expiry_and_refresh_tests {
         // refresh_token has an expiry gate: a comfortably-valid session is
         // returned unchanged, so no network login is attempted. This is the
         // behaviour that differs from force_refresh (which always re-logs in).
-        let auth = Auth::new(Arc::new(Config::default()));
+        let auth =
+            Auth::try_new(Arc::new(Config::default())).expect("auth construction should succeed");
         let future = u64::try_from(Utc::now().timestamp())
             .unwrap_or(0)
             .saturating_add(3600);

--- a/src/application/client.rs
+++ b/src/application/client.rs
@@ -1273,7 +1273,8 @@ impl StreamerClient {
     /// Returns [`AppError`] if the login / session lookup or Lightstreamer
     /// client initialization fails.
     pub async fn new() -> Result<Self, AppError> {
-        Self::with_client(&Client::try_new()?).await
+        let client = Client::try_new()?;
+        Self::with_client(&client).await
     }
 
     /// Creates a new streaming client that reuses the caller's existing REST

--- a/src/application/client.rs
+++ b/src/application/client.rs
@@ -177,27 +177,11 @@ pub struct Client {
 }
 
 impl Client {
-    /// Creates a new client instance
-    ///
-    /// # Returns
-    /// A new Client with default configuration
-    ///
-    /// # Panics
-    /// Panics if the underlying [`HttpClient`] cannot be constructed at
-    /// startup — typically a missing TLS backend, but also invalid proxy or
-    /// certificate configuration. This is an unrecoverable environment
-    /// invariant at construction time. For graceful handling use
-    /// [`Client::try_new`], which returns a typed [`AppError`] instead of
-    /// panicking.
-    pub fn new() -> Self {
-        Self::try_new().expect("failed to create HTTP client")
-    }
-
     /// Creates a new client instance without performing initial authentication,
     /// returning an error if the underlying HTTP client cannot be constructed.
     ///
-    /// This is the fallible counterpart to [`Client::new`]: it builds the
-    /// underlying [`HttpClient`] via [`HttpClient::new_lazy`] and surfaces a
+    /// This is the sole constructor for [`Client`]: it builds the underlying
+    /// [`HttpClient`] via [`HttpClient::new_lazy`] and surfaces a
     /// client-construction failure as a typed [`AppError`] instead of panicking.
     ///
     /// # Returns
@@ -238,12 +222,6 @@ impl Client {
     )]
     pub async fn get_ws_info(&self) -> WebsocketInfo {
         self.ws_info().await.unwrap_or_default()
-    }
-}
-
-impl Default for Client {
-    fn default() -> Self {
-        Self::new()
     }
 }
 
@@ -1295,7 +1273,7 @@ impl StreamerClient {
     /// Returns [`AppError`] if the login / session lookup or Lightstreamer
     /// client initialization fails.
     pub async fn new() -> Result<Self, AppError> {
-        Self::with_client(&Client::new()).await
+        Self::with_client(&Client::try_new()?).await
     }
 
     /// Creates a new streaming client that reuses the caller's existing REST

--- a/src/application/http.rs
+++ b/src/application/http.rs
@@ -53,6 +53,11 @@ impl HttpClient {
     /// # Returns
     /// * `Ok(Client)` - Authenticated client ready to use
     /// * `Err(AppError)` - If authentication fails
+    ///
+    /// # Errors
+    /// Returns [`AppError::Network`] if the underlying `reqwest` client cannot
+    /// be built (e.g. the system TLS backend fails to initialize), or any
+    /// [`AppError`] surfaced by the initial [`Auth::login`] call.
     pub async fn new(config: Config) -> Result<Self, AppError> {
         let config = Arc::new(config);
 
@@ -62,8 +67,9 @@ impl HttpClient {
             .build()?;
         let rate_limiter = RateLimiter::new(&config.rate_limiter);
 
-        // Create Auth instance
-        let auth = Arc::new(Auth::new(config.clone()));
+        // Create Auth instance via the fallible constructor so this path never
+        // panics on a broken TLS backend.
+        let auth = Arc::new(Auth::try_new(config.clone())?);
 
         // Perform initial login
         auth.login().await?;
@@ -373,25 +379,6 @@ impl HttpClient {
     /// Gets Auth reference
     pub fn auth(&self) -> &Auth {
         &self.auth
-    }
-}
-
-impl Default for HttpClient {
-    /// Creates a lazily-authenticated client with the default configuration.
-    ///
-    /// # Panics
-    /// Panics if the underlying HTTP client cannot be constructed via
-    /// [`HttpClient::new_lazy`] — typically a missing TLS backend, but also
-    /// invalid proxy or certificate configuration. This is an unrecoverable
-    /// startup invariant. Callers that need to handle that case gracefully
-    /// should call [`HttpClient::new_lazy`] directly and propagate the returned
-    /// [`AppError`] with `?`.
-    fn default() -> Self {
-        let config = Config::default();
-        // Construction normally succeeds; it fails only if the reqwest client
-        // cannot be built (no usable TLS backend, or invalid proxy/certificate
-        // configuration), which is an unrecoverable startup invariant.
-        Self::new_lazy(config).expect("failed to create default HTTP client")
     }
 }
 
@@ -840,7 +827,8 @@ mod tests {
             .await
             .expect("request should reach the mock server");
 
-        let client = HttpClient::default();
+        let client = HttpClient::new_lazy(crate::application::config::Config::default())
+            .expect("lazy HTTP client construction should succeed");
         let result: Result<RequiredFieldDto, AppError> = client.parse_response(response).await;
 
         let msg = match result {
@@ -893,7 +881,8 @@ mod tests {
             .await
             .expect("request should reach the mock server");
 
-        let client = HttpClient::default();
+        let client = HttpClient::new_lazy(crate::application::config::Config::default())
+            .expect("lazy HTTP client construction should succeed");
         let result: Result<RequiredFieldDto, AppError> = client.parse_response(response).await;
 
         let msg = match result {

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -13,7 +13,7 @@
 //! ```rust,ignore
 //! use ig_client::prelude::*;
 //!
-//! let client = Client::default();
+//! let client = Client::try_new()?;
 //! let markets = client.search_markets("EUR").await?;
 //! ```
 

--- a/tests/integration/common.rs
+++ b/tests/integration/common.rs
@@ -6,7 +6,7 @@ use tracing::info;
 
 /// Creates a test client
 pub fn create_test_client() -> Client {
-    Client::default()
+    Client::try_new().expect("client construction should succeed")
 }
 
 /// Performs login and optionally switches to the account specified in the config
@@ -29,7 +29,8 @@ pub fn login_with_account_switch() -> Session {
 /// Note: Account switching is now automatic during Client initialization
 pub async fn login_with_account_switch_async() -> Result<Session, String> {
     setup_logger();
-    let http_client = HttpClient::default();
+    let http_client = HttpClient::new_lazy(Config::default())
+        .expect("lazy HTTP client construction should succeed");
 
     // Login and get a session
     // The Client automatically handles account switching during initialization

--- a/tests/integration/common.rs
+++ b/tests/integration/common.rs
@@ -30,7 +30,7 @@ pub fn login_with_account_switch() -> Session {
 pub async fn login_with_account_switch_async() -> Result<Session, String> {
     setup_logger();
     let http_client = HttpClient::new_lazy(Config::default())
-        .expect("lazy HTTP client construction should succeed");
+        .map_err(|e| format!("lazy HTTP client construction failed: {e}"))?;
 
     // Login and get a session
     // The Client automatically handles account switching during initialization

--- a/tests/unit/application/test_auth_flow.rs
+++ b/tests/unit/application/test_auth_flow.rs
@@ -111,7 +111,8 @@ async fn test_login_v2_returns_session_with_cst_and_security_token() {
         .mount(&server)
         .await;
 
-    let auth = Auth::new(Arc::new(test_config(&server.uri(), 2)));
+    let auth = Auth::try_new(Arc::new(test_config(&server.uri(), 2)))
+        .expect("auth construction should succeed");
     let session = auth.login().await.expect("v2 login should succeed");
 
     assert!(!session.is_oauth());
@@ -131,7 +132,8 @@ async fn test_login_v2_missing_cst_header_yields_missing_session_token() {
         .mount(&server)
         .await;
 
-    let auth = Auth::new(Arc::new(test_config(&server.uri(), 2)));
+    let auth = Auth::try_new(Arc::new(test_config(&server.uri(), 2)))
+        .expect("auth construction should succeed");
     // A rejected / malformed auth response maps to a typed auth error naming
     // the missing header — NOT AppError::InvalidInput (which means bad caller
     // input).
@@ -151,7 +153,8 @@ async fn test_login_v2_missing_security_token_header_yields_missing_session_toke
         .mount(&server)
         .await;
 
-    let auth = Auth::new(Arc::new(test_config(&server.uri(), 2)));
+    let auth = Auth::try_new(Arc::new(test_config(&server.uri(), 2)))
+        .expect("auth construction should succeed");
     match auth.login().await {
         Err(AppError::Auth(AuthError::MissingSessionToken(header))) => {
             assert_eq!(header, "x-security-token");
@@ -170,7 +173,8 @@ async fn test_login_v3_returns_oauth_session() {
         .mount(&server)
         .await;
 
-    let auth = Auth::new(Arc::new(test_config(&server.uri(), 3)));
+    let auth = Auth::try_new(Arc::new(test_config(&server.uri(), 3)))
+        .expect("auth construction should succeed");
     let session = auth.login().await.expect("v3 login should succeed");
 
     assert!(session.is_oauth());
@@ -191,7 +195,8 @@ async fn test_get_session_refreshes_expired_session_with_relogin() {
         .mount(&server)
         .await;
 
-    let auth = Auth::new(Arc::new(test_config(&server.uri(), 3)));
+    let auth = Auth::try_new(Arc::new(test_config(&server.uri(), 3)))
+        .expect("auth construction should succeed");
     let first = auth.login().await.expect("initial login should succeed");
     assert!(first.is_oauth());
 

--- a/tests/unit/application/test_client.rs
+++ b/tests/unit/application/test_client.rs
@@ -4,7 +4,7 @@ use ig_client::error::AppError;
 
 #[tokio::test]
 async fn get_multiple_market_details_empty_returns_default() {
-    let client = Client::new();
+    let client = Client::try_new().expect("client construction should succeed");
     let resp = client
         .get_multiple_market_details(&[])
         .await
@@ -14,7 +14,7 @@ async fn get_multiple_market_details_empty_returns_default() {
 
 #[tokio::test]
 async fn get_multiple_market_details_more_than_50_returns_error() {
-    let client = Client::new();
+    let client = Client::try_new().expect("client construction should succeed");
     // Build 51 dummy EPICs
     let epics: Vec<String> = (0..51).map(|i| format!("EPIC{}", i)).collect();
     let err = client
@@ -30,8 +30,9 @@ async fn get_multiple_market_details_more_than_50_returns_error() {
 }
 
 #[test]
-fn client_default_new_equivalence() {
-    let _c1 = Client::new();
-    let _c2: Client = Default::default();
-    // Construction should not panic; no further assertions needed
+fn client_try_new_succeeds() {
+    // `try_new` is the sole constructor and must not panic; it returns the
+    // built client on a healthy TLS backend.
+    let result = Client::try_new();
+    assert!(result.is_ok(), "client try_new should succeed");
 }


### PR DESCRIPTION
## Summary

Completes #32's zero-panic goal. That PR added the panic-free fallible constructors (`Auth::try_new`, `Client::try_new`, `HttpClient::new_lazy`) but left the infallible-by-signature `new()`/`Default` constructors that could still panic on the reqwest client build. This PR removes them. Breaking (0.12.0).

## Changes

- Removed `impl Default for HttpClient`, `Auth::new`, `Client::new`, and `impl Default for Client` — all of which routed through a `.expect()` on the reqwest build.
- `HttpClient::new_lazy` / `HttpClient::new` (async, login) build `Auth` via `Auth::try_new`; `Client::try_new` is the sole `Client` entry point; `StreamerClient::new` builds via `Client::try_new()?`.
- Migrated 47 example call sites across all 13 example crates + the test suite to the fallible constructors (`Client::default()`/`Client::new()` → `Client::try_new()?`, `HttpClient::default()` → `HttpClient::new_lazy(config)?`, `Auth::new` → `Auth::try_new`).

## Result

`grep '.expect(' src/application/{http,auth,client}.rs` shows only test-only hits — **no production constructor can panic**. `# Errors` docs on the sole entry points.

## Testing

- [x] `make pre-push` clean; all 13 example crates compile; wiremock auth/http tests green; semver passes at 0.12.0

Closes #58
