### PR TITLE
refactor: API quality sweep — 0.12.0 (#28)

### DIFF
--- a/examples/streaming/src/bin/dynamic_market_streaming_example.rs
+++ b/examples/streaming/src/bin/dynamic_market_streaming_example.rs
@@ -43,7 +43,7 @@ async fn main() -> Result<(), AppError> {
     ]);
 
     // Create the dynamic streamer
-    let mut streamer = DynamicMarketStreamer::new(fields).await?;
+    let mut streamer = DynamicMarketStreamer::new(fields);
     info!("Dynamic market streamer created");
 
     // Get the receiver for price updates (can only be called once)

--- a/src/application/config.rs
+++ b/src/application/config.rs
@@ -216,6 +216,11 @@ impl Config {
         let page_size = get_env_or_default("TX_PAGE_SIZE", DEFAULT_PAGE_SIZE);
         let days_to_look_back = get_env_or_default("TX_DAYS_LOOKBACK", DAYS_TO_BACK_LOOK);
 
+        let database_url = get_env_or_default(
+            "DATABASE_URL",
+            String::from(crate::constants::DEFAULT_DATABASE_URL),
+        );
+
         // Check if we are using default values
         if username == "default_username" {
             error!("IG_USERNAME not found in environment variables or .env file");
@@ -225,6 +230,11 @@ impl Config {
         }
         if api_key == "default_api_key" {
             error!("IG_API_KEY not found in environment variables or .env file");
+        }
+        if database_url == crate::constants::DEFAULT_DATABASE_URL {
+            // Credential-less placeholder: persistence will not connect until
+            // DATABASE_URL is set. We never fall back to a credentialed default.
+            error!("DATABASE_URL not found in environment variables or .env file");
         }
 
         Config {
@@ -254,10 +264,7 @@ impl Config {
                 reconnect_interval: get_env_or_default("IG_WS_RECONNECT_INTERVAL", 5),
             },
             database: DatabaseConfig {
-                url: get_env_or_default(
-                    "DATABASE_URL",
-                    String::from("postgres://postgres:postgres@localhost/ig"),
-                ),
+                url: database_url,
                 max_connections: get_env_or_default("DATABASE_MAX_CONNECTIONS", 5),
             },
             rate_limiter: RateLimiterConfig {

--- a/src/application/config.rs
+++ b/src/application/config.rs
@@ -231,10 +231,16 @@ impl Config {
         if api_key == "default_api_key" {
             error!("IG_API_KEY not found in environment variables or .env file");
         }
-        if database_url == crate::constants::DEFAULT_DATABASE_URL {
-            // Credential-less placeholder: persistence will not connect until
-            // DATABASE_URL is set. We never fall back to a credentialed default.
-            error!("DATABASE_URL not found in environment variables or .env file");
+        // Check the variable directly rather than comparing the resolved value
+        // to the placeholder: a user may intentionally set a credential-less URL
+        // equal to the placeholder, which is not the "unset" case we warn about.
+        if env::var("DATABASE_URL").is_err() {
+            // Falls back to the credential-less placeholder; persistence will not
+            // connect until DATABASE_URL is set. We never use a credentialed default.
+            error!(
+                "DATABASE_URL not found in environment variables or .env file; \
+                 using a credential-less placeholder and persistence will not connect"
+            );
         }
 
         Config {

--- a/src/application/dynamic_streamer.rs
+++ b/src/application/dynamic_streamer.rs
@@ -41,7 +41,7 @@ use tracing::{debug, info, warn};
 ///     ]);
 ///
 ///     // Create the dynamic streamer
-///     let mut streamer = DynamicMarketStreamer::new(fields).await?;
+///     let mut streamer = DynamicMarketStreamer::new(fields);
 ///
 ///     // Get the receiver for price updates
 ///     let mut receiver = streamer.get_receiver().await?;
@@ -89,13 +89,17 @@ pub struct DynamicMarketStreamer {
 impl DynamicMarketStreamer {
     /// Creates a new dynamic market streamer.
     ///
+    /// Construction only wires up in-memory channels and state, so it neither
+    /// awaits nor fails; establishing the network connection happens later in
+    /// [`start`](Self::start).
+    ///
     /// # Arguments
     ///
     /// * `fields` - Set of market data fields to receive (e.g., BID, OFFER, etc.)
     ///
     /// # Returns
     ///
-    /// Returns a new `DynamicMarketStreamer` instance or an error if initialization fails.
+    /// A new `DynamicMarketStreamer` instance.
     ///
     /// # Examples
     ///
@@ -104,12 +108,13 @@ impl DynamicMarketStreamer {
     ///     StreamingMarketField::Bid,
     ///     StreamingMarketField::Offer,
     /// ]);
-    /// let streamer = DynamicMarketStreamer::new(fields).await?;
+    /// let streamer = DynamicMarketStreamer::new(fields);
     /// ```
-    pub async fn new(fields: HashSet<StreamingMarketField>) -> Result<Self, AppError> {
+    #[must_use]
+    pub fn new(fields: HashSet<StreamingMarketField>) -> Self {
         let (price_tx, price_rx) = mpsc::unbounded_channel();
 
-        Ok(Self {
+        Self {
             epics: Arc::new(RwLock::new(HashSet::new())),
             fields,
             price_tx: Arc::new(RwLock::new(Some(price_tx))),
@@ -117,7 +122,7 @@ impl DynamicMarketStreamer {
             is_connected: Arc::new(RwLock::new(false)),
             shutdown_signal: Arc::new(RwLock::new(None)),
             generation: Arc::new(AtomicU64::new(0)),
-        })
+        }
     }
 
     /// Adds a market EPIC to the subscription list.
@@ -511,9 +516,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_add_inserts_epic_when_not_connected() {
-        let streamer = DynamicMarketStreamer::new(HashSet::new())
-            .await
-            .expect("streamer construction should succeed");
+        let streamer = DynamicMarketStreamer::new(HashSet::new());
 
         let result = streamer.add(TEST_EPIC.to_string()).await;
 
@@ -527,9 +530,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_add_is_idempotent_for_duplicate_epic() {
-        let streamer = DynamicMarketStreamer::new(HashSet::new())
-            .await
-            .expect("streamer construction should succeed");
+        let streamer = DynamicMarketStreamer::new(HashSet::new());
 
         for _ in 0..3 {
             let result = streamer.add(TEST_EPIC.to_string()).await;
@@ -545,9 +546,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_remove_absent_epic_is_noop() {
-        let streamer = DynamicMarketStreamer::new(HashSet::new())
-            .await
-            .expect("streamer construction should succeed");
+        let streamer = DynamicMarketStreamer::new(HashSet::new());
         streamer.epics.write().await.insert(TEST_EPIC.to_string());
 
         let result = streamer.remove(OTHER_EPIC.to_string()).await;
@@ -565,9 +564,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_remove_existing_epic_when_not_connected_empties_set() {
-        let streamer = DynamicMarketStreamer::new(HashSet::new())
-            .await
-            .expect("streamer construction should succeed");
+        let streamer = DynamicMarketStreamer::new(HashSet::new());
         streamer.epics.write().await.insert(TEST_EPIC.to_string());
 
         let result = streamer.remove(TEST_EPIC.to_string()).await;
@@ -583,9 +580,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_receiver_can_only_be_taken_once() {
-        let streamer = DynamicMarketStreamer::new(HashSet::new())
-            .await
-            .expect("streamer construction should succeed");
+        let streamer = DynamicMarketStreamer::new(HashSet::new());
 
         let first = streamer.get_receiver().await;
         assert!(
@@ -604,9 +599,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_is_connected_transitions_on_disconnect() {
-        let mut streamer = DynamicMarketStreamer::new(HashSet::new())
-            .await
-            .expect("streamer construction should succeed");
+        let mut streamer = DynamicMarketStreamer::new(HashSet::new());
 
         // A freshly constructed streamer starts disconnected.
         assert!(
@@ -636,9 +629,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_disconnect_signals_shutdown_and_marks_disconnected() {
-        let mut streamer = DynamicMarketStreamer::new(HashSet::new())
-            .await
-            .expect("streamer construction should succeed");
+        let mut streamer = DynamicMarketStreamer::new(HashSet::new());
 
         // Simulate a live connection with a parked shutdown waiter.
         *streamer.is_connected.write().await = true;
@@ -664,9 +655,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_remove_last_epic_while_connected_signals_reconnect() {
-        let streamer = DynamicMarketStreamer::new(HashSet::new())
-            .await
-            .expect("streamer construction should succeed");
+        let streamer = DynamicMarketStreamer::new(HashSet::new());
 
         // Simulate a live connection subscribed to a single EPIC, with a
         // shutdown signal a connection task would be parked on.
@@ -703,9 +692,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_clear_when_not_connected_empties_epics() {
-        let streamer = DynamicMarketStreamer::new(HashSet::new())
-            .await
-            .expect("streamer construction should succeed");
+        let streamer = DynamicMarketStreamer::new(HashSet::new());
         streamer.epics.write().await.insert(TEST_EPIC.to_string());
 
         let result = streamer.clear().await;
@@ -723,9 +710,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_clear_when_connected_signals_shutdown_and_reports_stopped() {
-        let streamer = DynamicMarketStreamer::new(HashSet::new())
-            .await
-            .expect("streamer construction should succeed");
+        let streamer = DynamicMarketStreamer::new(HashSet::new());
 
         // Simulate a live connection: one EPIC, connected, and a shutdown
         // signal that a connection task would be parked on.
@@ -763,9 +748,7 @@ mod tests {
         // Models the connection-task teardown race: a newer generation is live
         // (is_connected == true) while an older, superseded task finishes tearing
         // its connection down. The superseded task must NOT clear the flag.
-        let streamer = DynamicMarketStreamer::new(HashSet::new())
-            .await
-            .expect("streamer construction should succeed");
+        let streamer = DynamicMarketStreamer::new(HashSet::new());
 
         // A newer connection has come up: bump the generation and mark connected.
         let newer = streamer.generation.fetch_add(1, Ordering::SeqCst) + 1;

--- a/src/application/market_hierarchy.rs
+++ b/src/application/market_hierarchy.rs
@@ -18,7 +18,7 @@ use crate::model::responses::MarketNavigationResponse;
 use crate::presentation::market::{MarketData, MarketNode};
 use std::future::Future;
 use std::pin::Pin;
-use tracing::{debug, error, info};
+use tracing::{debug, error, warn};
 
 /// Builds a market hierarchy recursively by traversing the navigation tree
 ///
@@ -41,29 +41,36 @@ pub fn build_market_hierarchy<'a>(
     Box::pin(async move {
         // Limit the depth to avoid infinite loops
         if depth > 7 {
-            debug!("Reached maximum depth of 5, stopping recursion");
+            debug!(
+                depth,
+                max_depth = 7,
+                "reached maximum recursion depth, stopping"
+            );
             return Ok(Vec::new());
         }
 
         // Get the nodes and markets at the current level
         let navigation: MarketNavigationResponse = match node_id {
             Some(id) => {
-                debug!("Getting navigation node: {}", id);
+                debug!(node_id = %id, "getting navigation node");
                 match client.get_market_navigation_node(id).await {
                     Ok(response) => {
                         debug!(
-                            "Response received for node {}: {} nodes, {} markets",
-                            id,
-                            response.nodes.len(),
-                            response.markets.len()
+                            node_id = %id,
+                            nodes = response.nodes.len(),
+                            markets = response.markets.len(),
+                            "navigation node response received"
                         );
                         response
                     }
                     Err(e) => {
-                        error!("Error getting node {}: {:?}", id, e);
+                        error!(node_id = %id, error = ?e, "error getting navigation node");
                         // If we hit a rate limit, return empty results instead of failing
                         if matches!(e, AppError::RateLimitExceeded | AppError::Unexpected(_)) {
-                            info!("Rate limit or API error encountered, returning partial results");
+                            warn!(
+                                node_id = %id,
+                                "rate limit or API error encountered, returning partial results"
+                            );
                             return Ok(Vec::new());
                         }
                         return Err(e);
@@ -71,18 +78,18 @@ pub fn build_market_hierarchy<'a>(
                 }
             }
             None => {
-                debug!("Getting top-level navigation nodes");
+                debug!("getting top-level navigation nodes");
                 match client.get_market_navigation().await {
                     Ok(response) => {
                         debug!(
-                            "Response received for top-level nodes: {} nodes, {} markets",
-                            response.nodes.len(),
-                            response.markets.len()
+                            nodes = response.nodes.len(),
+                            markets = response.markets.len(),
+                            "top-level navigation response received"
                         );
                         response
                     }
                     Err(e) => {
-                        error!("Error getting top-level nodes: {:?}", e);
+                        error!(error = ?e, "error getting top-level navigation nodes");
                         return Err(e);
                     }
                 }
@@ -102,7 +109,12 @@ pub fn build_market_hierarchy<'a>(
             // Recursively get the children of this node
             match build_market_hierarchy(client, Some(&node.id), depth + 1).await {
                 Ok(children) => {
-                    info!("Adding node {} with {} children", node.name, children.len());
+                    debug!(
+                        node_id = %node.id,
+                        node_name = %node.name,
+                        count = children.len(),
+                        "adding node to hierarchy"
+                    );
                     nodes.push(MarketNode {
                         id: node.id.clone(),
                         name: node.name.clone(),
@@ -111,7 +123,7 @@ pub fn build_market_hierarchy<'a>(
                     });
                 }
                 Err(e) => {
-                    error!("Error building hierarchy for node {}: {:?}", node.id, e);
+                    error!(node_id = %node.id, error = ?e, "error building hierarchy for node");
                     // Continue with other nodes even if one fails
                     if depth < 7 {
                         nodes.push(MarketNode {
@@ -128,7 +140,11 @@ pub fn build_market_hierarchy<'a>(
         // Process all markets in this node
         let markets_to_process = navigation.markets;
         for market in markets_to_process {
-            debug!("Adding market: {}", market.instrument_name);
+            debug!(
+                epic = %market.epic,
+                instrument_name = %market.instrument_name,
+                "adding market to hierarchy"
+            );
             nodes.push(MarketNode {
                 id: market.epic.clone(),
                 name: market.instrument_name.clone(),

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -92,6 +92,15 @@ pub const DEFAULT_ORDER_BUY_LEVEL: f64 = 10000.0;
 /// attempt to switch to this value.
 pub const DEFAULT_ACCOUNT_ID: &str = "default_account_id";
 
+/// Credential-less placeholder used for `DATABASE_URL` when it is not configured.
+///
+/// Persistence is optional, so an unset `DATABASE_URL` is not fatal at config
+/// construction; this placeholder lets `Config::new` produce a value while
+/// deliberately carrying NO username or password. It is not a working
+/// connection string — any component that actually needs Postgres must fail
+/// when it tries to connect. Never hard-code real credentials here.
+pub const DEFAULT_DATABASE_URL: &str = "postgres://localhost/ig";
+
 /// Lifetime of an IG API v2 (CST / X-SECURITY-TOKEN) session, in seconds
 /// (21600 = 6 hours).
 ///

--- a/src/model/requests.rs
+++ b/src/model/requests.rs
@@ -287,27 +287,64 @@ impl CreateOrderRequest {
         deal_reference: Option<String>,
         currency_code: Option<String>,
     ) -> Self {
+        Self::option_to_market(
+            Direction::Sell,
+            true,
+            epic,
+            size,
+            expiry,
+            deal_reference,
+            currency_code,
+        )
+    }
+
+    /// Shared builder behind the four option-to-market limit-order constructors.
+    ///
+    /// The public `sell_option_to_market` / `buy_option_to_market` variants (with
+    /// and without an explicit `force_open`) differ only by `direction` and
+    /// `force_open`; every other field is identical, so the shared body lives
+    /// here to keep the four wrappers in lock-step. The aggressive limit `level`
+    /// is chosen from `direction` (`DEFAULT_ORDER_SELL_LEVEL` for a sell,
+    /// `DEFAULT_ORDER_BUY_LEVEL` for a buy) so the order fills at market. `size`
+    /// is rounded to two decimals via [`round_order_size`]; a missing
+    /// `deal_reference` is auto-generated, and a missing `currency_code` defaults
+    /// to `"EUR"`.
+    #[must_use]
+    fn option_to_market(
+        direction: Direction,
+        force_open: bool,
+        epic: String,
+        size: f64,
+        expiry: Option<String>,
+        deal_reference: Option<String>,
+        currency_code: Option<String>,
+    ) -> Self {
         let rounded_size = round_order_size(size);
 
         let currency_code = currency_code.unwrap_or_else(|| "EUR".to_string());
 
         let deal_reference = deal_reference.or_else(|| Some(crate::utils::id::get_id()));
 
+        let level = match direction {
+            Direction::Sell => DEFAULT_ORDER_SELL_LEVEL,
+            Direction::Buy => DEFAULT_ORDER_BUY_LEVEL,
+        };
+
         Self {
             epic,
-            direction: Direction::Sell,
+            direction,
             size: rounded_size,
             order_type: OrderType::Limit,
             time_in_force: TimeInForce::FillOrKill,
-            level: Some(DEFAULT_ORDER_SELL_LEVEL),
+            level: Some(level),
             guaranteed_stop: false,
             stop_level: None,
             stop_distance: None,
             limit_level: None,
             limit_distance: None,
-            expiry: expiry.clone(),
-            deal_reference: deal_reference.clone(),
-            force_open: true,
+            expiry,
+            deal_reference,
+            force_open,
             currency_code,
             quote_id: None,
             trailing_stop: Some(false),
@@ -356,32 +393,15 @@ impl CreateOrderRequest {
         currency_code: Option<String>,
         force_open: bool, // Compensate position if it is already open
     ) -> Self {
-        let rounded_size = round_order_size(size);
-
-        let currency_code = currency_code.unwrap_or_else(|| "EUR".to_string());
-
-        let deal_reference = deal_reference.or_else(|| Some(crate::utils::id::get_id()));
-
-        Self {
-            epic,
-            direction: Direction::Sell,
-            size: rounded_size,
-            order_type: OrderType::Limit,
-            time_in_force: TimeInForce::FillOrKill,
-            level: Some(DEFAULT_ORDER_SELL_LEVEL),
-            guaranteed_stop: false,
-            stop_level: None,
-            stop_distance: None,
-            limit_level: None,
-            limit_distance: None,
-            expiry: expiry.clone(),
-            deal_reference: deal_reference.clone(),
+        Self::option_to_market(
+            Direction::Sell,
             force_open,
+            epic,
+            size,
+            expiry,
+            deal_reference,
             currency_code,
-            quote_id: None,
-            trailing_stop: Some(false),
-            trailing_stop_increment: None,
-        }
+        )
     }
 
     /// Creates a new instance of an order to buy an option in the market with specified parameters.
@@ -411,32 +431,15 @@ impl CreateOrderRequest {
         deal_reference: Option<String>,
         currency_code: Option<String>,
     ) -> Self {
-        let rounded_size = round_order_size(size);
-
-        let currency_code = currency_code.unwrap_or_else(|| "EUR".to_string());
-
-        let deal_reference = deal_reference.or_else(|| Some(crate::utils::id::get_id()));
-
-        Self {
+        Self::option_to_market(
+            Direction::Buy,
+            true,
             epic,
-            direction: Direction::Buy,
-            size: rounded_size,
-            order_type: OrderType::Limit,
-            time_in_force: TimeInForce::FillOrKill,
-            level: Some(DEFAULT_ORDER_BUY_LEVEL),
-            guaranteed_stop: false,
-            stop_level: None,
-            stop_distance: None,
-            limit_level: None,
-            limit_distance: None,
-            expiry: expiry.clone(),
-            deal_reference: deal_reference.clone(),
-            force_open: true,
-            currency_code: currency_code.clone(),
-            quote_id: None,
-            trailing_stop: Some(false),
-            trailing_stop_increment: None,
-        }
+            size,
+            expiry,
+            deal_reference,
+            currency_code,
+        )
     }
 
     /// Constructs a new instance of an order to buy an option in the market with optional force_open behavior.
@@ -475,32 +478,15 @@ impl CreateOrderRequest {
         currency_code: Option<String>,
         force_open: bool,
     ) -> Self {
-        let rounded_size = round_order_size(size);
-
-        let currency_code = currency_code.unwrap_or_else(|| "EUR".to_string());
-
-        let deal_reference = deal_reference.or_else(|| Some(crate::utils::id::get_id()));
-
-        Self {
-            epic,
-            direction: Direction::Buy,
-            size: rounded_size,
-            order_type: OrderType::Limit,
-            time_in_force: TimeInForce::FillOrKill,
-            level: Some(DEFAULT_ORDER_BUY_LEVEL),
-            guaranteed_stop: false,
-            stop_level: None,
-            stop_distance: None,
-            limit_level: None,
-            limit_distance: None,
-            expiry: expiry.clone(),
-            deal_reference: deal_reference.clone(),
+        Self::option_to_market(
+            Direction::Buy,
             force_open,
-            currency_code: currency_code.clone(),
-            quote_id: None,
-            trailing_stop: Some(false),
-            trailing_stop_increment: None,
-        }
+            epic,
+            size,
+            expiry,
+            deal_reference,
+            currency_code,
+        )
     }
 
     /// Adds a stop loss to the order
@@ -726,7 +712,7 @@ impl ClosePositionRequest {
 }
 
 /// Model for creating a new working order
-#[derive(DebugPretty, DisplaySimple, Clone, Deserialize, Serialize, Default)]
+#[derive(DebugPretty, DisplaySimple, Clone, Deserialize, Serialize)]
 pub struct CreateWorkingOrderRequest {
     /// Instrument EPIC identifier
     pub epic: String,
@@ -989,7 +975,7 @@ pub struct AddToWatchlistRequest {
 // ============================================================================
 
 /// Request to update an existing working order
-#[derive(DebugPretty, DisplaySimple, Clone, Serialize, Deserialize, Default)]
+#[derive(DebugPretty, DisplaySimple, Clone, Serialize, Deserialize)]
 pub struct UpdateWorkingOrderRequest {
     /// Good till date for the order (format: yyyy/MM/dd HH:mm:ss)
     #[serde(rename = "goodTillDate", skip_serializing_if = "Option::is_none")]
@@ -1063,7 +1049,7 @@ impl UpdateWorkingOrderRequest {
 // ============================================================================
 
 /// Request for indicative costs when opening a position
-#[derive(DebugPretty, DisplaySimple, Clone, Serialize, Deserialize, Default)]
+#[derive(DebugPretty, DisplaySimple, Clone, Serialize, Deserialize)]
 pub struct OpenCostsRequest {
     /// Instrument epic
     pub epic: String,
@@ -1106,7 +1092,7 @@ impl OpenCostsRequest {
 }
 
 /// Request for indicative costs when closing a position
-#[derive(DebugPretty, DisplaySimple, Clone, Serialize, Deserialize, Default)]
+#[derive(DebugPretty, DisplaySimple, Clone, Serialize, Deserialize)]
 pub struct CloseCostsRequest {
     /// Deal ID of the position to close
     #[serde(rename = "dealId")]
@@ -1134,7 +1120,7 @@ impl CloseCostsRequest {
 }
 
 /// Request for indicative costs when editing a position
-#[derive(DebugPretty, DisplaySimple, Clone, Serialize, Deserialize, Default)]
+#[derive(DebugPretty, DisplaySimple, Clone, Serialize, Deserialize)]
 pub struct EditCostsRequest {
     /// Deal ID of the position to edit
     #[serde(rename = "dealId")]

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -16,6 +16,22 @@
 //! let client = Client::try_new()?;
 //! let markets = client.search_markets("EUR").await?;
 //! ```
+//!
+//! The prelude is self-sufficient for the streaming API: `StreamerClient`,
+//! `DynamicMarketStreamer`, the `Streaming*Field` selectors and the
+//! [`PriceData`](crate::presentation::price::PriceData) DTO all resolve from a
+//! single glob import, with no extra `use` lines.
+//!
+//! ```rust
+//! use ig_client::prelude::*;
+//!
+//! // Both the streaming client type and the price DTO resolve through the
+//! // prelude alone — no additional imports are required.
+//! fn accepts_price(_price: &PriceData) {}
+//! fn returns_streamer(client: StreamerClient) -> StreamerClient {
+//!     client
+//! }
+//! ```
 
 // Core client
 pub use crate::application::client::Client;
@@ -36,9 +52,17 @@ pub use crate::application::rate_limiter::{RateLimitClass, RateLimiter};
 
 // Service interfaces
 pub use crate::application::interfaces::account::AccountService;
+pub use crate::application::interfaces::costs::CostsService;
 pub use crate::application::interfaces::listener::ListenerResult;
 pub use crate::application::interfaces::market::MarketService;
+pub use crate::application::interfaces::operations::OperationsService;
 pub use crate::application::interfaces::order::OrderService;
+pub use crate::application::interfaces::sentiment::SentimentService;
+pub use crate::application::interfaces::watchlist::WatchlistService;
+
+// Streaming client and subscription manager
+pub use crate::application::client::StreamerClient;
+pub use crate::application::dynamic_streamer::DynamicMarketStreamer;
 
 // Error handling
 pub use crate::error::AppError;
@@ -49,6 +73,7 @@ pub use crate::presentation::chart::*;
 pub use crate::presentation::instrument::*;
 pub use crate::presentation::market::*;
 pub use crate::presentation::order::*;
+pub use crate::presentation::price::PriceData;
 pub use crate::presentation::trade::*;
 pub use crate::presentation::transaction::*;
 
@@ -58,7 +83,18 @@ pub use crate::model::requests::*;
 // Response models
 pub use crate::model::responses::*;
 
-pub use crate::utils::*;
+// Streaming field selectors
+pub use crate::model::streaming::{
+    StreamingAccountDataField, StreamingChartField, StreamingMarketField, StreamingPriceField,
+};
+
+// Utility helpers
+pub use crate::utils::finance::{calculate_percentage_return, calculate_pnl};
+pub use crate::utils::id::get_id;
+pub use crate::utils::logger::setup_logger;
+pub use crate::utils::parsing::{
+    ParsedMarketData, ParsedOptionInfo, normalize_text, parse_instrument_name,
+};
 
 // Re-export commonly used external types
 pub use async_trait::async_trait;

--- a/src/presentation/account.rs
+++ b/src/presentation/account.rs
@@ -7,6 +7,29 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::ops::Add;
 
+/// Returns `true` if an instrument name denotes a call option.
+///
+/// IG encodes the option right in the human-readable `instrumentName` (for
+/// example `"...CALL..."`). The check is a case-sensitive substring match on
+/// the upper-case token IG uses. Shared by every `is_call` accessor in this
+/// module so the classification stays in one place.
+#[must_use]
+#[inline]
+fn is_call_name(name: &str) -> bool {
+    name.contains("CALL")
+}
+
+/// Returns `true` if an instrument name denotes a put option.
+///
+/// Counterpart to [`is_call_name`]: a case-sensitive substring match on the
+/// upper-case `"PUT"` token IG places in `instrumentName`. Shared by every
+/// `is_put` accessor in this module.
+#[must_use]
+#[inline]
+fn is_put_name(name: &str) -> bool {
+    name.contains("PUT")
+}
+
 /// Account information
 #[derive(DebugPretty, DisplaySimple, Clone, Deserialize, Serialize)]
 pub struct AccountInfo {
@@ -324,7 +347,7 @@ impl Position {
     #[must_use]
     #[inline]
     pub fn is_call(&self) -> bool {
-        self.market.instrument_name.contains("CALL")
+        is_call_name(&self.market.instrument_name)
     }
 
     /// Checks if the financial instrument is a "PUT" option.
@@ -341,7 +364,7 @@ impl Position {
     #[must_use]
     #[inline]
     pub fn is_put(&self) -> bool {
-        self.market.instrument_name.contains("PUT")
+        is_put_name(&self.market.instrument_name)
     }
 }
 
@@ -476,7 +499,7 @@ pub struct PositionMarket {
     pub epic: String,
     /// Type of the instrument
     #[serde(rename = "instrumentType")]
-    pub instrument_type: String,
+    pub instrument_type: InstrumentType,
     /// Size of one lot
     #[serde(rename = "lotSize")]
     pub lot_size: f64,
@@ -500,15 +523,15 @@ pub struct PositionMarket {
     /// UTC time of the last price update
     #[serde(rename = "updateTimeUTC")]
     pub update_time_utc: String,
-    /// Delay time in milliseconds for market data
+    /// Delay time in minutes for market data
     #[serde(rename = "delayTime")]
     pub delay_time: i64,
     /// Whether streaming prices are available for this market
     #[serde(rename = "streamingPricesAvailable")]
     pub streaming_prices_available: bool,
-    /// Current status of the market (e.g., "OPEN", "CLOSED")
+    /// Current status of the market (e.g., `TRADEABLE`, `CLOSED`)
     #[serde(rename = "marketStatus")]
-    pub market_status: String,
+    pub market_status: MarketState,
     /// Factor for scaling prices
     #[serde(rename = "scalingFactor")]
     pub scaling_factor: i64,
@@ -527,8 +550,10 @@ impl PositionMarket {
     /// * `true` if the instrument's name contains the substring `"CALL"`, indicating it is a call option.
     /// * `false` otherwise.
     ///
+    #[must_use]
+    #[inline]
     pub fn is_call(&self) -> bool {
-        self.instrument_name.contains("CALL")
+        is_call_name(&self.instrument_name)
     }
 
     /// Checks if the financial instrument is a "PUT" option.
@@ -542,8 +567,10 @@ impl PositionMarket {
     /// * `true` - If `instrument_name` contains the substring "PUT".
     /// * `false` - If `instrument_name` does not contain the substring "PUT".
     ///
+    #[must_use]
+    #[inline]
     pub fn is_put(&self) -> bool {
-        self.instrument_name.contains("PUT")
+        is_put_name(&self.instrument_name)
     }
 }
 
@@ -662,7 +689,7 @@ pub struct AccountMarketData {
     /// UTC time of the last price update
     #[serde(rename = "updateTimeUTC")]
     pub update_time_utc: String,
-    /// Delay time in milliseconds for market data
+    /// Delay time in minutes for market data
     #[serde(rename = "delayTime")]
     pub delay_time: i64,
     /// Whether streaming prices are available for this market
@@ -686,8 +713,10 @@ impl AccountMarketData {
     /// * `true` if the instrument's name contains the substring `"CALL"`, indicating it is a call option.
     /// * `false` otherwise.
     ///
+    #[must_use]
+    #[inline]
     pub fn is_call(&self) -> bool {
-        self.instrument_name.contains("CALL")
+        is_call_name(&self.instrument_name)
     }
 
     /// Checks if the financial instrument is a "PUT" option.
@@ -701,8 +730,10 @@ impl AccountMarketData {
     /// * `true` - If `instrument_name` contains the substring "PUT".
     /// * `false` - If `instrument_name` does not contain the substring "PUT".
     ///
+    #[must_use]
+    #[inline]
     pub fn is_put(&self) -> bool {
-        self.instrument_name.contains("PUT")
+        is_put_name(&self.instrument_name)
     }
 }
 
@@ -782,8 +813,10 @@ impl AccountTransaction {
     /// * `true` if the instrument's name contains the substring `"CALL"`, indicating it is a call option.
     /// * `false` otherwise.
     ///
+    #[must_use]
+    #[inline]
     pub fn is_call(&self) -> bool {
-        self.instrument_name.contains("CALL")
+        is_call_name(&self.instrument_name)
     }
 
     /// Checks if the financial instrument is a "PUT" option.
@@ -797,8 +830,10 @@ impl AccountTransaction {
     /// * `true` - If `instrument_name` contains the substring "PUT".
     /// * `false` - If `instrument_name` does not contain the substring "PUT".
     ///
+    #[must_use]
+    #[inline]
     pub fn is_put(&self) -> bool {
-        self.instrument_name.contains("PUT")
+        is_put_name(&self.instrument_name)
     }
 }
 
@@ -989,7 +1024,7 @@ mod tests {
             instrument_name: "US 500 6910 PUT ($1)".to_string(),
             expiry: "DEC-25".to_string(),
             epic: "OP.D.OTCSPX3.6910P.IP".to_string(),
-            instrument_type: "UNKNOWN".to_string(),
+            instrument_type: InstrumentType::Unknown,
             lot_size: 1.0,
             high: Some(153.43),
             low: Some(147.42),
@@ -1001,7 +1036,7 @@ mod tests {
             update_time_utc: "05:55:59".to_string(),
             delay_time: 0,
             streaming_prices_available: true,
-            market_status: "TRADEABLE".to_string(),
+            market_status: MarketState::Tradeable,
             scaling_factor: 1,
         }
     }

--- a/src/presentation/chart.rs
+++ b/src/presentation/chart.rs
@@ -365,16 +365,22 @@ impl ChartData {
     }
 
     /// Checks if these chart data are of type TICK
+    #[must_use]
+    #[inline]
     pub fn is_tick(&self) -> bool {
         matches!(self.scale, ChartScale::Tick)
     }
 
     /// Checks if these chart data are of type CANDLE (any time scale)
+    #[must_use]
+    #[inline]
     pub fn is_candle(&self) -> bool {
         !self.is_tick()
     }
 
     /// Gets the time scale of the data
+    #[must_use]
+    #[inline]
     pub fn get_scale(&self) -> &ChartScale {
         &self.scale
     }

--- a/src/presentation/market.rs
+++ b/src/presentation/market.rs
@@ -145,7 +145,7 @@ pub struct MarketSnapshot {
     #[serde(rename = "updateTime")]
     pub update_time: Option<String>,
 
-    /// Delay time in milliseconds for market data
+    /// Delay time in minutes for market data
     #[serde(rename = "delayTime")]
     pub delay_time: Option<i64>,
 
@@ -231,6 +231,8 @@ impl MarketData {
     /// * `true` if the instrument's name contains the substring `"CALL"`, indicating it is a call option.
     /// * `false` otherwise.
     ///
+    #[must_use]
+    #[inline]
     pub fn is_call(&self) -> bool {
         self.instrument_name.contains("CALL")
     }
@@ -246,6 +248,8 @@ impl MarketData {
     /// * `true` - If `instrument_name` contains the substring "PUT".
     /// * `false` - If `instrument_name` does not contain the substring "PUT".
     ///
+    #[must_use]
+    #[inline]
     pub fn is_put(&self) -> bool {
         self.instrument_name.contains("PUT")
     }

--- a/src/presentation/transaction.rs
+++ b/src/presentation/transaction.rs
@@ -5,6 +5,16 @@ use pretty_simple_display::{DebugPretty, DisplaySimple};
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 
+/// Absolute P&L magnitude, in EUR, below which a `WITH` (withdrawal / adjustment)
+/// transaction is classified as a fee rather than a realised trade result.
+///
+/// IG reports commissions, overnight funding and similar small charges as `WITH`
+/// transactions carrying a P&L close to zero, whereas a genuine cash movement of
+/// that type has a larger magnitude. Any `WITH` transaction whose absolute
+/// `pnl_eur` is strictly below this threshold is treated as a fee. Denominated in
+/// EUR because `pnl_eur` is normalised to EUR upstream.
+const FEE_THRESHOLD_EUR: f64 = 1.0;
+
 /// Represents a processed transaction from IG Markets with parsed fields
 #[derive(DebugPretty, DisplaySimple, Serialize, Deserialize, PartialEq, Clone, Default)]
 pub struct StoreTransaction {
@@ -97,6 +107,9 @@ impl From<AccountTransaction> for StoreTransaction {
         let deal_date = NaiveDateTime::parse_from_str(&raw.date_utc, "%Y-%m-%dT%H:%M:%S")
             .map(|naive| naive.and_utc())
             .unwrap_or_else(|_| Utc::now());
+        // An unparseable P&L string falls back to 0.0; combined with the fee
+        // classification below, a `WITH` transaction whose amount cannot be parsed
+        // is therefore treated as a fee (0.0 is below `FEE_THRESHOLD_EUR`).
         let pnl_eur = raw
             .profit_and_loss
             .trim_start_matches('E')
@@ -106,7 +119,7 @@ impl From<AccountTransaction> for StoreTransaction {
 
         let expiry = parse_period(&raw.period);
 
-        let is_fee = raw.transaction_type == "WITH" && pnl_eur.abs() < 1.0;
+        let is_fee = raw.transaction_type == "WITH" && pnl_eur.abs() < FEE_THRESHOLD_EUR;
 
         StoreTransaction {
             deal_date,

--- a/src/utils/parsing.rs
+++ b/src/utils/parsing.rs
@@ -37,31 +37,32 @@ impl ParsedMarketData {
     ///
     /// A call option is a financial derivative that gives the holder the right (but not the obligation)
     /// to buy an underlying asset at a specified price within a specified time period. This method checks
-    /// whether the instrument represented by this instance is a call option by inspecting the `instrument_name`
-    /// field.
+    /// whether the instrument is a call option by inspecting the already-parsed `option_type` field.
     ///
     /// # Returns
     ///
-    /// * `true` if the instrument's name contains the substring `"CALL"`, indicating it is a call option.
+    /// * `true` if the parsed `option_type` is exactly `"CALL"`, indicating it is a call option.
     /// * `false` otherwise.
     ///
+    #[must_use]
+    #[inline]
     pub fn is_call(&self) -> bool {
-        self.instrument_name.contains("CALL")
+        self.option_type.as_deref() == Some("CALL")
     }
 
     /// Checks if the financial instrument is a "PUT" option.
     ///
-    /// This method examines the `instrument_name` field of the struct to determine
-    /// if it contains the substring "PUT". If the substring is found, the method
-    /// returns `true`, indicating that the instrument is categorized as a "PUT" option.
-    /// Otherwise, it returns `false`.
+    /// This method inspects the already-parsed `option_type` field rather than
+    /// re-scanning the instrument name, so it stays in sync with the parser.
     ///
     /// # Returns
-    /// * `true` - If `instrument_name` contains the substring "PUT".
-    /// * `false` - If `instrument_name` does not contain the substring "PUT".
+    /// * `true` - If the parsed `option_type` is exactly `"PUT"`.
+    /// * `false` - Otherwise.
     ///
+    #[must_use]
+    #[inline]
     pub fn is_put(&self) -> bool {
-        self.instrument_name.contains("PUT")
+        self.option_type.as_deref() == Some("PUT")
     }
 }
 
@@ -270,6 +271,40 @@ mod tests {
         assert_eq!(info.asset_name, "Germany 40");
         assert_eq!(info.strike, None);
         assert_eq!(info.option_type, None);
+    }
+
+    fn market_with_option_type(option_type: Option<&str>) -> ParsedMarketData {
+        ParsedMarketData {
+            epic: "OP.D.OTCSPX3.6910C.IP".to_string(),
+            instrument_name: "US 500 6910 CALL ($1)".to_string(),
+            expiry: "DEC-25".to_string(),
+            asset_name: "US 500".to_string(),
+            strike: Some("6910".to_string()),
+            option_type: option_type.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn test_parsed_market_data_is_call_uses_parsed_option_type() {
+        let call = market_with_option_type(Some("CALL"));
+        assert!(call.is_call());
+        assert!(!call.is_put());
+    }
+
+    #[test]
+    fn test_parsed_market_data_is_put_uses_parsed_option_type() {
+        let put = market_with_option_type(Some("PUT"));
+        assert!(put.is_put());
+        assert!(!put.is_call());
+    }
+
+    #[test]
+    fn test_parsed_market_data_no_option_type_is_neither() {
+        // A non-option instrument has `option_type == None`, so neither
+        // predicate fires even though the name might contain other tokens.
+        let none = market_with_option_type(None);
+        assert!(!none.is_call());
+        assert!(!none.is_put());
     }
 
     #[test]

--- a/tests/unit/model/test_responses.rs
+++ b/tests/unit/model/test_responses.rs
@@ -291,7 +291,7 @@ fn positions_response_compact_by_epic_merges_positions() {
         instrument_name: "Germany 40".into(),
         expiry: "-".into(),
         epic: "IX.D.DAX.IFD.IP".into(),
-        instrument_type: "INDEX".into(),
+        instrument_type: InstrumentType::Indices,
         lot_size: 1.0,
         high: Some(100.0),
         low: Some(90.0),
@@ -303,7 +303,7 @@ fn positions_response_compact_by_epic_merges_positions() {
         update_time_utc: "08:00:00".into(),
         delay_time: 0,
         streaming_prices_available: true,
-        market_status: "OPEN".into(),
+        market_status: MarketState::Tradeable,
         scaling_factor: 1,
     };
 
@@ -362,6 +362,41 @@ fn positions_response_compact_by_epic_merges_positions() {
     assert!((m.position.level - 55.0).abs() < 1e-9);
     // PnL added
     assert_eq!(m.pnl, Some(6.0));
+}
+
+#[test]
+fn position_market_deserializes_typed_instrument_type_and_market_status() {
+    // Captured `market` object from a GET /positions (v2) response.
+    let json = r#"{
+        "instrumentName": "Germany 40 Cash (€1)",
+        "expiry": "-",
+        "epic": "IX.D.DAX.IFD.IP",
+        "instrumentType": "INDICES",
+        "lotSize": 1.0,
+        "high": 15900.0,
+        "low": 15800.0,
+        "percentageChange": 0.35,
+        "netChange": 55.0,
+        "bid": 15850.0,
+        "offer": 15851.0,
+        "updateTime": "10:00:00",
+        "updateTimeUTC": "08:00:00",
+        "delayTime": 0,
+        "streamingPricesAvailable": true,
+        "marketStatus": "TRADEABLE",
+        "scalingFactor": 1
+    }"#;
+
+    let pm: PositionMarket = serde_json::from_str(json).expect("valid positions market payload");
+    assert_eq!(pm.instrument_type, InstrumentType::Indices);
+    assert_eq!(pm.market_status, MarketState::Tradeable);
+
+    // Round-trip: re-serialize and re-parse yields the same typed values.
+    let round: PositionMarket =
+        serde_json::from_value(json_value(&pm)).expect("round-trip positions market");
+    assert_eq!(round.instrument_type, InstrumentType::Indices);
+    assert_eq!(round.market_status, MarketState::Tradeable);
+    assert_eq!(round.epic, "IX.D.DAX.IFD.IP");
 }
 
 #[test]

--- a/tests/unit/utils/test_finance.rs
+++ b/tests/unit/utils/test_finance.rs
@@ -1,4 +1,6 @@
 use ig_client::presentation::account::{Position, PositionDetails, PositionMarket};
+use ig_client::presentation::instrument::InstrumentType;
+use ig_client::presentation::market::MarketState;
 use ig_client::presentation::order::Direction;
 use ig_client::utils::finance::{calculate_percentage_return, calculate_pnl};
 
@@ -13,7 +15,7 @@ fn create_test_position(
         instrument_name: "Test Instrument".into(),
         expiry: "-".into(),
         epic: "TEST.EPIC".into(),
-        instrument_type: "SHARES".into(),
+        instrument_type: InstrumentType::Shares,
         lot_size: 1.0,
         high: None,
         low: None,
@@ -25,7 +27,7 @@ fn create_test_position(
         update_time_utc: "2024-01-01T00:00:00Z".into(),
         delay_time: 0,
         streaming_prices_available: true,
-        market_status: "TRADEABLE".into(),
+        market_status: MarketState::Tradeable,
         scaling_factor: 1,
     };
 


### PR DESCRIPTION
## Summary

A sweep of low-priority but real quality-debt items across the API surface, each a direct violation of a stated rule (no `Default` without a sensible default, no raw primitives for domain concepts, named constants for magic numbers, `#[must_use]` on pure fns, structured logging, no hard-coded credentials, curated prelude). Part of 0.12.0.

## Changes

- **`Default` derives** dropped from request DTOs with required fields (`CreateWorkingOrderRequest`, `UpdateWorkingOrderRequest`, `Open/Close/EditCostsRequest`) — a `Default` order is a nonsensical order; construction goes through the real constructors.
- **Dedup**: one private `option_to_market` helper backs the four option constructors (redundant clones removed); `is_call`/`is_put` unified into shared helpers (one per data source); `ParsedMarketData` uses the parsed `option_type` instead of a substring search.
- **`FEE_THRESHOLD_EUR`** names the `1.0` fee cutoff.
- **Typed fields**: `PositionMarket.instrument_type`/`market_status` are now `InstrumentType`/`MarketState` (were `String`), matching `AccountMarketData`.
- **`#[must_use]`** on the pure predicates/accessors; `delayTime` docs corrected to **minutes** across DTOs (one said milliseconds — a 60,000× error).
- **Structured logging** in `market_hierarchy`; per-node `info!` → `debug!`.
- **Prelude**: adds the streaming API (`StreamerClient`, `DynamicMarketStreamer`, `PriceData`, the four field enums) and the missing service traits, and replaces the `utils::*` glob with named helpers. A doc-test proves a prelude-only streaming call compiles.
- **`DynamicMarketStreamer::new`** is now sync/infallible (was `async` `Result` with no await).
- **Config**: `Config::new()` no longer hard-codes `postgres://postgres:postgres@localhost/ig`; it uses a credential-less `DEFAULT_DATABASE_URL` placeholder and `error!`-logs when `DATABASE_URL` is unset.

## Testing

- [x] `use ig_client::prelude::*` compiles a snippet calling the streaming API and consuming `PriceData` (doc-test)
- [x] Round-trip/behavior tests for the retyped `PositionMarket`, unified `is_call`/`is_put`, `ParsedMarketData`
- [x] `make pre-push` clean; semver passes at 0.12.0

Closes #28
