### PR TITLE
docs: rewrite lib.rs/README against the real 0.12.0 API (#30)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,13 @@ Add this to your `Cargo.toml`:
 [dependencies]
 ig-client = "0.12.0"
 tokio = { version = "1", features = ["full"] }  # Async runtime
-dotenv = "0.15"                                  # Optional: load a local .env
 tracing = "0.1"                                  # Logging facade
 # Optional, only if you use the PostgreSQL persistence layer:
 sqlx = { version = "0.9", features = ["runtime-tokio", "tls-native-tls", "postgres"] }
 ```
+
+You do not need to add `dotenv` yourself — `Config::new()` loads a local
+`.env` file internally.
 
 #### Requirements
 

--- a/README.md
+++ b/README.md
@@ -12,34 +12,42 @@
 
 ## IG Markets API Client for Rust
 
-A comprehensive Rust client for interacting with the IG Markets trading API. This library provides a type-safe and ergonomic way to access IG Markets' REST and WebSocket APIs for trading and market data retrieval.
+A comprehensive Rust client for the IG Markets trading API. This library
+provides a type-safe, async-first way to access IG Markets' REST and
+real-time streaming APIs for trading and market-data retrieval.
 
 ### Overview
 
-The IG Markets API Client for Rust is designed to provide a reliable and efficient interface to the IG Markets trading platform. It handles authentication, session management, and all API interactions while providing a clean, idiomatic Rust interface for developers.
+The IG Markets API Client for Rust offers a reliable interface to the IG
+Markets trading platform. It handles authentication and session management,
+automatic token refresh, rate limiting, finite retry with backoff, and
+real-time streaming over the Lightstreamer protocol, exposing a clean,
+idiomatic Rust API.
 
 ### Features
 
-- **Authentication**: Secure authentication with the IG Markets API including session refresh and account switching
-- **Account Management**: Access account information, balances, preferences, and activity history
-- **Market Data**: Retrieve market data, prices, instrument details, and historical prices
-- **Order Management**: Create, modify, and close positions and orders with various order types
-- **Working Orders**: Create, update, and manage working orders with support for limit and stop orders
-- **Watchlists**: Full CRUD operations for watchlists including adding/removing instruments
-- **Client Sentiment**: Access client sentiment data for single or multiple markets
-- **Indicative Costs**: Retrieve indicative costs and charges for opening, closing, or editing positions
-- **Transaction History**: Access detailed transaction and activity history
-- **WebSocket Support**: Real-time market data streaming via WebSocket connections
-- **Advanced Rate Limiting**: Sophisticated rate limiting with automatic backoff, concurrent request management, and explicit rate limit error handling
-- **Fully Documented**: Comprehensive documentation for all components and methods
-- **Error Handling**: Robust error handling and reporting with detailed error types
-- **Type Safety**: Strong type checking for API requests and responses
-- **Async Support**: Built with async/await for efficient non-blocking operations
-- **Concurrency Management**: Built-in semaphores and thread-safe primitives for handling concurrent API requests
-- **Configurable**: Flexible configuration options for different environments (demo/live)
-- **Persistence**: Optional database integration for storing historical data
-- **Database Support**: Integration with SQLx for storing and retrieving transaction data
-- **Serialization Utilities**: Custom serialization helpers for handling IG Markets API responses
+- **Authentication**: IG session v2 (`CST` / `X-SECURITY-TOKEN` headers) and
+  v3 (OAuth bearer) with automatic, transparent token refresh and account
+  switching.
+- **Account Management**: Accounts, balances, positions, working orders,
+  preferences, activity, and transaction history.
+- **Market Data**: Market search, instrument details, market navigation, and
+  historical prices at several resolutions.
+- **Order Management**: Create, update, and close positions and working
+  orders with typed request builders.
+- **Watchlists**: Full CRUD over watchlists and their instruments.
+- **Client Sentiment**: Sentiment for single, multiple, and related markets.
+- **Indicative Costs**: Costs and charges for opening, closing, or editing
+  positions, plus cost history.
+- **Real-time Streaming**: Market, price, trade, and account updates over
+  Lightstreamer, with thread-safe dynamic subscription management.
+- **Rate Limiting**: `governor`-backed pacing configured per IG's trading vs
+  non-trading budgets.
+- **Finite Retry**: Exponential backoff with jitter via `RetryConfig`
+  (bounded — no unbounded retry loops).
+- **Type Safety**: Strongly typed request / response DTOs and domain enums.
+- **Async**: Built on `tokio` with a shared, pooled `reqwest` client.
+- **Persistence (optional)**: PostgreSQL storage via `sqlx`.
 
 ### Installation
 
@@ -47,557 +55,350 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-ig-client = "0.11.1"
-tokio = { version = "1", features = ["full"] }  # For async runtime
-dotenv = "0.15"                                 # For environment variable loading
-tracing = "0.1"                                # For logging
-sqlx = { version = "0.8", features = ["runtime-tokio", "postgres"] }  # Optional for database support
+ig-client = "0.12.0"
+tokio = { version = "1", features = ["full"] }  # Async runtime
+dotenv = "0.15"                                  # Optional: load a local .env
+tracing = "0.1"                                  # Logging facade
+# Optional, only if you use the PostgreSQL persistence layer:
+sqlx = { version = "0.9", features = ["runtime-tokio", "tls-native-tls", "postgres"] }
 ```
 
 #### Requirements
 
-- Rust 1.56 or later (for async/await support)
-- An IG Markets account (demo or live)
-- API credentials from IG Markets
-- PostgreSQL database (optional, for data persistence)
+- Rust 2024 edition on the stable toolchain.
+- An IG Markets account (demo or live) and API credentials.
+- A PostgreSQL database (optional, only for the persistence layer).
 
 ### Configuration
 
-Create a `.env` file in your project root with the following variables:
+`Config::new()` reads configuration from the environment (and a local `.env`
+file, if present). Create a `.env` file in your project root with the
+following variables:
 
 ```
 IG_USERNAME=your_username
 IG_PASSWORD=your_password
 IG_API_KEY=your_api_key
 IG_ACCOUNT_ID=your_account_id
-IG_BASE_URL=https://demo-api.ig.com/gateway/deal  # Use demo or live as needed
-IG_TIMEOUT=30  # HTTP request timeout in seconds
-IG_WS_URL=wss://demo-apd.marketdatasystems.com  # WebSocket URL
-IG_WS_RECONNECT=5  # WebSocket reconnect interval in seconds
-DATABASE_URL=postgres://user:password@localhost/ig_db  # Optional for data persistence
-IG_DB_MAX_CONN=5  # Maximum database connections
-TX_LOOP_INTERVAL_HOURS=1  # Transaction loop interval in hours
-TX_PAGE_SIZE=20  # Transaction page size
-TX_DAYS_BACK=7  # Number of days to look back for transactions
+IG_API_VERSION=3                                   # 2 (CST/XST) or 3 (OAuth); defaults to 3
+IG_REST_BASE_URL=https://demo-api.ig.com/gateway/deal   # Use demo or live as needed
+IG_REST_TIMEOUT=30                                 # REST request timeout in seconds
+IG_WS_URL=wss://demo-apd.marketdatasystems.com     # Lightstreamer endpoint
+IG_WS_RECONNECT_INTERVAL=5                         # Reconnect interval in seconds
+IG_RATE_LIMIT_MAX_REQUESTS=4                       # Rate-limiter budget
+IG_RATE_LIMIT_PERIOD_SECONDS=12                    # Rate-limiter period (seconds)
+IG_RATE_LIMIT_BURST_SIZE=3                         # Rate-limiter burst size
+DATABASE_URL=postgres://user:password@localhost/ig_db   # Optional persistence
+DATABASE_MAX_CONNECTIONS=5                         # Optional connection-pool size
+TX_LOOP_INTERVAL_HOURS=1                           # Transaction loop interval (hours)
+TX_PAGE_SIZE=20                                    # Transaction page size
+TX_DAYS_LOOKBACK=7                                 # Days to look back for transactions
 ```
 
-### Usage Examples
+Live examples and integration tests default to the IG **demo** environment;
+pointing anything at production requires an explicit opt-in via
+`IG_REST_BASE_URL` / `IG_WS_URL`.
 
-#### Complete Example Application
+### Usage
 
-Here's a complete example showing how to set up the client, authenticate, and perform various operations:
+The main entry points are `Config` and `Client`. A single `Client`
+implements every REST service trait (`AccountService`, `MarketService`,
+`OrderService`, `WatchlistService`, `SentimentService`, `CostsService`,
+`OperationsService`). Session login and token refresh are performed
+transparently on first use. The prelude re-exports the full public surface,
+including the streaming API and the service traits, so a single glob import
+is usually enough:
 
 ```rust
-use ig_client::application::services::account_service::{AccountService, IgAccountService};
-use ig_client::application::services::market_service::{IgMarketService, MarketService};
-use ig_client::application::services::order_service::{IgOrderService, OrderService};
-use ig_client::application::models::order::{CreateOrderRequest, Direction};
-use ig_client::config::Config;
-use ig_client::session::auth::{IgAuth, IgAuthenticator};
-use std::sync::Arc;
-use dotenv::dotenv;
-use tracing::{info, error, Level};
-use tracing_subscriber::FmtSubscriber;
+use ig_client::prelude::*;
+```
+
+#### Client setup and account information
+
+```rust
+use ig_client::prelude::*;
 
 #[tokio::main]
-async fn main() -> Result<(), ig_client::error::AppError> {
-    // Initialize logging
-    let subscriber = FmtSubscriber::builder()
-        .with_max_level(Level::INFO)
-        .finish();
-    tracing::subscriber::set_global_default(subscriber)?;
+async fn main() -> Result<(), AppError> {
+    // Configuration is read from the environment / a local `.env` file.
+    let config = Config::new();
+    println!("configured API version: {:?}", config.api_version);
 
-    // Load environment variables
-    dotenv().ok();
-    info!("Environment variables loaded");
+    // `try_new` is the fallible constructor for the REST client.
+    // (`new()` / `default()` no longer exist.) Session login and automatic
+    // token refresh happen transparently on the first API call.
+    let client = Client::try_new()?;
 
-    // Create configuration
-    let config = Arc::new(Config::new());
-    info!("Configuration created");
-
-    // Authenticate
-    let auth = IgAuth::new(&config);
-    let session = auth.login().await?;
-    info!("Authentication successful");
-
-    // Create services
-    let account_service = IgAccountService::new(config.clone());
-    let market_service = IgMarketService::new(config.clone());
-    // Get account information
-    let account_info = account_service.get_accounts(&session).await?;
-    info!("Account information retrieved: {} accounts", account_info.accounts.len());
-
-    // Switch to a different account if needed
-    if account_info.accounts.len() > 1 {
-        let target_account = &account_info.accounts[1];
-        let updated_session = auth.switch_account(&session, &target_account.account_id, Some(true)).await?;
-        info!("Switched to account: {}", updated_session.account_id);
-    }
-
-    // Search for a market
-    let search_term = "US 500";
-    let search_results = market_service.search_markets(&session, search_term).await?;
-    info!("Found {} markets matching '{}'", search_results.markets.len(), search_term);
-
-    // Get market details for the first result
-    if let Some(market) = search_results.markets.first() {
-        let epic = &market.epic;
-        let market_details = market_service.get_market_details(&session, epic).await?;
-        info!("Market details for {}: {}", epic, market_details.instrument.name);
-
-        // Get historical prices
-        let prices = market_service.get_prices_by_date(
-            &session,
-            epic,
-            "MINUTE",
-            "1",
-            "2023-01-01T00:00:00",
-            "2023-01-02T00:00:00"
-        ).await?;
-        info!("Retrieved {} price points", prices.prices.len());
-
-        // Check if the market is tradable
-        if market_details.snapshot.market_status == "TRADEABLE" {
-            // Create a market order
-            let order_request = CreateOrderRequest::market(
-                epic.clone(),
-                Direction::Buy,
-                1.0, // Size
-            );
-
-            let order_result = order_service.create_order(&session, &order_request).await?;
-            info!("Order placed: deal reference = {}", order_result.deal_reference);
-
-            // Get positions
-            let positions = account_service.get_positions(&session).await?;
-            info!("Current positions: {}", positions.positions.len());
-        }
-    }
-
-    info!("Example completed successfully");
+    // `Client` implements `AccountService`.
+    let accounts = client.get_accounts().await?;
+    println!("{} account(s) available", accounts.accounts.len());
     Ok(())
 }
 ```
 
-#### Authentication
+#### Market data
 
 ```rust
-use ig_client::session::auth::IgAuth;
-use ig_client::config::Config;
-use std::sync::Arc;
+use ig_client::prelude::*;
 
 #[tokio::main]
-async fn main() -> Result<(), ig_client::error::AppError> {
-    // Load configuration from environment variables
-    let config = Arc::new(Config::new());
+async fn main() -> Result<(), AppError> {
+    let client = Client::try_new()?;
 
-    // Create authentication handler
-    let auth = IgAuth::new(config.clone());
-
-    // Authenticate and get a session
-    let session = auth.authenticate().await?;
-
-    info!("Successfully authenticated!");
+    // `Client` implements `MarketService`.
+    let results = client.search_markets("EUR/USD").await?;
+    if let Some(market) = results.markets.first() {
+        let details = client.get_market_details(&market.epic).await?;
+        println!("{}: {}", market.epic, details.instrument.name);
+    }
     Ok(())
 }
 ```
 
-#### Getting Account Information
+#### Placing an order
 
 ```rust
-use ig_client::application::services::account_service::{AccountService, IgAccountService};
-use std::sync::Arc;
+use ig_client::prelude::*;
 
-// Create account service
-let account_service = IgAccountService::new(config.clone());
+#[tokio::main]
+async fn main() -> Result<(), AppError> {
+    let client = Client::try_new()?;
 
-// Get account information
-let account_info = account_service.get_accounts(&session).await?;
-info!("Accounts: {:?}", account_info);
+    // Build a market order with the typed constructor. `size` is rounded to
+    // two decimals; a `None` currency code defaults to "EUR".
+    let order = CreateOrderRequest::market(
+        "CS.D.EURUSD.CFD.IP".to_string(), // epic
+        Direction::Buy,                   // direction
+        1.0,                              // size
+        Some("USD".to_string()),          // currency_code
+        None,                             // deal_reference
+    );
 
-// Get positions
-let positions = account_service.get_positions(&session).await?;
-info!("Open positions: {}", positions.positions.len());
-
-// Get transaction history
-let from_date = chrono::Utc::now() - chrono::Duration::days(7);
-let to_date = chrono::Utc::now();
-let transactions = account_service.get_transactions(&session, from_date, to_date).await?;
-info!("Transactions in the last week: {}", transactions.transactions.len());
-```
-
-#### Market Data
-
-```rust
-use ig_client::application::services::market_service::{MarketService, IgMarketService};
-
-// Create market service
-let market_service = IgMarketService::new(config.clone());
-
-// Search for markets
-let search_result = market_service.search_markets(&session, "Apple").await?;
-info!("Found {} markets matching 'Apple'", search_result.markets.len());
-
-// Get market details
-if let Some(market) = search_result.markets.first() {
-    let details = market_service.get_market_details(&session, &market.epic).await?;
-    info!("Market details for {}: {}", market.instrument_name, details.instrument.name);
-
-    // Get historical prices
-    let prices = market_service.get_prices(
-        &session,
-        &market.epic,
-        "DAY",   // Resolution
-        30,      // Number of data points
-    ).await?;
-    info!("Retrieved {} historical price points", prices.prices.len());
-}
-```
-
-#### Placing and Managing Orders
-
-```rust
-use ig_client::application::services::order_service::{OrderService, IgOrderService};
-use ig_client::application::models::order::{CreateOrderRequest, Direction, OrderType, TimeInForce};
-
-// Create order service
-let order_service = IgOrderService::new(config.clone());
-
-// Create a market order
-let market_order = CreateOrderRequest::market(
-    "OP.D.OTCDAX1.021100P.IP".to_string(),  // EPIC
-    Direction::Buy,                     // Direction
-    1.0,                               // Size
-    None,                              // Limit level
-    None,                              // Stop level
-);
-
-// Place the order
-let result = order_service.create_order(&session, &market_order).await?;
-info!("Market order placed: {:?}", result);
-
-// Create a limit order
-let limit_order = CreateOrderRequest {
-    epic: "OP.D.OTCDAX1.021100P.IP".to_string(),
-    direction: Direction::Buy,
-    size: 1.0,
-    order_type: OrderType::Limit,
-    level: Some(1.05),  // Limit price
-    guaranteed_stop: false,
-    time_in_force: TimeInForce::GoodTillDate,
-    good_till_date: Some("2025-06-01T12:00:00".to_string()),
-    stop_level: None,
-    stop_distance: None,
-    limit_level: None,
-    limit_distance: None,
-    deal_reference: Some("my-custom-reference".to_string()),
-};
-
-let result = order_service.create_order(&session, &limit_order).await?;
-info!("Limit order placed: {:?}", result);
-
-// Close a position
-let positions = account_service.get_positions(&session).await?;
-if let Some(position) = positions.positions.first() {
-    let close_request = order_service.close_position(
-        &session,
-        &position.position.deal_id,
-        position.position.direction.clone(),
-        position.position.size,
-    ).await?;
-    info!("Position closed: {:?}", close_request);
-}
-```
-
-#### WebSocket Streaming
-
-```rust
-use ig_client::application::services::market_listener::{MarketListener, MarketListenerCallback};
-use ig_client::application::models::market::MarketData;
-use std::sync::Arc;
-use tokio::sync::mpsc;
-
-// Create a channel to receive market updates
-let (tx, mut rx) = mpsc::channel(100);
-
-// Create a callback function to handle market updates
-let callback: MarketListenerCallback = Arc::new(move |market_data: &MarketData| {
-    let data = market_data.clone();
-    let tx = tx.clone();
-    tokio::spawn(async move {
-        let _ = tx.send(data).await;
-    });
+    // `Client` implements `OrderService`.
+    let confirmation = client.create_order(&order).await?;
+    println!("deal reference: {}", confirmation.deal_reference);
     Ok(())
-});
+}
+```
 
-// Create and start the market listener
-let listener = MarketListener::new(callback);
-listener.connect(&session).await?;
+#### Real-time streaming
 
-// Subscribe to market updates
-let epics = vec!["OP.D.OTCDAX1.021100P.IP", "CS.D.USDJPY.CFD.IP"];
-listener.subscribe(&epics).await?;
+`DynamicMarketStreamer` wraps the lower-level `StreamerClient` and manages
+subscriptions in a thread-safe way. Its constructor is **synchronous** — it
+only wires up in-memory channels; the network connection is established later
+by `start`. Updates arrive as `PriceData`, resolved through the prelude.
 
-// Process market updates
-while let Some(market_data) = rx.recv().await {
-    info!("Market update for {}: bid={}, offer={}",
-             market_data.epic, market_data.bid.unwrap_or(0.0), market_data.offer.unwrap_or(0.0));
+```rust
+use ig_client::prelude::*;
+use std::collections::HashSet;
+
+#[tokio::main]
+async fn main() -> Result<(), AppError> {
+    // Fields to receive on each market tick.
+    let fields = HashSet::from([StreamingMarketField::Bid, StreamingMarketField::Offer]);
+
+    // Synchronous construction — no `await`, no fallibility.
+    let mut streamer = DynamicMarketStreamer::new(fields);
+
+    // Take the receiver before connecting.
+    let mut receiver = streamer.get_receiver().await?;
+
+    // Subscribe to an instrument and open the Lightstreamer connection.
+    streamer.add("IX.D.DAX.DAILY.IP".to_string()).await?;
+    streamer.start().await?;
+
+    // Consume `PriceData` updates.
+    while let Some(price) = receiver.recv().await {
+        let price: PriceData = price;
+        println!("price update: {price}");
+    }
+    Ok(())
 }
 ```
 
 ### Available Services
 
-The library provides the following service traits for interacting with the IG Markets API:
+Every service trait below is implemented by `Client`; bring the traits into
+scope via `use ig_client::prelude::*;`.
 
-#### AccountService
-- `get_accounts()` - Get all accounts for the authenticated user
-- `get_positions()` - Get all open positions
-- `get_working_orders()` - Get all working orders
-- `get_activity(from, to)` - Get account activity for a date range
-- `get_activity_by_period(period_ms)` - Get activity for a period in milliseconds
-- `get_transactions(from, to)` - Get transaction history
-- `get_preferences()` - Get account preferences
-- `update_preferences(trailing_stops_enabled)` - Update account preferences
+#### `AccountService`
+- `get_accounts()` — all accounts for the authenticated user
+- `get_positions()` / `get_positions_w_filter(filter)` — open positions
+- `get_working_orders()` — working orders
+- `get_activity(from, to)` / `get_activity_with_details(from, to)` — activity
+- `get_activity_by_period(period_ms)` — activity for a period in milliseconds
+- `get_transactions(from, to)` — transaction history (paginated internally)
+- `get_preferences()` / `update_preferences(trailing_stops_enabled)`
 
-#### MarketService
-- `search_markets(term)` - Search for markets by keyword
-- `get_market_details(epic)` - Get detailed market information
-- `get_multiple_market_details(epics)` - Get details for multiple markets
-- `get_historical_prices(epic, resolution, num_points)` - Get historical price data
-- `get_historical_prices_by_date_range(epic, resolution, start, end)` - Get prices for date range
-- `get_market_navigation()` - Get market navigation hierarchy
-- `get_categories()` - Get market categories
-- `get_instruments_by_category(category)` - Get instruments in a category
+#### `MarketService`
+- `search_markets(term)` — search markets by keyword
+- `get_market_details(epic)` / `get_multiple_market_details(epics)`
+- `get_historical_prices(epic, resolution, from, to)` and
+  `get_historical_prices_by_date_range(epic, resolution, start, end)`
+- `get_historical_prices_by_count_v1` / `_v2(epic, resolution, num_points)`
+- `get_recent_prices(params)`
+- `get_market_navigation()` / `get_market_navigation_node(node_id)`
+- `get_all_markets()` / `get_vec_db_entries()`
+- `get_categories()` / `get_category_instruments(category_id, page, size)`
 
-#### OrderService
-- `create_order(request)` - Create a new market order
-- `get_order_confirmation(deal_reference)` - Get order confirmation
-- `update_position(deal_id, update)` - Update an existing position
-- `close_position(request)` - Close a position
-- `get_position(deal_id)` - Get a single position by deal ID
-- `create_working_order(request)` - Create a working order
-- `update_working_order(deal_id, update)` - Update an existing working order
-- `delete_working_order(deal_id)` - Delete a working order
+#### `OrderService`
+- `create_order(request)` — open a position
+- `get_order_confirmation(deal_reference)` and
+  `get_order_confirmation_w_retry(deal_reference, retries, delay_ms)`
+- `update_position(deal_id, update)` / `update_level_in_position(deal_id, level)`
+- `close_position(request)` / `get_position(deal_id)`
+- `create_working_order(request)` / `update_working_order(deal_id, update)` /
+  `delete_working_order(deal_id)`
 
-#### WatchlistService (New in 0.11.1)
-- `get_watchlists()` - Get all watchlists
-- `create_watchlist(name, epics)` - Create a new watchlist
-- `get_watchlist(id)` - Get watchlist markets
-- `delete_watchlist(id)` - Delete a watchlist
-- `add_to_watchlist(id, epic)` - Add instrument to watchlist
-- `remove_from_watchlist(id, epic)` - Remove instrument from watchlist
+#### `WatchlistService`
+- `get_watchlists()` / `create_watchlist(name, epics)`
+- `get_watchlist(id)` / `delete_watchlist(id)`
+- `add_to_watchlist(id, epic)` / `remove_from_watchlist(id, epic)`
 
-#### SentimentService (New in 0.11.1)
-- `get_client_sentiment(market_ids)` - Get sentiment for multiple markets
-- `get_client_sentiment_by_market(market_id)` - Get sentiment for a single market
-- `get_related_sentiment(market_id)` - Get sentiment for related markets
+#### `SentimentService`
+- `get_client_sentiment(market_ids)`
+- `get_client_sentiment_by_market(market_id)`
+- `get_related_sentiment(market_id)`
 
-#### CostsService (New in 0.11.1)
-- `get_indicative_costs_open(request)` - Get costs for opening a position
-- `get_indicative_costs_close(request)` - Get costs for closing a position
-- `get_indicative_costs_edit(request)` - Get costs for editing a position
-- `get_costs_history(from, to)` - Get historical costs
-- `get_durable_medium(quote_reference)` - Get durable medium document
+#### `CostsService`
+- `get_indicative_costs_open(request)` / `_close(request)` / `_edit(request)`
+- `get_costs_history(from, to)` / `get_durable_medium(quote_reference)`
 
-#### OperationsService (New in 0.11.1)
-- `get_client_apps()` - Get API application details
-- `disable_client_app()` - Disable current API key
+#### `OperationsService`
+- `get_client_apps()` — API application details
+- `disable_client_app()` — disable the current API key
 
-### Documentation
+### Rate Limiting
 
-Comprehensive documentation is available for all components of the library. The documentation includes detailed explanations of all modules, structs, and functions, along with examples of how to use them.
+All requests are paced by a `governor`-backed `RateLimiter` so the client
+stays within IG's published limits (trading and non-trading endpoints have
+different budgets). The budget is configured from the environment via
+`IG_RATE_LIMIT_MAX_REQUESTS`, `IG_RATE_LIMIT_PERIOD_SECONDS`, and
+`IG_RATE_LIMIT_BURST_SIZE` (see `RateLimiterConfig`). On top of pacing,
+transient failures (429 / 5xx / connection errors) are retried with
+**finite** exponential backoff and jitter via `RetryConfig`; non-idempotent
+trading calls are never retried blindly.
+
+### Architecture
+
+The crate is organized as a module-oriented library under `src/`:
+
+- **`application`** — all I/O. The REST `Client` and its service-trait
+  implementations, `Auth` / `Session` (login, refresh, logout, account
+  switching), `Config`, the `RateLimiter`, and the streaming layer
+  (`StreamerClient`, `DynamicMarketStreamer`). Service traits live under
+  `application::interfaces`.
+- **`model`** — pure request / response DTOs, streaming message DTOs, session
+  DTOs, and the retry policy. Serde only; no I/O.
+- **`presentation`** — domain entities per area: account, chart, instrument,
+  market, order, price, trade, transaction. Serde only; no I/O.
+- **`storage`** — optional PostgreSQL persistence via `sqlx` (sits on top of
+  `model` / `presentation`).
+- **`utils`** — leaf helpers: env-var config, logging, finance (P&L), parsing,
+  deal-reference id generation.
+- **`error`** — canonical typed error enums: `AppError`, `AuthError`, and
+  `FetchError`.
+- **`constants`** — crate-wide endpoint paths, header names, and defaults.
+- **`prelude`** — curated public re-exports (the recommended import surface).
 
 #### API Documentation
 
-You can access the API documentation on [docs.rs](https://docs.rs/ig-client) or generate it locally with:
+Browse the API documentation on [docs.rs](https://docs.rs/ig-client) or
+generate it locally with:
 
 ```bash
 make doc-open
 ```
 
-#### Architecture
+### Project Structure
 
-The library is organized into several modules:
-
-- **config**: Configuration handling and environment variable loading
-- **session**: Authentication and session management
-- **application**: Core business logic and services
-  - **models**: Data structures for API requests and responses
-  - **services**: Service implementations for different API areas
-- **transport**: HTTP and WebSocket communication with the IG Markets API
-- **utils**: Utility functions for parsing, logging, etc.
-- **error**: Error types and handling
+```
+src/
+├── application/       # I/O: client, auth, config, rate limiter, streaming
+│   ├── interfaces/    # Service traits (account, market, order, costs, …)
+│   ├── auth.rs        # Auth / Session: login, refresh, logout, switch
+│   ├── client.rs      # Client (REST services) + StreamerClient
+│   ├── config.rs      # Config, Credentials, REST / WS / rate-limiter config
+│   ├── rate_limiter.rs      # governor-backed request pacing
+│   └── dynamic_streamer.rs  # DynamicMarketStreamer (subscriptions)
+├── model/             # Pure DTOs: requests, responses, streaming, retry
+├── presentation/      # Domain entities (account, market, order, price, …)
+├── storage/           # Optional PostgreSQL persistence via sqlx
+├── utils/             # config, logger, finance, parsing, id helpers
+├── constants.rs       # Endpoint paths, header names, defaults
+├── error.rs           # AppError / AuthError / FetchError
+├── prelude.rs         # Curated public re-exports
+└── lib.rs             # Public API and crate docs (README source)
+examples/              # Runnable demos (workspace members)
+tests/                 # unit/ and env-gated integration/ tests
+benches/               # Criterion benchmarks
+```
 
 ### Development
 
-This project includes a comprehensive Makefile with commands for common development tasks.
-
-#### Building
+This project includes a Makefile with common development tasks:
 
 ```bash
 make build        # Debug build
 make release      # Release build
-```
-
-#### Testing
-
-```bash
 make test         # Run all tests
-```
-
-#### Code Quality
-
-```bash
 make fmt          # Format code with rustfmt
-make lint         # Run clippy linter
-make doc          # Check documentation coverage
-make check        # Run tests, format check, and linting
-make pre-push     # Run all checks before pushing code
-```
-
-#### Documentation
-
-```bash
-make doc-open     # Generate and open documentation
-```
-
-#### Code Coverage
-
-```bash
-make coverage     # Generate code coverage report (XML)
-make coverage-html # Generate HTML coverage report
-make open-coverage # Open HTML coverage report
-```
-
-#### Benchmarking
-
-```bash
-make bench        # Run benchmarks
-make bench-show   # Show benchmark results
-```
-
-#### Rate Limiting
-
-The library includes a sophisticated rate limiting system to comply with IG Markets API restrictions:
-
-- **Multiple Rate Limit Types**: Different limits for trading, non-trading, and historical data requests
-- **Thread-Safe Implementation**: Uses `tokio::sync::Mutex` for safe concurrent access
-- **Automatic Backoff**: Dynamically calculates wait times based on request history
-- **Explicit Rate Limit Handling**: Detects and handles rate limit errors from the API
-- **Global Semaphore**: Limits concurrent API requests to prevent overwhelming the API
-- **Configurable Safety Margins**: Adjustable safety margins to stay below API limits
-- **Rate Limit Error Recovery**: Automatic cooldown and recovery when rate limits are exceeded
-
-Example of configuring rate limits:
-
-```rust
-// Create a configuration with custom rate limit settings
-let config = Arc::new(Config::with_rate_limit_type(
-    RateLimitType::NonTradingAccount,  // Type of rate limit to enforce
-    0.8,                               // Safety margin (80% of actual limit)
-));
-
-// The rate limiter will automatically be used by all services
-let http_client = IgHttpClientImpl::new(config.clone());
-let auth = IgAuth::new(config.clone());
-
-// When rate limits are exceeded, the system will automatically:
-// 1. Detect the rate limit error from the API
-// 2. Enforce a mandatory cooldown period
-// 3. Gradually resume requests with appropriate delays
-```
-
-#### Continuous Integration
-
-```bash
-make workflow     # Run all CI workflow steps locally
-```
-
-### Project Structure
-
-```
-├── src/
-│   ├── application/       # Core business logic
-│   │   ├── interfaces/    # Service trait interfaces
-│   │   │   ├── account.rs # Account service trait
-│   │   │   ├── costs.rs   # Costs service trait (v0.11.1)
-│   │   │   ├── market.rs  # Market service trait
-│   │   │   ├── operations.rs # Operations service trait (v0.11.1)
-│   │   │   ├── order.rs   # Order service trait
-│   │   │   ├── sentiment.rs # Sentiment service trait (v0.11.1)
-│   │   │   └── watchlist.rs # Watchlist service trait (v0.11.1)
-│   │   ├── auth.rs        # Authentication handler
-│   │   ├── client.rs      # Main API client
-│   │   └── config.rs      # Configuration handling
-│   ├── model/             # Data models
-│   │   ├── requests.rs    # API request models
-│   │   ├── responses.rs   # API response models
-│   │   └── streaming.rs   # Streaming data models
-│   ├── presentation/      # Presentation layer
-│   │   ├── account.rs     # Account presentation
-│   │   ├── market.rs      # Market presentation
-│   │   └── order.rs       # Order presentation
-│   ├── storage/           # Data persistence
-│   │   └── config.rs      # Database configuration
-│   ├── constants.rs       # Global constants
-│   ├── error.rs           # Error types
-│   └── utils/             # Utility functions
-│       ├── parsing.rs     # Parsing utilities
-│       └── retry.rs       # Retry utilities
-├── examples/              # Example applications
-│   ├── chart/             # Chart examples
-│   ├── costs/             # Costs examples (v0.11.1)
-│   ├── market/            # Market examples
-│   ├── orders/            # Order examples
-│   ├── positions/         # Position examples
-│   ├── sentiment/         # Sentiment examples (v0.11.1)
-│   ├── streaming/         # Streaming examples
-│   ├── watchlist/         # Watchlist examples (v0.11.1)
-│   └── other/             # Other examples
-├── tests/                 # Tests
-│   ├── integration/       # Integration tests
-│   └── unit/              # Unit tests
-└── Makefile              # Development commands
+make lint         # Run clippy
+make readme       # Regenerate README.md from these crate docs
+make pre-push     # Run all checks before pushing
 ```
 
 ### Contributing
 
-Contributions are welcome! Here's how you can contribute:
+Contributions are welcome:
 
-1. Fork the repository
-2. Create a feature branch: `git checkout -b feature/my-feature`
-3. Make your changes and commit them: `git commit -m 'Add some feature'`
-4. Run the tests: `make test`
-5. Push to the branch: `git push origin feature/my-feature`
-6. Submit a pull request
+1. Fork the repository.
+2. Create a feature branch: `git checkout -b feature/my-feature`.
+3. Make your changes and commit them.
+4. Run the checks: `make pre-push`.
+5. Push the branch and open a pull request.
 
-Please make sure your code passes all tests and linting checks before submitting a pull request.
+Please make sure your code passes all tests and linting checks before
+submitting a pull request.
 
-## What's New in 0.11.1
+## What's New in 0.12.0
 
-This release adds comprehensive API coverage with the following new services:
+A large correctness, safety, and API-consistency release. Highlights:
 
-### New Services
-- **WatchlistService** - Full CRUD operations for watchlists
-  - `get_watchlists()`, `create_watchlist()`, `get_watchlist()`, `delete_watchlist()`
-  - `add_to_watchlist()`, `remove_from_watchlist()`
-- **SentimentService** - Client sentiment data
-  - `get_client_sentiment()`, `get_client_sentiment_by_market()`, `get_related_sentiment()`
-- **CostsService** - Indicative costs and charges
-  - `get_indicative_costs_open()`, `get_indicative_costs_close()`, `get_indicative_costs_edit()`
-  - `get_costs_history()`, `get_durable_medium()`
-- **OperationsService** - API application management
-  - `get_client_apps()`, `disable_client_app()`
+### Security & reliability
+- Credentials, session tokens (CST / X-SECURITY-TOKEN / OAuth) and the DB
+  connection URL are redacted from `Debug`/`Display` and never logged.
+- Retries are finite by default with exponential backoff + jitter; HTTP 429
+  is retried; unbounded retry loops are gone.
+- The rate limiter honours the configured `max_requests` and separates the
+  trading, non-trading and historical budgets.
+- Token expiry/refresh is consistent (single refresh-and-replay on 401); the
+  streaming connection no longer holds a lock across its lifetime and every
+  spawned task has a shutdown path.
 
-### Extended Services
-- **AccountService** - Added `get_preferences()`, `update_preferences()`, `get_activity_by_period()`
-- **OrderService** - Added `get_position()`, `update_working_order()`
+### Correctness
+- Order size rounds to the nearest tick (no more `0.29 → 0.28`); P&L math is
+  unified and correct when a market price is missing; position netting takes
+  the larger side's direction.
+- Storage: the unique-constraint migration actually runs, empty-epic stats no
+  longer panic, `instrument_type` is stored unquoted, and historical prices
+  persist in UTC (`snapshotTimeUTC`).
+- DTOs capture previously-dropped IG fields (`affectedDeals`/`profit` on
+  confirms, `EXECUTE_AND_ELIMINATE`, OPU stop/limit/trailing fields); IG
+  numeric fields are `i64`/unsigned, not `i32`.
 
-### New Examples
-- `examples/watchlist/` - Watchlist management examples
-- `examples/sentiment/` - Client sentiment examples
-- `examples/costs/` - Indicative costs examples
-- Additional examples in `positions/`, `orders/`, and `other/`
+### API & structure (breaking — 0.12.0)
+- Constructors are fallible and panic-free: use `Client::try_new()`,
+  `Auth::try_new()`, `HttpClient::new_lazy()` (`new()`/`Default` removed).
+- Module boundaries restored: `model`/`presentation` are pure DTO layers;
+  `HttpClient` and the streaming adapters live in `application`.
+- Typed errors are wired up (`AuthError`, deserialization context with the
+  auth-response body redacted). The prelude now exports the streaming API and
+  all service traits.
+
+### Testing
+- Offline test coverage for the auth flow, HTTP retry/status mapping,
+  streaming lifecycle, and serde round-trips (via a `wiremock` dev-dependency).
 
 ## Contribution 
 

--- a/README.tpl
+++ b/README.tpl
@@ -12,31 +12,44 @@
 
 {{readme}}
 
-## What's New in 0.11.1
+## What's New in 0.12.0
 
-This release adds comprehensive API coverage with the following new services:
+A large correctness, safety, and API-consistency release. Highlights:
 
-### New Services
-- **WatchlistService** - Full CRUD operations for watchlists
-  - `get_watchlists()`, `create_watchlist()`, `get_watchlist()`, `delete_watchlist()`
-  - `add_to_watchlist()`, `remove_from_watchlist()`
-- **SentimentService** - Client sentiment data
-  - `get_client_sentiment()`, `get_client_sentiment_by_market()`, `get_related_sentiment()`
-- **CostsService** - Indicative costs and charges
-  - `get_indicative_costs_open()`, `get_indicative_costs_close()`, `get_indicative_costs_edit()`
-  - `get_costs_history()`, `get_durable_medium()`
-- **OperationsService** - API application management
-  - `get_client_apps()`, `disable_client_app()`
+### Security & reliability
+- Credentials, session tokens (CST / X-SECURITY-TOKEN / OAuth) and the DB
+  connection URL are redacted from `Debug`/`Display` and never logged.
+- Retries are finite by default with exponential backoff + jitter; HTTP 429
+  is retried; unbounded retry loops are gone.
+- The rate limiter honours the configured `max_requests` and separates the
+  trading, non-trading and historical budgets.
+- Token expiry/refresh is consistent (single refresh-and-replay on 401); the
+  streaming connection no longer holds a lock across its lifetime and every
+  spawned task has a shutdown path.
 
-### Extended Services
-- **AccountService** - Added `get_preferences()`, `update_preferences()`, `get_activity_by_period()`
-- **OrderService** - Added `get_position()`, `update_working_order()`
+### Correctness
+- Order size rounds to the nearest tick (no more `0.29 → 0.28`); P&L math is
+  unified and correct when a market price is missing; position netting takes
+  the larger side's direction.
+- Storage: the unique-constraint migration actually runs, empty-epic stats no
+  longer panic, `instrument_type` is stored unquoted, and historical prices
+  persist in UTC (`snapshotTimeUTC`).
+- DTOs capture previously-dropped IG fields (`affectedDeals`/`profit` on
+  confirms, `EXECUTE_AND_ELIMINATE`, OPU stop/limit/trailing fields); IG
+  numeric fields are `i64`/unsigned, not `i32`.
 
-### New Examples
-- `examples/watchlist/` - Watchlist management examples
-- `examples/sentiment/` - Client sentiment examples
-- `examples/costs/` - Indicative costs examples
-- Additional examples in `positions/`, `orders/`, and `other/`
+### API & structure (breaking — 0.12.0)
+- Constructors are fallible and panic-free: use `Client::try_new()`,
+  `Auth::try_new()`, `HttpClient::new_lazy()` (`new()`/`Default` removed).
+- Module boundaries restored: `model`/`presentation` are pure DTO layers;
+  `HttpClient` and the streaming adapters live in `application`.
+- Typed errors are wired up (`AuthError`, deserialization context with the
+  auth-response body redacted). The prelude now exports the streaming API and
+  all service traits.
+
+### Testing
+- Offline test coverage for the auth flow, HTTP retry/status mapping,
+  streaming lifecycle, and serde round-trips (via a `wiremock` dev-dependency).
 
 ## Contribution 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,11 +45,13 @@
 //! [dependencies]
 //! ig-client = "0.12.0"
 //! tokio = { version = "1", features = ["full"] }  # Async runtime
-//! dotenv = "0.15"                                  # Optional: load a local .env
 //! tracing = "0.1"                                  # Logging facade
 //! # Optional, only if you use the PostgreSQL persistence layer:
 //! sqlx = { version = "0.9", features = ["runtime-tokio", "tls-native-tls", "postgres"] }
 //! ```
+//!
+//! You do not need to add `dotenv` yourself — `Config::new()` loads a local
+//! `.env` file internally.
 //!
 //! ### Requirements
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,33 +1,41 @@
 //! # IG Markets API Client for Rust
 //!
-//! A comprehensive Rust client for interacting with the IG Markets trading API. This library provides a type-safe and ergonomic way to access IG Markets' REST and WebSocket APIs for trading and market data retrieval.
+//! A comprehensive Rust client for the IG Markets trading API. This library
+//! provides a type-safe, async-first way to access IG Markets' REST and
+//! real-time streaming APIs for trading and market-data retrieval.
 //!
 //! ## Overview
 //!
-//! The IG Markets API Client for Rust is designed to provide a reliable and efficient interface to the IG Markets trading platform. It handles authentication, session management, and all API interactions while providing a clean, idiomatic Rust interface for developers.
+//! The IG Markets API Client for Rust offers a reliable interface to the IG
+//! Markets trading platform. It handles authentication and session management,
+//! automatic token refresh, rate limiting, finite retry with backoff, and
+//! real-time streaming over the Lightstreamer protocol, exposing a clean,
+//! idiomatic Rust API.
 //!
 //! ## Features
 //!
-//! - **Authentication**: Secure authentication with the IG Markets API including session refresh and account switching
-//! - **Account Management**: Access account information, balances, preferences, and activity history
-//! - **Market Data**: Retrieve market data, prices, instrument details, and historical prices
-//! - **Order Management**: Create, modify, and close positions and orders with various order types
-//! - **Working Orders**: Create, update, and manage working orders with support for limit and stop orders
-//! - **Watchlists**: Full CRUD operations for watchlists including adding/removing instruments
-//! - **Client Sentiment**: Access client sentiment data for single or multiple markets
-//! - **Indicative Costs**: Retrieve indicative costs and charges for opening, closing, or editing positions
-//! - **Transaction History**: Access detailed transaction and activity history
-//! - **WebSocket Support**: Real-time market data streaming via WebSocket connections
-//! - **Advanced Rate Limiting**: Sophisticated rate limiting with automatic backoff, concurrent request management, and explicit rate limit error handling
-//! - **Fully Documented**: Comprehensive documentation for all components and methods
-//! - **Error Handling**: Robust error handling and reporting with detailed error types
-//! - **Type Safety**: Strong type checking for API requests and responses
-//! - **Async Support**: Built with async/await for efficient non-blocking operations
-//! - **Concurrency Management**: Built-in semaphores and thread-safe primitives for handling concurrent API requests
-//! - **Configurable**: Flexible configuration options for different environments (demo/live)
-//! - **Persistence**: Optional database integration for storing historical data
-//! - **Database Support**: Integration with SQLx for storing and retrieving transaction data
-//! - **Serialization Utilities**: Custom serialization helpers for handling IG Markets API responses
+//! - **Authentication**: IG session v2 (`CST` / `X-SECURITY-TOKEN` headers) and
+//!   v3 (OAuth bearer) with automatic, transparent token refresh and account
+//!   switching.
+//! - **Account Management**: Accounts, balances, positions, working orders,
+//!   preferences, activity, and transaction history.
+//! - **Market Data**: Market search, instrument details, market navigation, and
+//!   historical prices at several resolutions.
+//! - **Order Management**: Create, update, and close positions and working
+//!   orders with typed request builders.
+//! - **Watchlists**: Full CRUD over watchlists and their instruments.
+//! - **Client Sentiment**: Sentiment for single, multiple, and related markets.
+//! - **Indicative Costs**: Costs and charges for opening, closing, or editing
+//!   positions, plus cost history.
+//! - **Real-time Streaming**: Market, price, trade, and account updates over
+//!   Lightstreamer, with thread-safe dynamic subscription management.
+//! - **Rate Limiting**: `governor`-backed pacing configured per IG's trading vs
+//!   non-trading budgets.
+//! - **Finite Retry**: Exponential backoff with jitter via `RetryConfig`
+//!   (bounded — no unbounded retry loops).
+//! - **Type Safety**: Strongly typed request / response DTOs and domain enums.
+//! - **Async**: Built on `tokio` with a shared, pooled `reqwest` client.
+//! - **Persistence (optional)**: PostgreSQL storage via `sqlx`.
 //!
 //! ## Installation
 //!
@@ -35,531 +43,311 @@
 //!
 //! ```toml
 //! [dependencies]
-//! ig-client = "0.11.1"
-//! tokio = { version = "1", features = ["full"] }  # For async runtime
-//! dotenv = "0.15"                                 # For environment variable loading
-//! tracing = "0.1"                                # For logging
-//! sqlx = { version = "0.8", features = ["runtime-tokio", "postgres"] }  # Optional for database support
+//! ig-client = "0.12.0"
+//! tokio = { version = "1", features = ["full"] }  # Async runtime
+//! dotenv = "0.15"                                  # Optional: load a local .env
+//! tracing = "0.1"                                  # Logging facade
+//! # Optional, only if you use the PostgreSQL persistence layer:
+//! sqlx = { version = "0.9", features = ["runtime-tokio", "tls-native-tls", "postgres"] }
 //! ```
 //!
 //! ### Requirements
 //!
-//! - Rust 1.56 or later (for async/await support)
-//! - An IG Markets account (demo or live)
-//! - API credentials from IG Markets
-//! - PostgreSQL database (optional, for data persistence)
+//! - Rust 2024 edition on the stable toolchain.
+//! - An IG Markets account (demo or live) and API credentials.
+//! - A PostgreSQL database (optional, only for the persistence layer).
 //!
 //! ## Configuration
 //!
-//! Create a `.env` file in your project root with the following variables:
+//! `Config::new()` reads configuration from the environment (and a local `.env`
+//! file, if present). Create a `.env` file in your project root with the
+//! following variables:
 //!
 //! ```text
 //! IG_USERNAME=your_username
 //! IG_PASSWORD=your_password
 //! IG_API_KEY=your_api_key
 //! IG_ACCOUNT_ID=your_account_id
-//! IG_BASE_URL=https://demo-api.ig.com/gateway/deal  # Use demo or live as needed
-//! IG_TIMEOUT=30  # HTTP request timeout in seconds
-//! IG_WS_URL=wss://demo-apd.marketdatasystems.com  # WebSocket URL
-//! IG_WS_RECONNECT=5  # WebSocket reconnect interval in seconds
-//! DATABASE_URL=postgres://user:password@localhost/ig_db  # Optional for data persistence
-//! IG_DB_MAX_CONN=5  # Maximum database connections
-//! TX_LOOP_INTERVAL_HOURS=1  # Transaction loop interval in hours
-//! TX_PAGE_SIZE=20  # Transaction page size
-//! TX_DAYS_BACK=7  # Number of days to look back for transactions
+//! IG_API_VERSION=3                                   # 2 (CST/XST) or 3 (OAuth); defaults to 3
+//! IG_REST_BASE_URL=https://demo-api.ig.com/gateway/deal   # Use demo or live as needed
+//! IG_REST_TIMEOUT=30                                 # REST request timeout in seconds
+//! IG_WS_URL=wss://demo-apd.marketdatasystems.com     # Lightstreamer endpoint
+//! IG_WS_RECONNECT_INTERVAL=5                         # Reconnect interval in seconds
+//! IG_RATE_LIMIT_MAX_REQUESTS=4                       # Rate-limiter budget
+//! IG_RATE_LIMIT_PERIOD_SECONDS=12                    # Rate-limiter period (seconds)
+//! IG_RATE_LIMIT_BURST_SIZE=3                         # Rate-limiter burst size
+//! DATABASE_URL=postgres://user:password@localhost/ig_db   # Optional persistence
+//! DATABASE_MAX_CONNECTIONS=5                         # Optional connection-pool size
+//! TX_LOOP_INTERVAL_HOURS=1                           # Transaction loop interval (hours)
+//! TX_PAGE_SIZE=20                                    # Transaction page size
+//! TX_DAYS_LOOKBACK=7                                 # Days to look back for transactions
 //! ```
 //!
-//! ## Usage Examples
+//! Live examples and integration tests default to the IG **demo** environment;
+//! pointing anything at production requires an explicit opt-in via
+//! `IG_REST_BASE_URL` / `IG_WS_URL`.
 //!
-//! ### Complete Example Application
+//! ## Usage
 //!
-//! Here's a complete example showing how to set up the client, authenticate, and perform various operations:
+//! The main entry points are `Config` and `Client`. A single `Client`
+//! implements every REST service trait (`AccountService`, `MarketService`,
+//! `OrderService`, `WatchlistService`, `SentimentService`, `CostsService`,
+//! `OperationsService`). Session login and token refresh are performed
+//! transparently on first use. The prelude re-exports the full public surface,
+//! including the streaming API and the service traits, so a single glob import
+//! is usually enough:
 //!
-//! ```rust,ignore
-//! use ig_client::application::services::account_service::{AccountService, IgAccountService};
-//! use ig_client::application::services::market_service::{IgMarketService, MarketService};
-//! use ig_client::application::services::order_service::{IgOrderService, OrderService};
-//! use ig_client::application::models::order::{CreateOrderRequest, Direction};
-//! use ig_client::config::Config;
-//! use ig_client::session::auth::{IgAuth, IgAuthenticator};
-//! use std::sync::Arc;
-//! use dotenv::dotenv;
-//! use tracing::{info, error, Level};
-//! use tracing_subscriber::FmtSubscriber;
+//! ```rust
+//! use ig_client::prelude::*;
+//! ```
+//!
+//! ### Client setup and account information
+//!
+//! ```rust,no_run
+//! use ig_client::prelude::*;
 //!
 //! #[tokio::main]
-//! async fn main() -> Result<(), ig_client::error::AppError> {
-//!     // Initialize logging
-//!     let subscriber = FmtSubscriber::builder()
-//!         .with_max_level(Level::INFO)
-//!         .finish();
-//!     tracing::subscriber::set_global_default(subscriber)?;
-//!     
-//!     // Load environment variables
-//!     dotenv().ok();
-//!     info!("Environment variables loaded");
-//!     
-//!     // Create configuration
-//!     let config = Arc::new(Config::new());
-//!     info!("Configuration created");
-//!     
-//!     // Authenticate
-//!     let auth = IgAuth::new(&config);
-//!     let session = auth.login().await?;
-//!     info!("Authentication successful");
-//!     
-//!     // Create services
-//!     let account_service = IgAccountService::new(config.clone());
-//!     let market_service = IgMarketService::new(config.clone());
-//!     // Get account information
-//!     let account_info = account_service.get_accounts(&session).await?;
-//!     info!("Account information retrieved: {} accounts", account_info.accounts.len());
-//!     
-//!     // Switch to a different account if needed
-//!     if account_info.accounts.len() > 1 {
-//!         let target_account = &account_info.accounts[1];
-//!         let updated_session = auth.switch_account(&session, &target_account.account_id, Some(true)).await?;
-//!         info!("Switched to account: {}", updated_session.account_id);
-//!     }
-//!     
-//!     // Search for a market
-//!     let search_term = "US 500";
-//!     let search_results = market_service.search_markets(&session, search_term).await?;
-//!     info!("Found {} markets matching '{}'", search_results.markets.len(), search_term);
-//!     
-//!     // Get market details for the first result
-//!     if let Some(market) = search_results.markets.first() {
-//!         let epic = &market.epic;
-//!         let market_details = market_service.get_market_details(&session, epic).await?;
-//!         info!("Market details for {}: {}", epic, market_details.instrument.name);
-//!         
-//!         // Get historical prices
-//!         let prices = market_service.get_prices_by_date(
-//!             &session,
-//!             epic,
-//!             "MINUTE",
-//!             "1",
-//!             "2023-01-01T00:00:00",
-//!             "2023-01-02T00:00:00"
-//!         ).await?;
-//!         info!("Retrieved {} price points", prices.prices.len());
-//!         
-//!         // Check if the market is tradable
-//!         if market_details.snapshot.market_status == "TRADEABLE" {
-//!             // Create a market order
-//!             let order_request = CreateOrderRequest::market(
-//!                 epic.clone(),
-//!                 Direction::Buy,
-//!                 1.0, // Size
-//!             );
-//!             
-//!             let order_result = order_service.create_order(&session, &order_request).await?;
-//!             info!("Order placed: deal reference = {}", order_result.deal_reference);
-//!             
-//!             // Get positions
-//!             let positions = account_service.get_positions(&session).await?;
-//!             info!("Current positions: {}", positions.positions.len());
-//!         }
-//!     }
-//!     
-//!     info!("Example completed successfully");
+//! async fn main() -> Result<(), AppError> {
+//!     // Configuration is read from the environment / a local `.env` file.
+//!     let config = Config::new();
+//!     println!("configured API version: {:?}", config.api_version);
+//!
+//!     // `try_new` is the fallible constructor for the REST client.
+//!     // (`new()` / `default()` no longer exist.) Session login and automatic
+//!     // token refresh happen transparently on the first API call.
+//!     let client = Client::try_new()?;
+//!
+//!     // `Client` implements `AccountService`.
+//!     let accounts = client.get_accounts().await?;
+//!     println!("{} account(s) available", accounts.accounts.len());
 //!     Ok(())
 //! }
 //! ```
 //!
-//! ### Authentication
+//! ### Market data
 //!
-//! ```rust,ignore
-//! use ig_client::session::auth::IgAuth;
-//! use ig_client::config::Config;
-//! use std::sync::Arc;
+//! ```rust,no_run
+//! use ig_client::prelude::*;
 //!
 //! #[tokio::main]
-//! async fn main() -> Result<(), ig_client::error::AppError> {
-//!     // Load configuration from environment variables
-//!     let config = Arc::new(Config::new());
-//!     
-//!     // Create authentication handler
-//!     let auth = IgAuth::new(config.clone());
-//!     
-//!     // Authenticate and get a session
-//!     let session = auth.authenticate().await?;
-//!     
-//!     info!("Successfully authenticated!");
+//! async fn main() -> Result<(), AppError> {
+//!     let client = Client::try_new()?;
+//!
+//!     // `Client` implements `MarketService`.
+//!     let results = client.search_markets("EUR/USD").await?;
+//!     if let Some(market) = results.markets.first() {
+//!         let details = client.get_market_details(&market.epic).await?;
+//!         println!("{}: {}", market.epic, details.instrument.name);
+//!     }
 //!     Ok(())
 //! }
 //! ```
 //!
-//! ### Getting Account Information
+//! ### Placing an order
 //!
-//! ```rust,ignore
-//! use ig_client::application::services::account_service::{AccountService, IgAccountService};
-//! use std::sync::Arc;
+//! ```rust,no_run
+//! use ig_client::prelude::*;
 //!
-//! // Create account service
-//! let account_service = IgAccountService::new(config.clone());
+//! #[tokio::main]
+//! async fn main() -> Result<(), AppError> {
+//!     let client = Client::try_new()?;
 //!
-//! // Get account information
-//! let account_info = account_service.get_accounts(&session).await?;
-//! info!("Accounts: {:?}", account_info);
+//!     // Build a market order with the typed constructor. `size` is rounded to
+//!     // two decimals; a `None` currency code defaults to "EUR".
+//!     let order = CreateOrderRequest::market(
+//!         "CS.D.EURUSD.CFD.IP".to_string(), // epic
+//!         Direction::Buy,                   // direction
+//!         1.0,                              // size
+//!         Some("USD".to_string()),          // currency_code
+//!         None,                             // deal_reference
+//!     );
 //!
-//! // Get positions
-//! let positions = account_service.get_positions(&session).await?;
-//! info!("Open positions: {}", positions.positions.len());
-//!
-//! // Get transaction history
-//! let from_date = chrono::Utc::now() - chrono::Duration::days(7);
-//! let to_date = chrono::Utc::now();
-//! let transactions = account_service.get_transactions(&session, from_date, to_date).await?;
-//! info!("Transactions in the last week: {}", transactions.transactions.len());
-//! ```
-//!
-//! ### Market Data
-//!
-//! ```rust,ignore
-//! use ig_client::application::services::market_service::{MarketService, IgMarketService};
-//!
-//! // Create market service
-//! let market_service = IgMarketService::new(config.clone());
-//!
-//! // Search for markets
-//! let search_result = market_service.search_markets(&session, "Apple").await?;
-//! info!("Found {} markets matching 'Apple'", search_result.markets.len());
-//!
-//! // Get market details
-//! if let Some(market) = search_result.markets.first() {
-//!     let details = market_service.get_market_details(&session, &market.epic).await?;
-//!     info!("Market details for {}: {}", market.instrument_name, details.instrument.name);
-//!     
-//!     // Get historical prices
-//!     let prices = market_service.get_prices(
-//!         &session,
-//!         &market.epic,
-//!         "DAY",   // Resolution
-//!         30,      // Number of data points
-//!     ).await?;
-//!     info!("Retrieved {} historical price points", prices.prices.len());
-//! }
-//! ```
-//!
-//! ### Placing and Managing Orders
-//!
-//! ```rust,ignore
-//! use ig_client::application::services::order_service::{OrderService, IgOrderService};
-//! use ig_client::application::models::order::{CreateOrderRequest, Direction, OrderType, TimeInForce};
-//!
-//! // Create order service
-//! let order_service = IgOrderService::new(config.clone());
-//!
-//! // Create a market order
-//! let market_order = CreateOrderRequest::market(
-//!     "OP.D.OTCDAX1.021100P.IP".to_string(),  // EPIC
-//!     Direction::Buy,                     // Direction
-//!     1.0,                               // Size
-//!     None,                              // Limit level
-//!     None,                              // Stop level
-//! );
-//!
-//! // Place the order
-//! let result = order_service.create_order(&session, &market_order).await?;
-//! info!("Market order placed: {:?}", result);
-//!
-//! // Create a limit order
-//! let limit_order = CreateOrderRequest {
-//!     epic: "OP.D.OTCDAX1.021100P.IP".to_string(),
-//!     direction: Direction::Buy,
-//!     size: 1.0,
-//!     order_type: OrderType::Limit,
-//!     level: Some(1.05),  // Limit price
-//!     guaranteed_stop: false,
-//!     time_in_force: TimeInForce::GoodTillDate,
-//!     good_till_date: Some("2025-06-01T12:00:00".to_string()),
-//!     stop_level: None,
-//!     stop_distance: None,
-//!     limit_level: None,
-//!     limit_distance: None,
-//!     deal_reference: Some("my-custom-reference".to_string()),
-//! };
-//!
-//! let result = order_service.create_order(&session, &limit_order).await?;
-//! info!("Limit order placed: {:?}", result);
-//!
-//! // Close a position
-//! let positions = account_service.get_positions(&session).await?;
-//! if let Some(position) = positions.positions.first() {
-//!     let close_request = order_service.close_position(
-//!         &session,
-//!         &position.position.deal_id,
-//!         position.position.direction.clone(),
-//!         position.position.size,
-//!     ).await?;
-//!     info!("Position closed: {:?}", close_request);
-//! }
-//! ```
-//!
-//! ### WebSocket Streaming
-//!
-//! ```rust,ignore
-//! use ig_client::application::services::market_listener::{MarketListener, MarketListenerCallback};
-//! use ig_client::application::models::market::MarketData;
-//! use std::sync::Arc;
-//! use tokio::sync::mpsc;
-//!
-//! // Create a channel to receive market updates
-//! let (tx, mut rx) = mpsc::channel(100);
-//!
-//! // Create a callback function to handle market updates
-//! let callback: MarketListenerCallback = Arc::new(move |market_data: &MarketData| {
-//!     let data = market_data.clone();
-//!     let tx = tx.clone();
-//!     tokio::spawn(async move {
-//!         let _ = tx.send(data).await;
-//!     });
+//!     // `Client` implements `OrderService`.
+//!     let confirmation = client.create_order(&order).await?;
+//!     println!("deal reference: {}", confirmation.deal_reference);
 //!     Ok(())
-//! });
+//! }
+//! ```
 //!
-//! // Create and start the market listener
-//! let listener = MarketListener::new(callback);
-//! listener.connect(&session).await?;
+//! ### Real-time streaming
 //!
-//! // Subscribe to market updates
-//! let epics = vec!["OP.D.OTCDAX1.021100P.IP", "CS.D.USDJPY.CFD.IP"];
-//! listener.subscribe(&epics).await?;
+//! `DynamicMarketStreamer` wraps the lower-level `StreamerClient` and manages
+//! subscriptions in a thread-safe way. Its constructor is **synchronous** — it
+//! only wires up in-memory channels; the network connection is established later
+//! by `start`. Updates arrive as `PriceData`, resolved through the prelude.
 //!
-//! // Process market updates
-//! while let Some(market_data) = rx.recv().await {
-//!     info!("Market update for {}: bid={}, offer={}",
-//!              market_data.epic, market_data.bid.unwrap_or(0.0), market_data.offer.unwrap_or(0.0));
+//! ```rust,no_run
+//! use ig_client::prelude::*;
+//! use std::collections::HashSet;
+//!
+//! #[tokio::main]
+//! async fn main() -> Result<(), AppError> {
+//!     // Fields to receive on each market tick.
+//!     let fields = HashSet::from([StreamingMarketField::Bid, StreamingMarketField::Offer]);
+//!
+//!     // Synchronous construction — no `await`, no fallibility.
+//!     let mut streamer = DynamicMarketStreamer::new(fields);
+//!
+//!     // Take the receiver before connecting.
+//!     let mut receiver = streamer.get_receiver().await?;
+//!
+//!     // Subscribe to an instrument and open the Lightstreamer connection.
+//!     streamer.add("IX.D.DAX.DAILY.IP".to_string()).await?;
+//!     streamer.start().await?;
+//!
+//!     // Consume `PriceData` updates.
+//!     while let Some(price) = receiver.recv().await {
+//!         let price: PriceData = price;
+//!         println!("price update: {price}");
+//!     }
+//!     Ok(())
 //! }
 //! ```
 //!
 //! ## Available Services
 //!
-//! The library provides the following service traits for interacting with the IG Markets API:
+//! Every service trait below is implemented by `Client`; bring the traits into
+//! scope via `use ig_client::prelude::*;`.
 //!
-//! ### AccountService
-//! - `get_accounts()` - Get all accounts for the authenticated user
-//! - `get_positions()` - Get all open positions
-//! - `get_working_orders()` - Get all working orders
-//! - `get_activity(from, to)` - Get account activity for a date range
-//! - `get_activity_by_period(period_ms)` - Get activity for a period in milliseconds
-//! - `get_transactions(from, to)` - Get transaction history
-//! - `get_preferences()` - Get account preferences
-//! - `update_preferences(trailing_stops_enabled)` - Update account preferences
+//! ### `AccountService`
+//! - `get_accounts()` — all accounts for the authenticated user
+//! - `get_positions()` / `get_positions_w_filter(filter)` — open positions
+//! - `get_working_orders()` — working orders
+//! - `get_activity(from, to)` / `get_activity_with_details(from, to)` — activity
+//! - `get_activity_by_period(period_ms)` — activity for a period in milliseconds
+//! - `get_transactions(from, to)` — transaction history (paginated internally)
+//! - `get_preferences()` / `update_preferences(trailing_stops_enabled)`
 //!
-//! ### MarketService
-//! - `search_markets(term)` - Search for markets by keyword
-//! - `get_market_details(epic)` - Get detailed market information
-//! - `get_multiple_market_details(epics)` - Get details for multiple markets
-//! - `get_historical_prices(epic, resolution, num_points)` - Get historical price data
-//! - `get_historical_prices_by_date_range(epic, resolution, start, end)` - Get prices for date range
-//! - `get_market_navigation()` - Get market navigation hierarchy
-//! - `get_categories()` - Get market categories
-//! - `get_instruments_by_category(category)` - Get instruments in a category
+//! ### `MarketService`
+//! - `search_markets(term)` — search markets by keyword
+//! - `get_market_details(epic)` / `get_multiple_market_details(epics)`
+//! - `get_historical_prices(epic, resolution, from, to)` and
+//!   `get_historical_prices_by_date_range(epic, resolution, start, end)`
+//! - `get_historical_prices_by_count_v1` / `_v2(epic, resolution, num_points)`
+//! - `get_recent_prices(params)`
+//! - `get_market_navigation()` / `get_market_navigation_node(node_id)`
+//! - `get_all_markets()` / `get_vec_db_entries()`
+//! - `get_categories()` / `get_category_instruments(category_id, page, size)`
 //!
-//! ### OrderService
-//! - `create_order(request)` - Create a new market order
-//! - `get_order_confirmation(deal_reference)` - Get order confirmation
-//! - `update_position(deal_id, update)` - Update an existing position
-//! - `close_position(request)` - Close a position
-//! - `get_position(deal_id)` - Get a single position by deal ID
-//! - `create_working_order(request)` - Create a working order
-//! - `update_working_order(deal_id, update)` - Update an existing working order
-//! - `delete_working_order(deal_id)` - Delete a working order
+//! ### `OrderService`
+//! - `create_order(request)` — open a position
+//! - `get_order_confirmation(deal_reference)` and
+//!   `get_order_confirmation_w_retry(deal_reference, retries, delay_ms)`
+//! - `update_position(deal_id, update)` / `update_level_in_position(deal_id, level)`
+//! - `close_position(request)` / `get_position(deal_id)`
+//! - `create_working_order(request)` / `update_working_order(deal_id, update)` /
+//!   `delete_working_order(deal_id)`
 //!
-//! ### WatchlistService (New in 0.11.1)
-//! - `get_watchlists()` - Get all watchlists
-//! - `create_watchlist(name, epics)` - Create a new watchlist
-//! - `get_watchlist(id)` - Get watchlist markets
-//! - `delete_watchlist(id)` - Delete a watchlist
-//! - `add_to_watchlist(id, epic)` - Add instrument to watchlist
-//! - `remove_from_watchlist(id, epic)` - Remove instrument from watchlist
+//! ### `WatchlistService`
+//! - `get_watchlists()` / `create_watchlist(name, epics)`
+//! - `get_watchlist(id)` / `delete_watchlist(id)`
+//! - `add_to_watchlist(id, epic)` / `remove_from_watchlist(id, epic)`
 //!
-//! ### SentimentService (New in 0.11.1)
-//! - `get_client_sentiment(market_ids)` - Get sentiment for multiple markets
-//! - `get_client_sentiment_by_market(market_id)` - Get sentiment for a single market
-//! - `get_related_sentiment(market_id)` - Get sentiment for related markets
+//! ### `SentimentService`
+//! - `get_client_sentiment(market_ids)`
+//! - `get_client_sentiment_by_market(market_id)`
+//! - `get_related_sentiment(market_id)`
 //!
-//! ### CostsService (New in 0.11.1)
-//! - `get_indicative_costs_open(request)` - Get costs for opening a position
-//! - `get_indicative_costs_close(request)` - Get costs for closing a position
-//! - `get_indicative_costs_edit(request)` - Get costs for editing a position
-//! - `get_costs_history(from, to)` - Get historical costs
-//! - `get_durable_medium(quote_reference)` - Get durable medium document
+//! ### `CostsService`
+//! - `get_indicative_costs_open(request)` / `_close(request)` / `_edit(request)`
+//! - `get_costs_history(from, to)` / `get_durable_medium(quote_reference)`
 //!
-//! ### OperationsService (New in 0.11.1)
-//! - `get_client_apps()` - Get API application details
-//! - `disable_client_app()` - Disable current API key
+//! ### `OperationsService`
+//! - `get_client_apps()` — API application details
+//! - `disable_client_app()` — disable the current API key
 //!
-//! ## Documentation
+//! ## Rate Limiting
 //!
-//! Comprehensive documentation is available for all components of the library. The documentation includes detailed explanations of all modules, structs, and functions, along with examples of how to use them.
+//! All requests are paced by a `governor`-backed `RateLimiter` so the client
+//! stays within IG's published limits (trading and non-trading endpoints have
+//! different budgets). The budget is configured from the environment via
+//! `IG_RATE_LIMIT_MAX_REQUESTS`, `IG_RATE_LIMIT_PERIOD_SECONDS`, and
+//! `IG_RATE_LIMIT_BURST_SIZE` (see `RateLimiterConfig`). On top of pacing,
+//! transient failures (429 / 5xx / connection errors) are retried with
+//! **finite** exponential backoff and jitter via `RetryConfig`; non-idempotent
+//! trading calls are never retried blindly.
+//!
+//! ## Architecture
+//!
+//! The crate is organized as a module-oriented library under `src/`:
+//!
+//! - **`application`** — all I/O. The REST `Client` and its service-trait
+//!   implementations, `Auth` / `Session` (login, refresh, logout, account
+//!   switching), `Config`, the `RateLimiter`, and the streaming layer
+//!   (`StreamerClient`, `DynamicMarketStreamer`). Service traits live under
+//!   `application::interfaces`.
+//! - **`model`** — pure request / response DTOs, streaming message DTOs, session
+//!   DTOs, and the retry policy. Serde only; no I/O.
+//! - **`presentation`** — domain entities per area: account, chart, instrument,
+//!   market, order, price, trade, transaction. Serde only; no I/O.
+//! - **`storage`** — optional PostgreSQL persistence via `sqlx` (sits on top of
+//!   `model` / `presentation`).
+//! - **`utils`** — leaf helpers: env-var config, logging, finance (P&L), parsing,
+//!   deal-reference id generation.
+//! - **`error`** — canonical typed error enums: `AppError`, `AuthError`, and
+//!   `FetchError`.
+//! - **`constants`** — crate-wide endpoint paths, header names, and defaults.
+//! - **`prelude`** — curated public re-exports (the recommended import surface).
 //!
 //! ### API Documentation
 //!
-//! You can access the API documentation on [docs.rs](https://docs.rs/ig-client) or generate it locally with:
+//! Browse the API documentation on [docs.rs](https://docs.rs/ig-client) or
+//! generate it locally with:
 //!
 //! ```bash
 //! make doc-open
 //! ```
 //!
-//! ### Architecture
+//! ## Project Structure
 //!
-//! The library is organized into several modules:
-//!
-//! - **config**: Configuration handling and environment variable loading
-//! - **session**: Authentication and session management
-//! - **application**: Core business logic and services
-//!   - **models**: Data structures for API requests and responses
-//!   - **services**: Service implementations for different API areas
-//! - **transport**: HTTP and WebSocket communication with the IG Markets API
-//! - **utils**: Utility functions for parsing, logging, etc.
-//! - **error**: Error types and handling
+//! ```text
+//! src/
+//! ├── application/       # I/O: client, auth, config, rate limiter, streaming
+//! │   ├── interfaces/    # Service traits (account, market, order, costs, …)
+//! │   ├── auth.rs        # Auth / Session: login, refresh, logout, switch
+//! │   ├── client.rs      # Client (REST services) + StreamerClient
+//! │   ├── config.rs      # Config, Credentials, REST / WS / rate-limiter config
+//! │   ├── rate_limiter.rs      # governor-backed request pacing
+//! │   └── dynamic_streamer.rs  # DynamicMarketStreamer (subscriptions)
+//! ├── model/             # Pure DTOs: requests, responses, streaming, retry
+//! ├── presentation/      # Domain entities (account, market, order, price, …)
+//! ├── storage/           # Optional PostgreSQL persistence via sqlx
+//! ├── utils/             # config, logger, finance, parsing, id helpers
+//! ├── constants.rs       # Endpoint paths, header names, defaults
+//! ├── error.rs           # AppError / AuthError / FetchError
+//! ├── prelude.rs         # Curated public re-exports
+//! └── lib.rs             # Public API and crate docs (README source)
+//! examples/              # Runnable demos (workspace members)
+//! tests/                 # unit/ and env-gated integration/ tests
+//! benches/               # Criterion benchmarks
+//! ```
 //!
 //! ## Development
 //!
-//! This project includes a comprehensive Makefile with commands for common development tasks.
-//!
-//! ### Building
+//! This project includes a Makefile with common development tasks:
 //!
 //! ```bash
 //! make build        # Debug build
 //! make release      # Release build
-//! ```
-//!
-//! ### Testing
-//!
-//! ```bash
 //! make test         # Run all tests
-//! ```
-//!
-//! ### Code Quality
-//!
-//! ```bash
 //! make fmt          # Format code with rustfmt
-//! make lint         # Run clippy linter
-//! make doc          # Check documentation coverage
-//! make check        # Run tests, format check, and linting
-//! make pre-push     # Run all checks before pushing code
-//! ```
-//!
-//! ### Documentation
-//!
-//! ```bash
-//! make doc-open     # Generate and open documentation
-//! ```
-//!
-//! ### Code Coverage
-//!
-//! ```bash
-//! make coverage     # Generate code coverage report (XML)
-//! make coverage-html # Generate HTML coverage report
-//! make open-coverage # Open HTML coverage report
-//! ```
-//!
-//! ### Benchmarking
-//!
-//! ```bash
-//! make bench        # Run benchmarks
-//! make bench-show   # Show benchmark results
-//! ```
-//!
-//! ### Rate Limiting
-//!
-//! The library includes a sophisticated rate limiting system to comply with IG Markets API restrictions:
-//!
-//! - **Multiple Rate Limit Types**: Different limits for trading, non-trading, and historical data requests
-//! - **Thread-Safe Implementation**: Uses `tokio::sync::Mutex` for safe concurrent access
-//! - **Automatic Backoff**: Dynamically calculates wait times based on request history
-//! - **Explicit Rate Limit Handling**: Detects and handles rate limit errors from the API
-//! - **Global Semaphore**: Limits concurrent API requests to prevent overwhelming the API
-//! - **Configurable Safety Margins**: Adjustable safety margins to stay below API limits
-//! - **Rate Limit Error Recovery**: Automatic cooldown and recovery when rate limits are exceeded
-//!
-//! Example of configuring rate limits:
-//!
-//! ```rust,ignore
-//! // Create a configuration with custom rate limit settings
-//! let config = Arc::new(Config::with_rate_limit_type(
-//!     RateLimitType::NonTradingAccount,  // Type of rate limit to enforce
-//!     0.8,                               // Safety margin (80% of actual limit)
-//! ));
-//!
-//! // The rate limiter will automatically be used by all services
-//! let http_client = IgHttpClientImpl::new(config.clone());
-//! let auth = IgAuth::new(config.clone());
-//!
-//! // When rate limits are exceeded, the system will automatically:
-//! // 1. Detect the rate limit error from the API
-//! // 2. Enforce a mandatory cooldown period
-//! // 3. Gradually resume requests with appropriate delays
-//! ```
-//!
-//! ### Continuous Integration
-//!
-//! ```bash
-//! make workflow     # Run all CI workflow steps locally
-//! ```
-//!
-//! ## Project Structure
-//!
-//! ```text
-//! ├── src/
-//! │   ├── application/       # Core business logic
-//! │   │   ├── interfaces/    # Service trait interfaces
-//! │   │   │   ├── account.rs # Account service trait
-//! │   │   │   ├── costs.rs   # Costs service trait (v0.11.1)
-//! │   │   │   ├── market.rs  # Market service trait
-//! │   │   │   ├── operations.rs # Operations service trait (v0.11.1)
-//! │   │   │   ├── order.rs   # Order service trait
-//! │   │   │   ├── sentiment.rs # Sentiment service trait (v0.11.1)
-//! │   │   │   └── watchlist.rs # Watchlist service trait (v0.11.1)
-//! │   │   ├── auth.rs        # Authentication handler
-//! │   │   ├── client.rs      # Main API client
-//! │   │   └── config.rs      # Configuration handling
-//! │   ├── model/             # Data models
-//! │   │   ├── requests.rs    # API request models
-//! │   │   ├── responses.rs   # API response models
-//! │   │   └── streaming.rs   # Streaming data models
-//! │   ├── presentation/      # Presentation layer
-//! │   │   ├── account.rs     # Account presentation
-//! │   │   ├── market.rs      # Market presentation
-//! │   │   └── order.rs       # Order presentation
-//! │   ├── storage/           # Data persistence
-//! │   │   └── config.rs      # Database configuration
-//! │   ├── constants.rs       # Global constants
-//! │   ├── error.rs           # Error types
-//! │   └── utils/             # Utility functions
-//! │       ├── parsing.rs     # Parsing utilities
-//! │       └── retry.rs       # Retry utilities
-//! ├── examples/              # Example applications
-//! │   ├── chart/             # Chart examples
-//! │   ├── costs/             # Costs examples (v0.11.1)
-//! │   ├── market/            # Market examples
-//! │   ├── orders/            # Order examples
-//! │   ├── positions/         # Position examples
-//! │   ├── sentiment/         # Sentiment examples (v0.11.1)
-//! │   ├── streaming/         # Streaming examples
-//! │   ├── watchlist/         # Watchlist examples (v0.11.1)
-//! │   └── other/             # Other examples
-//! ├── tests/                 # Tests
-//! │   ├── integration/       # Integration tests
-//! │   └── unit/              # Unit tests
-//! └── Makefile              # Development commands
+//! make lint         # Run clippy
+//! make readme       # Regenerate README.md from these crate docs
+//! make pre-push     # Run all checks before pushing
 //! ```
 //!
 //! ## Contributing
 //!
-//! Contributions are welcome! Here's how you can contribute:
+//! Contributions are welcome:
 //!
-//! 1. Fork the repository
-//! 2. Create a feature branch: `git checkout -b feature/my-feature`
-//! 3. Make your changes and commit them: `git commit -m 'Add some feature'`
-//! 4. Run the tests: `make test`
-//! 5. Push to the branch: `git push origin feature/my-feature`
-//! 6. Submit a pull request
+//! 1. Fork the repository.
+//! 2. Create a feature branch: `git checkout -b feature/my-feature`.
+//! 3. Make your changes and commit them.
+//! 4. Run the checks: `make pre-push`.
+//! 5. Push the branch and open a pull request.
 //!
-//! Please make sure your code passes all tests and linting checks before submitting a pull request.
+//! Please make sure your code passes all tests and linting checks before
+//! submitting a pull request.
 
 /// Core application logic and services
 pub mod application;


### PR DESCRIPTION
## Summary

The crate-level docs in `src/lib.rs` (the source for `README.md` via `make readme`) documented an API that no longer exists — anyone following the README got immediate compile errors. Rewritten against the real 0.12.0 surface. Docs only.

## Changes

- Four working `no_run` examples (all compile via `cargo test --doc`), all through `use ig_client::prelude::*;`:
  1. `Config::new()` + `Client::try_new()?` + `AccountService::get_accounts()`
  2. `MarketService::search_markets` → `get_market_details`
  3. `CreateOrderRequest::market(...)` (real signature) → `OrderService::create_order`
  4. Streaming via `DynamicMarketStreamer::new` (now sync) + `StreamerClient`, consuming `PriceData`
- Architecture / Project Structure sections rewritten to match the real `application` / `model` / `presentation` / `storage` / `utils` layout; env-var names corrected to the real ones; Requirements fixed to "Rust 2024 edition, stable toolchain" (removed "Rust 1.56 or later").
- Removed every reference to the nonexistent `application::services`, `session::auth`, `IgAuth`, `IgAccountService`, `MarketListener`, `transport`, etc.
- `README.md` regenerated via `make readme` and in sync with `lib.rs`; the "What's New" section refreshed to summarize the 0.12.0 release.

## Verification

- [x] `grep` for the removed items is empty in both `src/lib.rs` and `README.md`
- [x] `cargo test --doc` passes (the four examples compile)
- [x] `make pre-push` clean; `cargo semver-checks` unchanged (docs don't touch the surface)

Closes #30
