### PR TITLE
Tolerate SQLSTATE 42P07 in historical_prices migration (#79)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ig-client"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2024"
 authors = ["Joaquin Bejar <jb@taunais.com>"]
 description = "This crate provides a client for the IG Markets API"

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-ig-client = "0.12.0"
+ig-client = "0.12.1"
 tokio = { version = "1", features = ["full"] }  # Async runtime
 tracing = "0.1"                                  # Logging facade
 # Optional, only if you use the PostgreSQL persistence layer:
@@ -362,6 +362,13 @@ Contributions are welcome:
 
 Please make sure your code passes all tests and linting checks before
 submitting a pull request.
+
+## What's New in 0.12.1
+
+- The `historical_prices` unique-constraint migration now tolerates
+  PostgreSQL SQLSTATE `42P07` ("relation already exists") when an index with
+  the constraint's name already exists without an attached constraint —
+  previously this failed application startup on every run ([#79](https://github.com/joaquinbejar/ig-client/issues/79)).
 
 ## What's New in 0.12.0
 

--- a/README.tpl
+++ b/README.tpl
@@ -12,6 +12,13 @@
 
 {{readme}}
 
+## What's New in 0.12.1
+
+- The `historical_prices` unique-constraint migration now tolerates
+  PostgreSQL SQLSTATE `42P07` ("relation already exists") when an index with
+  the constraint's name already exists without an attached constraint —
+  previously this failed application startup on every run ([#79](https://github.com/joaquinbejar/ig-client/issues/79)).
+
 ## What's New in 0.12.0
 
 A large correctness, safety, and API-consistency release. Highlights:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! ig-client = "0.12.0"
+//! ig-client = "0.12.1"
 //! tokio = { version = "1", features = ["full"] }  # Async runtime
 //! tracing = "0.1"                                  # Logging facade
 //! # Optional, only if you use the PostgreSQL persistence layer:

--- a/src/storage/historical_prices.rs
+++ b/src/storage/historical_prices.rs
@@ -64,9 +64,11 @@ pub async fn initialize_historical_prices_table(pool: &PgPool) -> Result<(), sql
     // NOT dropped here: `CREATE TABLE ... UNIQUE(epic, resolution, snapshot_time)`
     // above already creates it (auto-named `historical_prices_epic_resolution_snapshot_time_key`),
     // so dropping and re-adding it on every startup would churn an
-    // AccessExclusive lock for nothing. The tolerant ADD below handles both the
-    // fresh case (constraint already present → 42710 → skipped) and the migration
-    // case (old two-column DB whose legacy constraint was just dropped).
+    // AccessExclusive lock for nothing. The tolerant ADD below handles the
+    // fresh case (constraint already present → 42710 → skipped), the migration
+    // case (old two-column DB whose legacy constraint was just dropped), and
+    // the orphan-index case (an index by the constraint's name exists without
+    // an attached constraint → 42P07 → skipped).
     sqlx::query(
         "ALTER TABLE historical_prices \
          DROP CONSTRAINT IF EXISTS historical_prices_epic_snapshot_time_key",
@@ -75,8 +77,9 @@ pub async fn initialize_historical_prices_table(pool: &PgPool) -> Result<(), sql
     .await?;
 
     // Add the three-column unique constraint. There is no `IF NOT EXISTS` for
-    // `ADD CONSTRAINT`, so tolerate a duplicate-object error (SQLSTATE 42710)
-    // when it already exists while surfacing any other failure.
+    // `ADD CONSTRAINT`, so tolerate the "already exists" SQLSTATEs (42710 for
+    // the constraint, 42P07 for its backing index) while surfacing any other
+    // failure.
     if let Err(e) = sqlx::query(
         "ALTER TABLE historical_prices \
          ADD CONSTRAINT historical_prices_epic_resolution_snapshot_time_key \
@@ -86,11 +89,11 @@ pub async fn initialize_historical_prices_table(pool: &PgPool) -> Result<(), sql
     .await
     {
         match e.as_database_error().and_then(|db| db.code()) {
-            // 42710 = duplicate_object: the constraint already exists.
-            Some(code) if code == "42710" => {
+            Some(code) if is_benign_already_exists(&code) => {
                 warn!(
                     constraint = "historical_prices_epic_resolution_snapshot_time_key",
-                    "unique constraint already exists, skipping add"
+                    sqlstate = %code,
+                    "unique constraint or its backing index already exists, skipping add"
                 );
             }
             _ => return Err(e),
@@ -145,6 +148,18 @@ pub async fn initialize_historical_prices_table(pool: &PgPool) -> Result<(), sql
 
     info!("✅ Historical prices table initialized successfully");
     Ok(())
+}
+
+/// Returns `true` for the PostgreSQL SQLSTATEs that mean the unique
+/// constraint (or its backing index) already exists: `42710`
+/// (duplicate_object — the constraint is already present) and `42P07`
+/// (duplicate_table — `ADD CONSTRAINT ... UNIQUE` implicitly creates a
+/// backing index of the same name, so a pre-existing relation by that name
+/// surfaces as "relation already exists").
+#[must_use]
+#[inline]
+fn is_benign_already_exists(code: &str) -> bool {
+    matches!(code, "42710" | "42P07")
 }
 
 /// Storage statistics for tracking insert/update operations
@@ -558,5 +573,25 @@ mod tests {
             let result = parse_snapshot_time(&timestamp);
             assert!(result.is_ok(), "Failed for month: {}", month);
         }
+    }
+
+    #[test]
+    fn test_is_benign_already_exists_duplicate_object_true() {
+        // 42710 = duplicate_object: the constraint itself already exists.
+        assert!(is_benign_already_exists("42710"));
+    }
+
+    #[test]
+    fn test_is_benign_already_exists_duplicate_relation_true() {
+        // 42P07 = duplicate_table: the backing index name already exists.
+        assert!(is_benign_already_exists("42P07"));
+    }
+
+    #[test]
+    fn test_is_benign_already_exists_other_code_false() {
+        // Unrelated SQLSTATEs must keep propagating as errors.
+        assert!(!is_benign_already_exists("23505")); // unique_violation
+        assert!(!is_benign_already_exists("42P01")); // undefined_table
+        assert!(!is_benign_already_exists(""));
     }
 }

--- a/tests/integration/storage_tests.rs
+++ b/tests/integration/storage_tests.rs
@@ -103,6 +103,82 @@ async fn test_initialize_historical_prices_table_creates_unique_constraint() {
 
 #[tokio::test]
 #[ignore = "requires a live PostgreSQL via DATABASE_URL"]
+async fn test_initialize_tolerates_orphan_backing_index() {
+    let Some(pool) = test_pool().await else {
+        return;
+    };
+
+    initialize_historical_prices_table(&pool)
+        .await
+        .expect("baseline initialization should succeed");
+
+    // Reproduce issue #79: an index with the constraint's name exists but no
+    // constraint is attached (manually created index, pg_restore, partial
+    // migration). `ADD CONSTRAINT ... UNIQUE` then fails with SQLSTATE 42P07
+    // ("relation already exists") while trying to create the backing index.
+    // Both statements run in one transaction so concurrent ignored tests
+    // never observe a window without the unique index.
+    let mut tx = pool.begin().await.expect("transaction should start");
+    sqlx::query(
+        "ALTER TABLE historical_prices \
+         DROP CONSTRAINT historical_prices_epic_resolution_snapshot_time_key",
+    )
+    .execute(&mut *tx)
+    .await
+    .expect("dropping the constraint should succeed");
+    sqlx::query(
+        "CREATE UNIQUE INDEX historical_prices_epic_resolution_snapshot_time_key \
+         ON historical_prices (epic, resolution, snapshot_time)",
+    )
+    .execute(&mut *tx)
+    .await
+    .expect("creating the orphan index should succeed");
+    tx.commit().await.expect("transaction should commit");
+
+    // The migration must tolerate the orphan backing index instead of
+    // failing on every startup. Capture the result instead of asserting here
+    // so the restore below always runs — a panic at this point would leave
+    // the shared schema without its constraint and cascade into the other
+    // ignored tests.
+    let tolerate_result = initialize_historical_prices_table(&pool).await;
+
+    // Restore the canonical constraint-backed state for the other tests.
+    // Valid in both outcomes: whether the init tolerated the orphan index or
+    // errored, the state is still index-present / constraint-absent.
+    let mut tx = pool.begin().await.expect("transaction should start");
+    sqlx::query("DROP INDEX historical_prices_epic_resolution_snapshot_time_key")
+        .execute(&mut *tx)
+        .await
+        .expect("dropping the orphan index should succeed");
+    sqlx::query(
+        "ALTER TABLE historical_prices \
+         ADD CONSTRAINT historical_prices_epic_resolution_snapshot_time_key \
+         UNIQUE (epic, resolution, snapshot_time)",
+    )
+    .execute(&mut *tx)
+    .await
+    .expect("re-adding the constraint should succeed");
+    tx.commit().await.expect("transaction should commit");
+
+    let row = sqlx::query(
+        "SELECT COUNT(*) AS n FROM pg_constraint \
+         WHERE conname = 'historical_prices_epic_resolution_snapshot_time_key'",
+    )
+    .fetch_one(&pool)
+    .await
+    .expect("constraint lookup should succeed");
+    let count: i64 = row.get("n");
+    assert_eq!(count, 1, "the canonical unique constraint must be restored");
+
+    assert!(
+        tolerate_result.is_ok(),
+        "initialization must tolerate an orphan backing index (42P07): {:?}",
+        tolerate_result.err()
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires a live PostgreSQL via DATABASE_URL"]
 async fn test_store_historical_prices_upsert_is_idempotent() {
     let Some(pool) = test_pool().await else {
         return;

--- a/tests/integration/storage_tests.rs
+++ b/tests/integration/storage_tests.rs
@@ -116,16 +116,23 @@ async fn test_initialize_tolerates_orphan_backing_index() {
     // constraint is attached (manually created index, pg_restore, partial
     // migration). `ADD CONSTRAINT ... UNIQUE` then fails with SQLSTATE 42P07
     // ("relation already exists") while trying to create the backing index.
-    // Both statements run in one transaction so concurrent ignored tests
-    // never observe a window without the unique index.
+    // All statements run in one transaction so concurrent ignored tests
+    // never observe a window without the unique index. `IF EXISTS` on both
+    // drops makes the setup idempotent when a prior failed run left the
+    // schema in the orphan-index state: dropping the constraint also drops
+    // its backing index, and the second drop clears a leftover orphan index.
     let mut tx = pool.begin().await.expect("transaction should start");
     sqlx::query(
         "ALTER TABLE historical_prices \
-         DROP CONSTRAINT historical_prices_epic_resolution_snapshot_time_key",
+         DROP CONSTRAINT IF EXISTS historical_prices_epic_resolution_snapshot_time_key",
     )
     .execute(&mut *tx)
     .await
     .expect("dropping the constraint should succeed");
+    sqlx::query("DROP INDEX IF EXISTS historical_prices_epic_resolution_snapshot_time_key")
+        .execute(&mut *tx)
+        .await
+        .expect("dropping a leftover orphan index should succeed");
     sqlx::query(
         "CREATE UNIQUE INDEX historical_prices_epic_resolution_snapshot_time_key \
          ON historical_prices (epic, resolution, snapshot_time)",
@@ -143,10 +150,19 @@ async fn test_initialize_tolerates_orphan_backing_index() {
     let tolerate_result = initialize_historical_prices_table(&pool).await;
 
     // Restore the canonical constraint-backed state for the other tests.
-    // Valid in both outcomes: whether the init tolerated the orphan index or
-    // errored, the state is still index-present / constraint-absent.
+    // Dropping the constraint (if any) before the index keeps the cleanup
+    // robust even if a future `initialize_historical_prices_table()` were to
+    // attach a constraint to the orphan index — a bare `DROP INDEX` would
+    // then fail on the dependency.
     let mut tx = pool.begin().await.expect("transaction should start");
-    sqlx::query("DROP INDEX historical_prices_epic_resolution_snapshot_time_key")
+    sqlx::query(
+        "ALTER TABLE historical_prices \
+         DROP CONSTRAINT IF EXISTS historical_prices_epic_resolution_snapshot_time_key",
+    )
+    .execute(&mut *tx)
+    .await
+    .expect("dropping a constraint attached to the index should succeed");
+    sqlx::query("DROP INDEX IF EXISTS historical_prices_epic_resolution_snapshot_time_key")
         .execute(&mut *tx)
         .await
         .expect("dropping the orphan index should succeed");


### PR DESCRIPTION
## Summary

`initialize_historical_prices_table()` failed on every startup when the
backing index for the `(epic, resolution, snapshot_time)` unique constraint
already existed without an attached constraint (manually created index,
`pg_restore`, partial migration): `ADD CONSTRAINT ... UNIQUE` implicitly
creates a backing index of the same name, so PostgreSQL raises SQLSTATE
`42P07` ("relation already exists") — which the migration did not tolerate,
only `42710` (duplicate_object). Reported in #79 against PostgreSQL 18.1 /
ig-client 0.12.0. Also bumps the release version to 0.12.1.

## Changes

- The unique-constraint migration now treats SQLSTATE `42P07` as a second
  benign "already exists" case alongside `42710`, via a new private pure
  helper `is_benign_already_exists()`; the `warn!` log now includes the
  tolerated SQLSTATE so the two cases are distinguishable.
- Any other error (including database errors with no SQLSTATE) still
  propagates unchanged.
- New env-gated integration test reproduces the reporter's exact database
  state (constraint dropped + orphan unique index created in one
  transaction, so concurrent ignored tests never observe a window without
  the unique index) and asserts the migration now succeeds; canonical
  constraint-backed state is restored before the assertion so a regression
  cannot leave the shared schema dirty.
- Version bumped to 0.12.1 (`Cargo.toml`, install snippet in `src/lib.rs`,
  `README.tpl` "What's New" entry); `README.md` regenerated via
  `make readme`.

## Technical decisions

- Chose the issue's suggested fix (tolerate `42P07`) over a pre-flight
  `pg_constraint` existence check: the reporter's state has the *index*
  without the *constraint*, so a constraint-existence check would not have
  prevented the failure.
- Known caveat (accepted): tolerating `42P07` assumes the pre-existing
  relation is a compatible unique index over the three columns — the
  scenario the fix targets. An incompatible relation of the same name would
  surface later at the `ON CONFLICT` upsert instead of at startup.

## Testing

- [x] Unit tests added or updated (SQLSTATE classification: `42710`,
      `42P07`, and non-benign codes keep propagating)
- [x] Live-API tests under `tests/integration/` remain env-gated (never run
      in CI); the new orphan-index repro test follows the existing
      `DATABASE_URL`-gated pattern
- [x] `make pre-push` run locally and clean

## Checklist

- [x] Code follows `rules/global_rules.md` and `CLAUDE.md`
- [x] All `pub` items have `///` documentation; `# Errors` on fallible functions
- [x] No `.unwrap()` / `.expect()` / unchecked indexing in production code
- [x] No `unsafe` introduced (banned crate-wide)
- [x] Module boundaries respected (`model` / `presentation` stay I/O-free; `application` has no deps on `storage`)
- [x] No new dependencies added without explicit approval
- [x] `tracing` only for logging — no credentials / tokens / CST / X-SECURITY-TOKEN in logs, errors, or fixtures
- [x] Retry stays finite — no unbounded retry loops (removed in PR #26)
- [x] SQL values via bind parameters; DDL strings remain static (no `AssertSqlSafe` needed)
- [x] `src/lib.rs` docs + `README.md` (via `make readme`) updated; version bumped in `Cargo.toml` (0.12.1)

Closes #79
