### PR TITLE
feat(storage): persist historical prices in UTC via snapshotTimeUTC — 0.12.0 (#60)

### DIFF
--- a/src/presentation/market.rs
+++ b/src/presentation/market.rs
@@ -254,9 +254,18 @@ impl MarketData {
 /// Historical price data point
 #[derive(DebugPretty, DisplaySimple, Clone, Serialize, Deserialize)]
 pub struct HistoricalPrice {
-    /// Timestamp of the price data point
+    /// Timestamp of the price data point, in the account's timezone
+    /// (e.g. `"2024/01/15 14:30:00"`). Prefer [`snapshot_time_utc`] for storage.
+    ///
+    /// [`snapshot_time_utc`]: HistoricalPrice::snapshot_time_utc
     #[serde(rename = "snapshotTime")]
     pub snapshot_time: String,
+    /// UTC timestamp of the price data point (`"2024-01-15T14:30:00"`), as IG
+    /// returns it in `snapshotTimeUTC`. Authoritative for persistence — the
+    /// account-timezone `snapshot_time` shifts stored values by the account's
+    /// offset. `None` on older payloads that omit the field.
+    #[serde(rename = "snapshotTimeUTC", default)]
+    pub snapshot_time_utc: Option<String>,
     /// Opening price for the period
     #[serde(rename = "openPrice")]
     pub open_price: PricePoint,
@@ -683,6 +692,43 @@ pub struct MarketFields {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_historical_price_captures_snapshot_time_utc() {
+        // IG returns both snapshotTime (account tz) and snapshotTimeUTC.
+        let json = r#"{
+            "snapshotTime": "2024/01/15 15:30:00",
+            "snapshotTimeUTC": "2024-01-15T14:30:00",
+            "openPrice": { "bid": 1.1, "ask": 1.2, "lastTraded": null },
+            "highPrice": { "bid": 1.3, "ask": 1.4, "lastTraded": null },
+            "lowPrice": { "bid": 1.0, "ask": 1.05, "lastTraded": null },
+            "closePrice": { "bid": 1.25, "ask": 1.26, "lastTraded": null },
+            "lastTradedVolume": 42
+        }"#;
+        let hp: HistoricalPrice = serde_json::from_str(json).expect("deserialize");
+        assert_eq!(hp.snapshot_time, "2024/01/15 15:30:00");
+        assert_eq!(hp.snapshot_time_utc.as_deref(), Some("2024-01-15T14:30:00"));
+
+        // Round-trips through serialize -> deserialize.
+        let round: HistoricalPrice =
+            serde_json::from_str(&serde_json::to_string(&hp).expect("ser")).expect("de");
+        assert_eq!(
+            round.snapshot_time_utc.as_deref(),
+            Some("2024-01-15T14:30:00")
+        );
+
+        // Older payloads without the field default to None.
+        let legacy = r#"{
+            "snapshotTime": "2024/01/15 15:30:00",
+            "openPrice": { "bid": 1.1, "ask": 1.2, "lastTraded": null },
+            "highPrice": { "bid": 1.3, "ask": 1.4, "lastTraded": null },
+            "lowPrice": { "bid": 1.0, "ask": 1.05, "lastTraded": null },
+            "closePrice": { "bid": 1.25, "ask": 1.26, "lastTraded": null },
+            "lastTradedVolume": null
+        }"#;
+        let hp2: HistoricalPrice = serde_json::from_str(legacy).expect("deserialize legacy");
+        assert!(hp2.snapshot_time_utc.is_none());
+    }
 
     #[test]
     fn test_market_data_is_call_returns_true_for_call_option() {

--- a/src/storage/historical_prices.rs
+++ b/src/storage/historical_prices.rs
@@ -179,14 +179,20 @@ pub async fn store_historical_prices(
     for (i, price) in prices.iter().enumerate() {
         stats.total_processed += 1;
 
-        // Parse snapshot time
-        let snapshot_time = match parse_snapshot_time(&price.snapshot_time) {
+        // Parse snapshot time. Prefer the UTC value IG provides in
+        // `snapshotTimeUTC`; the plain `snapshotTime` is in the account's
+        // timezone, so storing it would shift every row by the account offset.
+        let raw_snapshot_time = price
+            .snapshot_time_utc
+            .as_deref()
+            .unwrap_or(&price.snapshot_time);
+        let snapshot_time = match parse_snapshot_time(raw_snapshot_time) {
             Ok(time) => time,
             Err(e) => {
                 warn!(
                     "⚠️  Skipping record {}: Invalid timestamp '{}': {}",
                     i + 1,
-                    price.snapshot_time,
+                    raw_snapshot_time,
                     e
                 );
                 stats.skipped += 1;
@@ -274,12 +280,16 @@ pub async fn store_historical_prices(
 ///
 /// Returns `AppError::Generic` if the timestamp cannot be parsed with any supported format.
 pub fn parse_snapshot_time(snapshot_time: &str) -> Result<DateTime<Utc>, AppError> {
-    // IG format: "yyyy/MM/dd hh:mm:ss" or "yyyy-MM-dd hh:mm:ss"
+    // IG formats: "yyyy/MM/dd hh:mm:ss" / "yyyy-MM-dd hh:mm:ss" (snapshotTime),
+    // and the ISO-8601 "yyyy-MM-ddTHH:mm:ss" that snapshotTimeUTC uses.
     let formats = [
         "%Y/%m/%d %H:%M:%S",
         "%Y-%m-%d %H:%M:%S",
+        "%Y-%m-%dT%H:%M:%S",
+        "%Y-%m-%dT%H:%M:%SZ",
         "%Y/%m/%d %H:%M",
         "%Y-%m-%d %H:%M",
+        "%Y-%m-%dT%H:%M",
     ];
 
     for format in &formats {
@@ -411,6 +421,19 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_snapshot_time_iso_utc_format() {
+        // snapshotTimeUTC uses the ISO-8601 `T` separator, with or without `Z`.
+        for input in ["2024-01-15T14:30:00", "2024-01-15T14:30:00Z"] {
+            let dt =
+                parse_snapshot_time(input).unwrap_or_else(|e| panic!("should parse {input}: {e}"));
+            assert_eq!(
+                dt.format("%Y-%m-%d %H:%M:%S").to_string(),
+                "2024-01-15 14:30:00"
+            );
+        }
+    }
+
+    #[test]
     fn test_parse_snapshot_time_without_seconds_slash() {
         let result = parse_snapshot_time("2024/01/15 14:30");
         assert!(result.is_ok());
@@ -437,10 +460,10 @@ mod tests {
         // Out-of-range components and unsupported separators/orderings must all
         // fail rather than silently coerce.
         for bad in [
-            "2025/13/01 00:00:00",  // invalid month
-            "2025-10-32 00:00:00",  // invalid day
-            "2025-10-20T19:22:33Z", // ISO 8601 separator/timezone (unsupported)
-            "20-10-2025 00:00:00",  // day-month-year order (unsupported)
+            "2025/13/01 00:00:00",       // invalid month
+            "2025-10-32 00:00:00",       // invalid day
+            "20-10-2025 00:00:00",       // day-month-year order (unsupported)
+            "2025-10-20 19:22:33+02:00", // numeric offset (unsupported)
         ] {
             assert!(
                 parse_snapshot_time(bad).is_err(),

--- a/tests/integration/storage_tests.rs
+++ b/tests/integration/storage_tests.rs
@@ -40,6 +40,7 @@ async fn test_pool() -> Option<PgPool> {
 fn sample_price(snapshot: &str) -> HistoricalPrice {
     HistoricalPrice {
         snapshot_time: snapshot.to_string(),
+        snapshot_time_utc: None,
         open_price: PricePoint {
             bid: Some(1.0),
             ask: Some(1.1),

--- a/tests/unit/model/test_responses.rs
+++ b/tests/unit/model/test_responses.rs
@@ -150,6 +150,7 @@ fn multiple_market_details_response_helpers_and_display() {
 fn historical_prices_response_helpers_and_display() {
     let p1 = HistoricalPrice {
         snapshot_time: "2025-10-19T10:00:00".into(),
+        snapshot_time_utc: Some("2025-10-19T09:00:00".into()),
         open_price: PricePoint {
             bid: Some(1.1234),
             ask: Some(1.1236),
@@ -174,6 +175,7 @@ fn historical_prices_response_helpers_and_display() {
     };
     let p2 = HistoricalPrice {
         snapshot_time: "2025-10-19T10:01:00".into(),
+        snapshot_time_utc: None,
         open_price: PricePoint {
             bid: Some(1.2234),
             ask: Some(1.2236),


### PR DESCRIPTION
## Summary

Split from #41. IG's historical-prices payload carries both `snapshotTime` (in the account's timezone) and `snapshotTimeUTC`; `HistoricalPrice` captured only `snapshotTime`, so persisted timestamps were shifted by the account offset. Part of 0.12.0 (breaking DTO field addition).

## Changes

- `HistoricalPrice` gains `snapshot_time_utc: Option<String>` (`#[serde(rename = "snapshotTimeUTC", default)]` — older payloads deserialize to `None`).
- `store_historical_prices` prefers `snapshot_time_utc` over `snapshot_time` when parsing the timestamp to persist, so stored values are UTC.
- `parse_snapshot_time` accepts the ISO-8601 `T` separator (`2024-01-15T14:30:00`, with or without `Z`) that `snapshotTimeUTC` uses, in addition to the existing space-separated formats.

## Public API impact (breaking — 0.12.0)

`HistoricalPrice` (a pub-fields struct) gains a field. `cargo semver-checks` passes at 0.12.0.

## Testing

- [x] Round-trip test from a payload with `snapshotTimeUTC` (asserts capture + round-trip; a legacy payload without it deserializes to `None`)
- [x] `parse_snapshot_time` ISO-8601-`T` test (with/without `Z`)
- [x] `make pre-push` clean; semver passes at 0.12.0

Closes #60
