### PR TITLE
fix(dto): capture dropped IG fields on confirms/TimeInForce/OPU — 0.12.0 (#31)

### DIFF
--- a/src/model/responses.rs
+++ b/src/model/responses.rs
@@ -437,8 +437,9 @@ pub struct CreateWorkingOrderResponse {
 /// Outcome of a deal as reported by the order confirmation endpoint.
 ///
 /// Returned by `GET /confirms/{dealReference}` in the top-level `dealStatus`
-/// field and in each [`AffectedDeal`]. IG documents `ACCEPTED` and `REJECTED`
-/// for this field.
+/// field, for which IG documents `ACCEPTED` and `REJECTED`. This is distinct
+/// from [`AffectedDeal::status`], which reports a per-deal lifecycle status
+/// (e.g. `FULLY_CLOSED`, `PARTIALLY_CLOSED`, `OPENED`).
 #[repr(u8)]
 #[derive(Debug, Clone, Copy, DisplaySimple, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
@@ -458,7 +459,10 @@ pub struct AffectedDeal {
     /// Identifier of the affected deal.
     #[serde(rename = "dealId")]
     pub deal_id: String,
-    /// Status of the affected deal (for example `ACCEPTED`).
+    /// Per-deal lifecycle status — a different domain from the top-level
+    /// [`DealStatus`]; IG returns values such as `FULLY_CLOSED`,
+    /// `PARTIALLY_CLOSED` or `OPENED`. Kept as a `String` because the set is
+    /// broader and less stable than the accept/reject outcome.
     #[serde(rename = "status")]
     pub status: String,
 }

--- a/src/model/responses.rs
+++ b/src/model/responses.rs
@@ -434,6 +434,35 @@ pub struct CreateWorkingOrderResponse {
     pub deal_reference: String,
 }
 
+/// Outcome of a deal as reported by the order confirmation endpoint.
+///
+/// Returned by `GET /confirms/{dealReference}` in the top-level `dealStatus`
+/// field and in each [`AffectedDeal`]. IG documents `ACCEPTED` and `REJECTED`
+/// for this field.
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, DisplaySimple, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum DealStatus {
+    /// The deal was accepted by IG.
+    Accepted,
+    /// The deal was rejected by IG.
+    Rejected,
+}
+
+/// A deal affected by an order confirmation.
+///
+/// IG returns one entry per deal touched by the confirmed order — for example
+/// the individual deals partially closed to fill a closing order.
+#[derive(DebugPretty, DisplaySimple, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct AffectedDeal {
+    /// Identifier of the affected deal.
+    #[serde(rename = "dealId")]
+    pub deal_id: String,
+    /// Status of the affected deal (for example `ACCEPTED`).
+    #[serde(rename = "status")]
+    pub status: String,
+}
+
 /// Details of a confirmed order
 #[derive(DebugPretty, DisplaySimple, Clone, Serialize, Deserialize)]
 pub struct OrderConfirmationResponse {
@@ -451,9 +480,10 @@ pub struct OrderConfirmationResponse {
     /// Client-generated reference for the deal
     #[serde(rename = "dealReference")]
     pub deal_reference: String,
-    /// Status of the deal
+    /// Status of the deal (accepted or rejected)
     #[serde(rename = "dealStatus")]
-    pub deal_status: Option<String>,
+    #[serde(default)]
+    pub deal_status: Option<DealStatus>,
     /// Instrument EPIC identifier
     pub epic: Option<String>,
     /// Expiry date for the order
@@ -484,6 +514,18 @@ pub struct OrderConfirmationResponse {
     pub trailing_stop: Option<bool>,
     /// Direction of the order (buy or sell)
     pub direction: Option<Direction>,
+    /// Deals affected by this confirmation (empty when IG omits the field)
+    #[serde(rename = "affectedDeals")]
+    #[serde(default)]
+    pub affected_deals: Vec<AffectedDeal>,
+    /// Realised profit or loss for the confirmed deal, in `profit_currency`
+    #[serde(rename = "profit")]
+    #[serde(default)]
+    pub profit: Option<f64>,
+    /// Currency in which `profit` is denominated (ISO code, for example `GBP`)
+    #[serde(rename = "profitCurrency")]
+    #[serde(default)]
+    pub profit_currency: Option<String>,
 }
 
 impl std::fmt::Display for MultipleMarketDetailsResponse {

--- a/src/presentation/order.rs
+++ b/src/presentation/order.rs
@@ -93,8 +93,20 @@ pub enum TimeInForce {
     GoodTillCancelled,
     /// Order remains valid until a specified date
     GoodTillDate,
-    /// Order is executed immediately (partially or completely) or cancelled
+    /// Order is executed immediately (partially or completely) or cancelled.
+    ///
+    /// Note: `IMMEDIATE_OR_CANCEL` is not a documented value for IG's OTC
+    /// `timeInForce`; it is retained for backward compatibility. Prefer
+    /// [`TimeInForce::ExecuteAndEliminate`] for partial-fill-then-cancel
+    /// semantics on OTC create/close position endpoints.
     ImmediateOrCancel,
-    /// Order must be filled completely immediately or cancelled
+    /// Order must be filled completely immediately or cancelled.
+    ///
+    /// Serializes to `FILL_OR_KILL`.
     FillOrKill,
+    /// Order fills as much as possible immediately, then cancels the remainder.
+    ///
+    /// Serializes to `EXECUTE_AND_ELIMINATE`. Accepted alongside
+    /// [`TimeInForce::FillOrKill`] by IG's OTC create/close position endpoints.
+    ExecuteAndEliminate,
 }

--- a/src/presentation/trade.rs
+++ b/src/presentation/trade.rs
@@ -91,6 +91,30 @@ pub struct OpenPositionUpdate {
     #[serde(with = "option_string_empty_as_none")]
     #[serde(default)]
     pub deal_id_origin: Option<String>,
+    /// Price level of the stop loss, if set (points).
+    #[serde(rename = "stopLevel")]
+    #[serde(with = "string_as_float_opt")]
+    #[serde(default)]
+    pub stop_level: Option<f64>,
+    /// Price level of the limit (take profit), if set (points).
+    #[serde(rename = "limitLevel")]
+    #[serde(with = "string_as_float_opt")]
+    #[serde(default)]
+    pub limit_level: Option<f64>,
+    /// Whether the stop is a guaranteed stop.
+    #[serde(rename = "guaranteedStop")]
+    #[serde(default)]
+    pub guaranteed_stop: Option<bool>,
+    /// Trailing stop step increment, if a trailing stop is set (points).
+    #[serde(rename = "trailingStep")]
+    #[serde(with = "string_as_float_opt")]
+    #[serde(default)]
+    pub trailing_step: Option<f64>,
+    /// Trailing stop distance from the current level, if set (points).
+    #[serde(rename = "trailingStopDistance")]
+    #[serde(with = "string_as_float_opt")]
+    #[serde(default)]
+    pub trailing_stop_distance: Option<f64>,
 }
 
 /// Structure representing details of a working order update.
@@ -296,6 +320,63 @@ mod tests {
         let opu = fields.opu.expect("OPU should be populated");
         assert_eq!(opu.deal_id.as_deref(), Some("DIAAAAF00SYNTH01"));
         assert_eq!(opu.level, Some(18000.5));
+    }
+
+    #[test]
+    fn test_open_position_update_captures_stop_limit_and_trailing_fields() {
+        // Realistic OPU payload for a position carrying a stop, a limit and a
+        // trailing stop. Deal ids are synthetic; the numeric fields arrive as
+        // strings in the OPU JSON and are parsed via `string_as_float_opt`.
+        let json = r#"{
+            "dealReference": "REF_SYNTHETIC_0002",
+            "dealId": "DIAAAAF00SYNTH02",
+            "dealIdOrigin": "DIAAAAF00SYNTH02",
+            "direction": "SELL",
+            "epic": "IX.D.DAX.DAILY.IP",
+            "status": "OPEN",
+            "dealStatus": "ACCEPTED",
+            "level": "18010.0",
+            "size": "2.0",
+            "currency": "EUR",
+            "timestamp": "2024-01-15T10:31:00.000",
+            "channel": "PublicRestOTC",
+            "expiry": "DFB",
+            "stopLevel": "18100.0",
+            "limitLevel": "17900.0",
+            "guaranteedStop": true,
+            "trailingStep": "5.0",
+            "trailingStopDistance": "50.0"
+        }"#;
+
+        let opu: OpenPositionUpdate = serde_json::from_str(json).expect("deserialize failed");
+        assert_eq!(opu.stop_level, Some(18100.0));
+        assert_eq!(opu.limit_level, Some(17900.0));
+        assert_eq!(opu.guaranteed_stop, Some(true));
+        assert_eq!(opu.trailing_step, Some(5.0));
+        assert_eq!(opu.trailing_stop_distance, Some(50.0));
+
+        // Round-trip leg: compare structs, not JSON text.
+        let out = serde_json::to_string(&opu).expect("serialize failed");
+        let reparsed: OpenPositionUpdate =
+            serde_json::from_str(&out).expect("re-deserialize failed");
+        assert_eq!(reparsed.stop_level, Some(18100.0));
+        assert_eq!(reparsed.limit_level, Some(17900.0));
+        assert_eq!(reparsed.guaranteed_stop, Some(true));
+        assert_eq!(reparsed.trailing_step, Some(5.0));
+        assert_eq!(reparsed.trailing_stop_distance, Some(50.0));
+    }
+
+    #[test]
+    fn test_open_position_update_new_fields_absent_default_to_none() {
+        // The original OPU shape (no stop/limit/trailing keys) must still parse,
+        // with the added fields defaulting to `None`.
+        let opu: OpenPositionUpdate =
+            serde_json::from_str(SANITIZED_OPU_JSON).expect("deserialize failed");
+        assert!(opu.stop_level.is_none());
+        assert!(opu.limit_level.is_none());
+        assert!(opu.guaranteed_stop.is_none());
+        assert!(opu.trailing_step.is_none());
+        assert!(opu.trailing_stop_distance.is_none());
     }
 
     #[test]

--- a/tests/unit/model/test_requests.rs
+++ b/tests/unit/model/test_requests.rs
@@ -9,6 +9,34 @@ fn json_value<T: serde::Serialize>(v: &T) -> serde_json::Value {
 }
 
 #[test]
+fn time_in_force_execute_and_eliminate_serde_round_trips() {
+    // The variant maps to IG's exact wire name.
+    let tif = TimeInForce::ExecuteAndEliminate;
+    let raw = serde_json::to_string(&tif).unwrap();
+    assert_eq!(raw, "\"EXECUTE_AND_ELIMINATE\"");
+
+    let back: TimeInForce = serde_json::from_str("\"EXECUTE_AND_ELIMINATE\"").unwrap();
+    assert_eq!(back, TimeInForce::ExecuteAndEliminate);
+
+    // A request DTO carrying the variant serialises it on the wire and round-trips.
+    let mut order = CreateOrderRequest::market(
+        "CS.D.EURUSD.TODAY.IP".to_string(),
+        Direction::Buy,
+        1.0,
+        Some("EUR".to_string()),
+        Some("REF_EAE".to_string()),
+    );
+    order.time_in_force = TimeInForce::ExecuteAndEliminate;
+
+    let json = json_value(&order);
+    assert_eq!(json.get("timeInForce").unwrap(), "EXECUTE_AND_ELIMINATE");
+
+    let raw = serde_json::to_string(&order).unwrap();
+    let re: CreateOrderRequest = serde_json::from_str(&raw).unwrap();
+    assert_eq!(re.time_in_force, TimeInForce::ExecuteAndEliminate);
+}
+
+#[test]
 fn recent_prices_request_builders() {
     let req = RecentPricesRequest::new("CS.D.EURUSD.TODAY.IP")
         .with_resolution("MINUTE")

--- a/tests/unit/model/test_responses.rs
+++ b/tests/unit/model/test_responses.rs
@@ -417,6 +417,79 @@ fn order_confirmation_response_deserialize_status_and_fields() {
 }
 
 #[test]
+fn order_confirmation_response_captures_affected_deals_profit_and_deal_status() {
+    // Realistic DealConfirmation payload from GET /confirms/{dealReference} for a
+    // closing order that partially matched two open deals. Deal ids are fake.
+    let json = r#"{
+        "date": "2025-10-19T10:15:30.123",
+        "status": "CLOSED",
+        "reason": "SUCCESS",
+        "dealId": "DIAAAABBBBCCCC1",
+        "dealReference": "TEST_REF_0001",
+        "dealStatus": "ACCEPTED",
+        "epic": "CS.D.EURUSD.CFD.IP",
+        "expiry": "-",
+        "guaranteedStop": false,
+        "level": 1.10256,
+        "limitDistance": null,
+        "limitLevel": null,
+        "size": 2.0,
+        "stopDistance": null,
+        "stopLevel": null,
+        "trailingStop": false,
+        "direction": "SELL",
+        "affectedDeals": [
+            { "dealId": "DIAAAABBBBCCCC2", "status": "FULLY_CLOSED" },
+            { "dealId": "DIAAAABBBBCCCC3", "status": "PARTIALLY_CLOSED" }
+        ],
+        "profit": 12.5,
+        "profitCurrency": "GBP"
+    }"#;
+
+    let conf: OrderConfirmationResponse = serde_json::from_str(json).expect("deserialize failed");
+    assert_eq!(conf.deal_status, Some(DealStatus::Accepted));
+    assert_eq!(conf.profit, Some(12.5));
+    assert_eq!(conf.profit_currency.as_deref(), Some("GBP"));
+    assert_eq!(conf.affected_deals.len(), 2);
+    assert_eq!(conf.affected_deals[0].deal_id, "DIAAAABBBBCCCC2");
+    assert_eq!(conf.affected_deals[0].status, "FULLY_CLOSED");
+    assert_eq!(conf.affected_deals[1].deal_id, "DIAAAABBBBCCCC3");
+    assert_eq!(conf.affected_deals[1].status, "PARTIALLY_CLOSED");
+
+    // Round-trip leg: compare structs, not JSON text.
+    let out = serde_json::to_string(&conf).expect("serialize failed");
+    let reparsed: OrderConfirmationResponse =
+        serde_json::from_str(&out).expect("re-deserialize failed");
+    assert_eq!(reparsed.deal_status, Some(DealStatus::Accepted));
+    assert_eq!(reparsed.profit, Some(12.5));
+    assert_eq!(reparsed.profit_currency.as_deref(), Some("GBP"));
+    assert_eq!(reparsed.affected_deals.len(), 2);
+    assert_eq!(reparsed.affected_deals, conf.affected_deals);
+}
+
+#[test]
+fn order_confirmation_response_rejected_deal_status_and_absent_new_fields() {
+    // Minimal rejected confirmation: no affectedDeals / profit / profitCurrency.
+    let json = r#"{
+        "date": "2025-10-19T10:16:00",
+        "status": "REJECTED",
+        "reason": "INSUFFICIENT_FUNDS",
+        "dealId": "DIAAAABBBBCCCC9",
+        "dealReference": "TEST_REF_0002",
+        "dealStatus": "REJECTED",
+        "epic": "CS.D.EURUSD.CFD.IP",
+        "direction": "BUY"
+    }"#;
+
+    let conf: OrderConfirmationResponse = serde_json::from_str(json).expect("deserialize failed");
+    assert_eq!(conf.deal_status, Some(DealStatus::Rejected));
+    assert_eq!(conf.status, Status::Rejected);
+    assert!(conf.affected_deals.is_empty());
+    assert!(conf.profit.is_none());
+    assert!(conf.profit_currency.is_none());
+}
+
+#[test]
 fn simple_deal_reference_responses_serde_field_names() {
     let c = CreateOrderResponse {
         deal_reference: "ABC".into(),


### PR DESCRIPTION
## Summary

Three verified silent field drops against IG's documented payloads — the same failure mode as the `expiryTimestamp` bug fixed in 0.11.4. Part of 0.12.0 (breaking DTO changes).

## Changes

- **`OrderConfirmationResponse`** (GET /confirms/{dealReference}) now captures `affectedDeals` (`Vec<AffectedDeal>` of `dealId` + `status`), `profit`, and `profitCurrency`, and types `deal_status` as a new `DealStatus` enum (ACCEPTED/REJECTED) instead of a raw `Option<String>`.
- **`TimeInForce`** gains `ExecuteAndEliminate` (`EXECUTE_AND_ELIMINATE`), which IG's OTC create/close position endpoints accept alongside `FILL_OR_KILL`. (`ImmediateOrCancel` kept with a doc note that it's not a documented IG OTC value.)
- **`OpenPositionUpdate`** captures `stopLevel`, `limitLevel`, `guaranteedStop`, `trailingStep`, `trailingStopDistance` from the Lightstreamer TRADE:OPU JSON, mirroring `WorkingOrderUpdate` — streaming consumers can now see stop/limit changes on positions.

All added fields carry `#[serde(default)]` so older payloads still deserialize.

## Public API impact (breaking — 0.12.0, additive to the prelude)

New `AffectedDeal`/`DealStatus` types; new fields on `OrderConfirmationResponse`/`OpenPositionUpdate`; `deal_status` retyped; new `TimeInForce` variant. `cargo semver-checks` passes at 0.12.0.

## Testing

- [x] Round-trip tests from realistic payloads: confirms (affectedDeals/profit/dealStatus), a REJECTED + older-shape variant, `TimeInForce::ExecuteAndEliminate` (both directions + on a request DTO), OPU with the five new fields + an older-shape variant
- [x] `make pre-push` clean; semver passes at 0.12.0

Closes #31
