### PR TITLE
feat(client): add Client::with_config for programmatic config injection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ig-client"
-version = "0.12.1"
+version = "0.12.2"
 edition = "2024"
 authors = ["Joaquin Bejar <jb@taunais.com>"]
 description = "This crate provides a client for the IG Markets API"

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-ig-client = "0.12.1"
+ig-client = "0.12.2"
 tokio = { version = "1", features = ["full"] }  # Async runtime
 tracing = "0.1"                                  # Logging facade
 # Optional, only if you use the PostgreSQL persistence layer:
@@ -63,7 +63,10 @@ sqlx = { version = "0.9", features = ["runtime-tokio", "tls-native-tls", "postgr
 ```
 
 You do not need to add `dotenv` yourself — `Config::new()` loads a local
-`.env` file internally.
+`.env` file internally. If your application supplies its own configuration
+and must not read a `.env` file or the `IG_*` namespace, use
+`Config::from_credentials()` with `Client::with_config()` instead (see
+[Programmatic configuration](#programmatic-configuration-embedders)).
 
 #### Requirements
 
@@ -100,6 +103,68 @@ TX_DAYS_LOOKBACK=7                                 # Days to look back for trans
 Live examples and integration tests default to the IG **demo** environment;
 pointing anything at production requires an explicit opt-in via
 `IG_REST_BASE_URL` / `IG_WS_URL`.
+
+#### Programmatic configuration (embedders)
+
+There are two configuration paths and they do not mix:
+
+- `Config::new()` / `Client::try_new()` — the **convenience path**. Loads a
+  local `.env` file and reads the global `IG_*` namespace, as above.
+- `Config::from_credentials()` / `Client::with_config()` — the **injection
+  path**. Reads no environment variable and loads no `.env` file, for an
+  embedding application that owns its configuration source (its own
+  namespaced variables, a config file, a secrets manager). Useful under
+  `#![forbid(unsafe_code)]`, where pre-populating `IG_*` is not an option
+  because `std::env::set_var` is `unsafe` on edition 2024.
+
+```rust
+use ig_client::prelude::*;
+
+// Fail fast on a missing variable: an empty credential would only surface
+// later as a confusing authentication failure. Never log the value.
+fn required_var(name: &str) -> Result<String, AppError> {
+    std::env::var(name).map_err(|_| AppError::InvalidInput(format!("{name} is not set")))
+}
+
+let credentials = Credentials::new(
+    required_var("MYAPP_IG_USERNAME")?,
+    required_var("MYAPP_IG_PASSWORD")?,
+    required_var("MYAPP_IG_ACCOUNT_ID")?,
+    required_var("MYAPP_IG_API_KEY")?,
+);
+
+// Struct update overrides individual sections and stays env-free,
+// because the base value is the env-free constructor.
+let config = Config {
+    rest_api: RestApiConfig {
+        base_url: "https://demo-api.ig.com/gateway/deal".to_string(),
+        timeout: 30,
+    },
+    ..Config::from_credentials(credentials)
+};
+
+let client = Client::with_config(config)?;
+println!("REST base URL: {}", client.config().rest_api.base_url);
+```
+
+Non-credential fields default to the IG **demo** endpoints; see
+`examples/simples/src/bin/client_with_config.rs` for a runnable version.
+
+For streaming, build the streamer from the injected client with
+`StreamerClient::with_client(&client)` — `StreamerClient::new()` goes
+through `Client::try_new()` and therefore back to `.env` / `IG_*`.
+
+Two knobs are still resolved from the process environment on the injected
+path, because they are not part of `Config`:
+
+- Retry policy — `MAX_RETRY_COUNT` and `RETRY_DELAY_SECS` are read per
+  request via `RetryConfig::default()`; unset means the crate defaults.
+- `IG_PRICING_ADAPTER` — the Lightstreamer price adapter name, defaulting
+  to `Pricing` when unset.
+
+Neither carries a credential, and both have safe defaults, so an embedder
+that sets neither variable is unaffected. Moving them into `Config` is a
+breaking change scheduled for a future minor release.
 
 ### Usage
 
@@ -362,6 +427,21 @@ Contributions are welcome:
 
 Please make sure your code passes all tests and linting checks before
 submitting a pull request.
+
+## What's New in 0.12.2
+
+- `Client::with_config(config)` builds a client from a caller-supplied
+  `Config`, reading no environment variable and loading no `.env` file — the
+  injection path for applications that own their configuration source.
+  `Client::try_new()` is unchanged and remains the `.env` / `IG_*` convenience
+  path ([#81](https://github.com/joaquinbejar/ig-client/issues/81)).
+- `Config::from_credentials(credentials)` and `Credentials::new(..)` build a
+  configuration entirely from caller-supplied values, with `Default` impls on
+  `RestApiConfig`, `WebSocketConfig`, `RateLimiterConfig` and `DatabaseConfig`
+  supplying the non-credential defaults (the same values `Config::new()` falls
+  back to).
+- `Client::config()` / `HttpClient::config()` expose the effective
+  configuration (secrets stay redacted in `Debug` / `Display`).
 
 ## What's New in 0.12.1
 

--- a/README.tpl
+++ b/README.tpl
@@ -12,6 +12,21 @@
 
 {{readme}}
 
+## What's New in 0.12.2
+
+- `Client::with_config(config)` builds a client from a caller-supplied
+  `Config`, reading no environment variable and loading no `.env` file — the
+  injection path for applications that own their configuration source.
+  `Client::try_new()` is unchanged and remains the `.env` / `IG_*` convenience
+  path ([#81](https://github.com/joaquinbejar/ig-client/issues/81)).
+- `Config::from_credentials(credentials)` and `Credentials::new(..)` build a
+  configuration entirely from caller-supplied values, with `Default` impls on
+  `RestApiConfig`, `WebSocketConfig`, `RateLimiterConfig` and `DatabaseConfig`
+  supplying the non-credential defaults (the same values `Config::new()` falls
+  back to).
+- `Client::config()` / `HttpClient::config()` expose the effective
+  configuration (secrets stay redacted in `Debug` / `Display`).
+
 ## What's New in 0.12.1
 
 - The `historical_prices` unique-constraint migration now tolerates

--- a/doc/RATE_LIMITER.md
+++ b/doc/RATE_LIMITER.md
@@ -12,17 +12,23 @@ Rate limiting is configured through environment variables that are loaded when c
 
 | Variable | Description | Default | Example |
 |----------|-------------|---------|---------|
-| `IG_RATE_LIMIT_MAX_REQUESTS` | Maximum number of requests allowed per period | 60 | 60 |
-| `IG_RATE_LIMIT_PERIOD_SECONDS` | Time period in seconds for the rate limit | 60 | 60 |
-| `IG_RATE_LIMIT_BURST_SIZE` | Maximum number of requests that can be made at once (burst) | 10 | 10 |
+| `IG_RATE_LIMIT_MAX_REQUESTS` | Maximum number of requests allowed per period | 4 | 4 |
+| `IG_RATE_LIMIT_PERIOD_SECONDS` | Time period in seconds for the rate limit | 12 | 12 |
+| `IG_RATE_LIMIT_BURST_SIZE` | Maximum number of requests that can be made at once (burst) | 3 | 3 |
+
+The defaults are the canonical `DEFAULT_CONFIG_RATE_LIMIT_MAX_REQUESTS`,
+`DEFAULT_CONFIG_RATE_LIMIT_PERIOD_SECONDS` and
+`DEFAULT_CONFIG_RATE_LIMIT_BURST_SIZE` constants in `src/constants.rs`, which
+also back `RateLimiterConfig::default()` — the value used by the environment-free
+`Config::from_credentials` path.
 
 ### Example .env File
 
 ```env
 # Rate Limiter Configuration
-IG_RATE_LIMIT_MAX_REQUESTS=60
-IG_RATE_LIMIT_PERIOD_SECONDS=60
-IG_RATE_LIMIT_BURST_SIZE=10
+IG_RATE_LIMIT_MAX_REQUESTS=4
+IG_RATE_LIMIT_PERIOD_SECONDS=12
+IG_RATE_LIMIT_BURST_SIZE=3
 ```
 
 ## How It Works
@@ -39,19 +45,19 @@ The rate limiter uses a token bucket algorithm:
 
 #### Scenario 1: Steady Rate
 ```
-Config: 60 requests per 60 seconds, burst size 10
+Config: 4 requests per 12 seconds, burst size 3
 
-- Can make 10 requests immediately (burst)
-- Then limited to ~1 request per second
-- Over 60 seconds, can make 60 requests total
+- Can make 3 requests immediately (burst)
+- Then limited to ~1 request every 3 seconds
+- Over 12 seconds, can make 4 requests total
 ```
 
 #### Scenario 2: Burst Handling
 ```
-Config: 60 requests per 60 seconds, burst size 20
+Config: 4 requests per 12 seconds, burst size 10
 
-- Can make 20 requests immediately (larger burst)
-- Then rate-limited to maintain average of 60/minute
+- Can make 10 requests immediately (larger burst)
+- Then rate-limited to maintain the average of 4 per 12 seconds
 ```
 
 ## Usage
@@ -128,9 +134,9 @@ According to IG Markets documentation, the API has the following limits:
 
 For general use:
 ```env
-IG_RATE_LIMIT_MAX_REQUESTS=60
-IG_RATE_LIMIT_PERIOD_SECONDS=60
-IG_RATE_LIMIT_BURST_SIZE=10
+IG_RATE_LIMIT_MAX_REQUESTS=4
+IG_RATE_LIMIT_PERIOD_SECONDS=12
+IG_RATE_LIMIT_BURST_SIZE=3
 ```
 
 For conservative use (to stay well under limits):

--- a/examples/simples/Cargo.toml
+++ b/examples/simples/Cargo.toml
@@ -7,6 +7,10 @@ edition = "2024"
 name = "historical_prices_example"
 path = "src/bin/historical_prices_example.rs"
 
+[[bin]]
+name = "client_with_config"
+path = "src/bin/client_with_config.rs"
+
 [dependencies]
 ig-client = { workspace = true }
 tracing = { workspace = true }

--- a/examples/simples/src/bin/client_with_config.rs
+++ b/examples/simples/src/bin/client_with_config.rs
@@ -1,0 +1,61 @@
+//! Constructing a `Client` from configuration the embedding application owns.
+//!
+//! `Client::try_new()` is the convenience path: it loads a local `.env` file and
+//! reads the global `IG_*` environment namespace. An embedding application that
+//! keeps credentials in its own namespaced variables — and must not have the
+//! crate reach for globals or a `.env` file — uses `Config::from_credentials`
+//! plus `Client::with_config` instead. Neither touches `dotenv` nor `IG_*`.
+//!
+//! Run with the embedder's own variables set:
+//!
+//! ```bash
+//! MYAPP_IG_USERNAME=... MYAPP_IG_PASSWORD=... MYAPP_IG_ACCOUNT_ID=... \
+//! MYAPP_IG_API_KEY=... cargo run -p simples --bin client_with_config
+//! ```
+
+use ig_client::prelude::*;
+use std::env;
+use tracing::info;
+
+/// Reads a variable from the embedder's own namespace.
+fn required_var(name: &str) -> Result<String, AppError> {
+    env::var(name).map_err(|_| AppError::InvalidInput(format!("{name} is not set")))
+}
+
+#[tokio::main]
+async fn main() -> Result<(), AppError> {
+    setup_logger();
+
+    // Credentials come from the embedder's namespace, never from `IG_*`.
+    let credentials = Credentials::new(
+        required_var("MYAPP_IG_USERNAME")?,
+        required_var("MYAPP_IG_PASSWORD")?,
+        required_var("MYAPP_IG_ACCOUNT_ID")?,
+        required_var("MYAPP_IG_API_KEY")?,
+    );
+
+    // `from_credentials` reads no environment variable and loads no `.env`
+    // file; struct update overrides only the sections we care about.
+    let config = Config {
+        rest_api: RestApiConfig {
+            base_url: env::var("MYAPP_IG_REST_BASE_URL")
+                .unwrap_or_else(|_| RestApiConfig::default().base_url),
+            timeout: 30,
+        },
+        ..Config::from_credentials(credentials)
+    };
+
+    let client = Client::with_config(config)?;
+
+    // `Config`'s Display redacts credentials, so this logs no secrets.
+    info!(
+        "client built from injected config, REST base URL: {}",
+        client.config().rest_api.base_url
+    );
+
+    // Session login happens transparently on the first API call.
+    let accounts = client.get_accounts().await?;
+    info!("{} account(s) available", accounts.accounts.len());
+
+    Ok(())
+}

--- a/src/application/client.rs
+++ b/src/application/client.rs
@@ -177,12 +177,15 @@ pub struct Client {
 }
 
 impl Client {
-    /// Creates a new client instance without performing initial authentication,
-    /// returning an error if the underlying HTTP client cannot be constructed.
+    /// Creates a new client instance from the environment, without performing
+    /// initial authentication, returning an error if the underlying HTTP client
+    /// cannot be constructed.
     ///
-    /// This is the sole constructor for [`Client`]: it builds the underlying
-    /// [`HttpClient`] via [`HttpClient::new_lazy`] and surfaces a
-    /// client-construction failure as a typed [`AppError`] instead of panicking.
+    /// This is the environment convenience path: the configuration comes from
+    /// [`Config::default`], which loads a local `.env` file and reads the
+    /// `IG_*` environment namespace. Embedders that supply their own
+    /// configuration should use [`Client::with_config`] instead, which touches
+    /// neither.
     ///
     /// # Returns
     /// * `Ok(Client)` - A client ready to use with the default configuration.
@@ -194,6 +197,85 @@ impl Client {
     pub fn try_new() -> Result<Self, AppError> {
         let http_client = Arc::new(HttpClient::new_lazy(Config::default())?);
         Ok(Self { http_client })
+    }
+
+    /// Creates a new client instance from a caller-supplied [`Config`], without
+    /// reading a `.env` file or the `IG_*` environment namespace.
+    ///
+    /// This is the injection path for applications that own their
+    /// configuration source (their own namespaced environment variables, a
+    /// config file, a secrets manager) and must not have the crate reach for
+    /// globals. Build the `Config` with
+    /// [`Config::from_credentials`](crate::application::config::Config::from_credentials),
+    /// which is likewise env-free; [`Client::try_new`] remains the `.env`
+    /// convenience path.
+    ///
+    /// As with [`try_new`](Self::try_new), no authentication is performed here:
+    /// session login and token refresh happen transparently on the first API
+    /// call.
+    ///
+    /// Two knobs live outside [`Config`] and are still resolved from the
+    /// process environment on this path: the retry policy (`MAX_RETRY_COUNT` /
+    /// `RETRY_DELAY_SECS`, read per request by
+    /// [`RetryConfig::default`](crate::model::retry::RetryConfig)) and
+    /// `IG_PRICING_ADAPTER` (the Lightstreamer price adapter name). Neither
+    /// carries a credential and both have safe defaults, so an embedder that
+    /// sets neither is unaffected.
+    ///
+    /// For streaming, pair this with
+    /// [`StreamerClient::with_client`](crate::application::client::StreamerClient::with_client):
+    /// [`StreamerClient::new`](crate::application::client::StreamerClient::new)
+    /// builds its own client via [`try_new`](Self::try_new) and would go back
+    /// to the `.env` / `IG_*` path.
+    ///
+    /// ```rust,no_run
+    /// use ig_client::prelude::*;
+    ///
+    /// // Fail fast on a missing variable: an empty credential would only
+    /// // surface later as a confusing authentication failure.
+    /// fn required_var(name: &str) -> Result<String, AppError> {
+    ///     std::env::var(name).map_err(|_| AppError::InvalidInput(format!("{name} is not set")))
+    /// }
+    ///
+    /// # fn main() -> Result<(), AppError> {
+    /// let credentials = Credentials::new(
+    ///     required_var("MYAPP_IG_USERNAME")?,
+    ///     required_var("MYAPP_IG_PASSWORD")?,
+    ///     required_var("MYAPP_IG_ACCOUNT_ID")?,
+    ///     required_var("MYAPP_IG_API_KEY")?,
+    /// );
+    /// let client = Client::with_config(Config::from_credentials(credentials))?;
+    /// # let _ = client;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// # Arguments
+    /// * `config` - The configuration the client and its session layer will use.
+    ///
+    /// # Returns
+    /// * `Ok(Client)` - A client ready to use with `config`.
+    /// * `Err(AppError)` - If the underlying HTTP client cannot be constructed.
+    ///
+    /// # Errors
+    /// Returns [`AppError::Network`] if the underlying `reqwest` client cannot
+    /// be built (e.g. the system TLS backend fails to initialize).
+    pub fn with_config(config: Config) -> Result<Self, AppError> {
+        let http_client = Arc::new(HttpClient::new_lazy(config)?);
+        Ok(Self { http_client })
+    }
+
+    /// Returns the configuration this client was built with.
+    ///
+    /// Useful to confirm which environment the client is pointed at (e.g.
+    /// `client.config().rest_api.base_url`). `Config`'s `Debug` / `Display`
+    /// redact credentials and the database URL, so rendering it that way is
+    /// safe. Its `Serialize` impl does **not** redact — never serialize a
+    /// `Config` into logs, telemetry or an error payload.
+    #[inline]
+    #[must_use]
+    pub fn config(&self) -> &Config {
+        self.http_client.config()
     }
 
     /// Gets WebSocket connection information for Lightstreamer, reusing the

--- a/src/application/config.rs
+++ b/src/application/config.rs
@@ -1,4 +1,10 @@
-use crate::constants::{DAYS_TO_BACK_LOOK, DEFAULT_PAGE_SIZE, DEFAULT_SLEEP_TIME};
+use crate::constants::{
+    DAYS_TO_BACK_LOOK, DEFAULT_API_VERSION, DEFAULT_CONFIG_RATE_LIMIT_BURST_SIZE,
+    DEFAULT_CONFIG_RATE_LIMIT_MAX_REQUESTS, DEFAULT_CONFIG_RATE_LIMIT_PERIOD_SECONDS,
+    DEFAULT_DATABASE_MAX_CONNECTIONS, DEFAULT_DATABASE_URL, DEFAULT_PAGE_SIZE,
+    DEFAULT_REST_BASE_URL, DEFAULT_REST_TIMEOUT_SECS, DEFAULT_SLEEP_TIME,
+    DEFAULT_WS_RECONNECT_INTERVAL_SECS, DEFAULT_WS_URL,
+};
 use crate::utils::config::get_env_or_default;
 use dotenv::dotenv;
 use pretty_simple_display::{DebugPretty, DisplaySimple};
@@ -127,7 +133,10 @@ pub struct Config {
     pub page_size: u32,
     /// Number of days to look back when fetching historical data
     pub days_to_look_back: i64,
-    /// API version to use for authentication (2 or 3). If None, auto-detect based on available tokens
+    /// API version to use for authentication: `Some(2)` for CST /
+    /// X-SECURITY-TOKEN, `Some(3)` for OAuth. Both constructors set
+    /// `Some(3)` ([`crate::constants::DEFAULT_API_VERSION`]); an explicit
+    /// `None` makes login fall back to v2.
     pub api_version: Option<u8>,
 }
 
@@ -184,19 +193,155 @@ pub struct RateLimiterConfig {
     pub burst_size: u32,
 }
 
+// The `Default` impls below are the single source of truth for the
+// non-credential defaults: they hold the literals and `Config::new()` uses them
+// as its `get_env_or_default` fallbacks. They read no environment variable and
+// load no `.env` file, so they are usable from the injection path
+// ([`Config::from_credentials`] / `Client::with_config`).
+
+impl Default for RestApiConfig {
+    /// IG **demo** REST gateway with a 30 second request timeout.
+    fn default() -> Self {
+        Self {
+            base_url: String::from(DEFAULT_REST_BASE_URL),
+            timeout: DEFAULT_REST_TIMEOUT_SECS,
+        }
+    }
+}
+
+impl Default for WebSocketConfig {
+    /// IG **demo** Lightstreamer endpoint with a 5 second reconnect interval.
+    fn default() -> Self {
+        Self {
+            url: String::from(DEFAULT_WS_URL),
+            reconnect_interval: DEFAULT_WS_RECONNECT_INTERVAL_SECS,
+        }
+    }
+}
+
+impl Default for RateLimiterConfig {
+    /// The crate-wide non-trading budget: 4 requests per 12 seconds, burst 3.
+    fn default() -> Self {
+        Self {
+            max_requests: DEFAULT_CONFIG_RATE_LIMIT_MAX_REQUESTS,
+            period_seconds: DEFAULT_CONFIG_RATE_LIMIT_PERIOD_SECONDS,
+            burst_size: DEFAULT_CONFIG_RATE_LIMIT_BURST_SIZE,
+        }
+    }
+}
+
+impl Default for DatabaseConfig {
+    /// Credential-less placeholder URL — persistence will not connect until the
+    /// caller supplies a real one.
+    fn default() -> Self {
+        Self {
+            url: String::from(DEFAULT_DATABASE_URL),
+            max_connections: DEFAULT_DATABASE_MAX_CONNECTIONS,
+        }
+    }
+}
+
+impl Credentials {
+    /// Builds credentials from the four required fields, leaving both session
+    /// tokens unset.
+    ///
+    /// The tokens (`client_token` / `account_token`) are populated by the
+    /// session layer on login, so callers never provide them.
+    ///
+    /// # Arguments
+    ///
+    /// * `username` - IG account username
+    /// * `password` - IG account password
+    /// * `account_id` - IG account identifier
+    /// * `api_key` - IG API key
+    #[must_use]
+    pub fn new(username: String, password: String, account_id: String, api_key: String) -> Self {
+        Self {
+            username,
+            password,
+            account_id,
+            api_key,
+            client_token: None,
+            account_token: None,
+        }
+    }
+}
+
 impl Default for Config {
+    /// Delegates to [`Config::new`] and therefore loads a `.env` file and reads
+    /// the `IG_*` namespace — unlike the section-level `Default` impls above,
+    /// which are env-free. `Config { .., ..Config::default() }` still touches
+    /// the environment; use [`Config::from_credentials`] as the base value when
+    /// that is not acceptable.
     fn default() -> Self {
         Self::new()
     }
 }
 
 impl Config {
-    /// Creates a new configuration instance with a specific rate limit type
+    /// Creates a configuration from caller-supplied credentials, reading **no**
+    /// environment variable and loading **no** `.env` file.
+    ///
+    /// This is the injection path for embedding applications that own their
+    /// configuration source (their own namespaced env vars, a config file, a
+    /// secrets manager). Pair it with
+    /// [`Client::with_config`](crate::application::client::Client::with_config).
+    /// [`Config::new`] remains the `.env` / `IG_*` convenience path.
+    ///
+    /// Every non-credential field takes its documented default (IG **demo**
+    /// endpoints — see the `Default` impls of [`RestApiConfig`],
+    /// [`WebSocketConfig`], [`RateLimiterConfig`] and [`DatabaseConfig`]).
+    /// Override individual sections with a struct-update expression, which
+    /// stays env-free because the base value is this constructor:
+    ///
+    /// ```rust
+    /// use ig_client::prelude::*;
+    ///
+    /// let credentials = Credentials::new(
+    ///     "user".to_string(),
+    ///     "password".to_string(),
+    ///     "ABC123".to_string(),
+    ///     "api-key".to_string(),
+    /// );
+    /// let config = Config {
+    ///     rest_api: RestApiConfig {
+    ///         base_url: "https://demo-api.ig.com/gateway/deal".to_string(),
+    ///         timeout: 30,
+    ///     },
+    ///     ..Config::from_credentials(credentials)
+    /// };
+    /// assert_eq!(config.rest_api.base_url, "https://demo-api.ig.com/gateway/deal");
+    /// ```
     ///
     /// # Arguments
     ///
-    /// * `rate_limit_type` - The type of rate limit to enforce
-    /// * `safety_margin` - A value between 0.0 and 1.0 representing the percentage of the actual limit to use
+    /// * `credentials` - IG credentials supplied by the caller
+    ///
+    /// # Returns
+    ///
+    /// A `Config` built entirely from `credentials` plus the documented defaults
+    #[must_use]
+    pub fn from_credentials(credentials: Credentials) -> Self {
+        Config {
+            credentials,
+            rest_api: RestApiConfig::default(),
+            websocket: WebSocketConfig::default(),
+            database: DatabaseConfig::default(),
+            rate_limiter: RateLimiterConfig::default(),
+            sleep_hours: DEFAULT_SLEEP_TIME,
+            page_size: DEFAULT_PAGE_SIZE,
+            days_to_look_back: DAYS_TO_BACK_LOOK,
+            api_version: Some(DEFAULT_API_VERSION),
+        }
+    }
+
+    /// Creates a new configuration instance from the environment.
+    ///
+    /// Loads a local `.env` file (via `dotenv`) and reads the `IG_*` /
+    /// `DATABASE_*` / `TX_*` environment variables, falling back to the
+    /// documented defaults for anything unset. Embedders that must not touch
+    /// the `.env` file or the `IG_*` namespace should use
+    /// [`Config::from_credentials`] instead.
     ///
     /// # Returns
     ///
@@ -216,10 +361,14 @@ impl Config {
         let page_size = get_env_or_default("TX_PAGE_SIZE", DEFAULT_PAGE_SIZE);
         let days_to_look_back = get_env_or_default("TX_DAYS_LOOKBACK", DAYS_TO_BACK_LOOK);
 
-        let database_url = get_env_or_default(
-            "DATABASE_URL",
-            String::from(crate::constants::DEFAULT_DATABASE_URL),
-        );
+        // Defaults come from the `Default` impls so the env path and the
+        // env-free path (`from_credentials`) cannot drift apart.
+        let rest_defaults = RestApiConfig::default();
+        let ws_defaults = WebSocketConfig::default();
+        let rate_limit_defaults = RateLimiterConfig::default();
+        let database_defaults = DatabaseConfig::default();
+
+        let database_url = get_env_or_default("DATABASE_URL", database_defaults.url);
 
         // Check if we are using default values
         if username == "default_username" {
@@ -256,27 +405,36 @@ impl Config {
                 account_token: None,
             },
             rest_api: RestApiConfig {
-                base_url: get_env_or_default(
-                    "IG_REST_BASE_URL",
-                    String::from("https://demo-api.ig.com/gateway/deal"),
-                ),
-                timeout: get_env_or_default("IG_REST_TIMEOUT", 30),
+                base_url: get_env_or_default("IG_REST_BASE_URL", rest_defaults.base_url),
+                timeout: get_env_or_default("IG_REST_TIMEOUT", rest_defaults.timeout),
             },
             websocket: WebSocketConfig {
-                url: get_env_or_default(
-                    "IG_WS_URL",
-                    String::from("wss://demo-apd.marketdatasystems.com"),
+                url: get_env_or_default("IG_WS_URL", ws_defaults.url),
+                reconnect_interval: get_env_or_default(
+                    "IG_WS_RECONNECT_INTERVAL",
+                    ws_defaults.reconnect_interval,
                 ),
-                reconnect_interval: get_env_or_default("IG_WS_RECONNECT_INTERVAL", 5),
             },
             database: DatabaseConfig {
                 url: database_url,
-                max_connections: get_env_or_default("DATABASE_MAX_CONNECTIONS", 5),
+                max_connections: get_env_or_default(
+                    "DATABASE_MAX_CONNECTIONS",
+                    database_defaults.max_connections,
+                ),
             },
             rate_limiter: RateLimiterConfig {
-                max_requests: get_env_or_default("IG_RATE_LIMIT_MAX_REQUESTS", 4), // 3
-                period_seconds: get_env_or_default("IG_RATE_LIMIT_PERIOD_SECONDS", 12), // 10
-                burst_size: get_env_or_default("IG_RATE_LIMIT_BURST_SIZE", 3),
+                max_requests: get_env_or_default(
+                    "IG_RATE_LIMIT_MAX_REQUESTS",
+                    rate_limit_defaults.max_requests,
+                ),
+                period_seconds: get_env_or_default(
+                    "IG_RATE_LIMIT_PERIOD_SECONDS",
+                    rate_limit_defaults.period_seconds,
+                ),
+                burst_size: get_env_or_default(
+                    "IG_RATE_LIMIT_BURST_SIZE",
+                    rate_limit_defaults.burst_size,
+                ),
             },
             sleep_hours,
             page_size,
@@ -285,8 +443,131 @@ impl Config {
                 .ok()
                 .and_then(|v| v.parse::<u8>().ok())
                 .filter(|&v| v == 2 || v == 3)
-                .or(Some(3)), // Default to API v3 (OAuth) if not specified
+                .or(Some(DEFAULT_API_VERSION)), // Default to API v3 (OAuth) if not specified
         }
+    }
+}
+
+#[cfg(test)]
+mod injection_tests {
+    use super::*;
+
+    fn injected_credentials() -> Credentials {
+        Credentials::new(
+            "embedder-user".to_string(),
+            "embedder-password".to_string(),
+            "EMBEDDER-ACC".to_string(),
+            "embedder-api-key".to_string(),
+        )
+    }
+
+    #[test]
+    fn test_credentials_new_leaves_session_tokens_unset() {
+        let credentials = injected_credentials();
+        assert_eq!(credentials.username, "embedder-user");
+        assert_eq!(credentials.password, "embedder-password");
+        assert_eq!(credentials.account_id, "EMBEDDER-ACC");
+        assert_eq!(credentials.api_key, "embedder-api-key");
+        assert!(credentials.client_token.is_none());
+        assert!(credentials.account_token.is_none());
+    }
+
+    #[test]
+    fn test_config_from_credentials_keeps_injected_credentials_and_env_free_defaults() {
+        // No environment is mutated here (`set_var` is `unsafe` on edition 2024
+        // and racy under the parallel harness), so this asserts the contract
+        // rather than proving env-independence by construction: the injected
+        // credentials survive and every other field equals its documented
+        // default. The end-to-end env-independence check lives in
+        // `tests/unit/application/test_client.rs`, where the injected values
+        // cannot coincide with anything the environment holds.
+        let config = Config::from_credentials(injected_credentials());
+
+        assert_eq!(config.credentials.username, "embedder-user");
+        assert_eq!(config.credentials.api_key, "embedder-api-key");
+        assert_eq!(config.rest_api.base_url, DEFAULT_REST_BASE_URL);
+        assert_eq!(config.rest_api.timeout, DEFAULT_REST_TIMEOUT_SECS);
+        assert_eq!(config.websocket.url, DEFAULT_WS_URL);
+        assert_eq!(
+            config.websocket.reconnect_interval,
+            DEFAULT_WS_RECONNECT_INTERVAL_SECS
+        );
+        assert_eq!(config.database.url, DEFAULT_DATABASE_URL);
+        assert_eq!(
+            config.database.max_connections,
+            DEFAULT_DATABASE_MAX_CONNECTIONS
+        );
+        assert_eq!(
+            config.rate_limiter.max_requests,
+            DEFAULT_CONFIG_RATE_LIMIT_MAX_REQUESTS
+        );
+        assert_eq!(
+            config.rate_limiter.period_seconds,
+            DEFAULT_CONFIG_RATE_LIMIT_PERIOD_SECONDS
+        );
+        assert_eq!(
+            config.rate_limiter.burst_size,
+            DEFAULT_CONFIG_RATE_LIMIT_BURST_SIZE
+        );
+        assert_eq!(config.sleep_hours, DEFAULT_SLEEP_TIME);
+        assert_eq!(config.page_size, DEFAULT_PAGE_SIZE);
+        assert_eq!(config.days_to_look_back, DAYS_TO_BACK_LOOK);
+        assert_eq!(config.api_version, Some(DEFAULT_API_VERSION));
+    }
+
+    #[test]
+    fn test_config_from_credentials_struct_update_overrides_section() {
+        // The documented override pattern must not fall back to `Config::new()`
+        // (which would run `dotenv()`); the base value is the env-free ctor.
+        let config = Config {
+            rest_api: RestApiConfig {
+                base_url: "https://demo-api.ig.com/gateway/deal".to_string(),
+                timeout: 7,
+            },
+            ..Config::from_credentials(injected_credentials())
+        };
+
+        assert_eq!(
+            config.rest_api.base_url,
+            "https://demo-api.ig.com/gateway/deal"
+        );
+        assert_eq!(config.rest_api.timeout, 7);
+        // Untouched sections keep their env-free defaults.
+        assert_eq!(config.websocket.url, DEFAULT_WS_URL);
+    }
+
+    #[test]
+    fn test_section_defaults_match_documented_constants() {
+        // Guards the refactor that made `Config::new()` use these `Default`
+        // impls as its env fallbacks: the two paths must not drift apart.
+        let rest = RestApiConfig::default();
+        let ws = WebSocketConfig::default();
+        let rate_limiter = RateLimiterConfig::default();
+        let database = DatabaseConfig::default();
+
+        assert_eq!(rest.base_url, DEFAULT_REST_BASE_URL);
+        assert_eq!(rest.timeout, DEFAULT_REST_TIMEOUT_SECS);
+        assert_eq!(ws.url, DEFAULT_WS_URL);
+        assert_eq!(ws.reconnect_interval, DEFAULT_WS_RECONNECT_INTERVAL_SECS);
+        assert_eq!(
+            rate_limiter.max_requests,
+            DEFAULT_CONFIG_RATE_LIMIT_MAX_REQUESTS
+        );
+        assert_eq!(
+            rate_limiter.period_seconds,
+            DEFAULT_CONFIG_RATE_LIMIT_PERIOD_SECONDS
+        );
+        assert_eq!(
+            rate_limiter.burst_size,
+            DEFAULT_CONFIG_RATE_LIMIT_BURST_SIZE
+        );
+        assert_eq!(database.url, DEFAULT_DATABASE_URL);
+        assert_eq!(database.max_connections, DEFAULT_DATABASE_MAX_CONNECTIONS);
+        // The rate-limiter default is NOT the zero-burst fallback constant.
+        assert_ne!(
+            rate_limiter.burst_size,
+            crate::constants::DEFAULT_RATE_LIMIT_BURST_SIZE
+        );
     }
 }
 

--- a/src/application/http.rs
+++ b/src/application/http.rs
@@ -380,6 +380,18 @@ impl HttpClient {
     pub fn auth(&self) -> &Auth {
         &self.auth
     }
+
+    /// Returns the configuration this HTTP client was built with.
+    ///
+    /// `Config`'s `Debug` / `Display` impls redact credentials and the database
+    /// URL, so the returned value can be rendered that way without leaking
+    /// secrets. Its `Serialize` impl does **not** redact — never serialize a
+    /// `Config` into logs, telemetry or an error payload.
+    #[inline]
+    #[must_use]
+    pub fn config(&self) -> &Config {
+        &self.config
+    }
 }
 
 /// Makes an HTTP request with automatic rate limiting and retry on rate limit errors

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -101,6 +101,54 @@ pub const DEFAULT_ACCOUNT_ID: &str = "default_account_id";
 /// when it tries to connect. Never hard-code real credentials here.
 pub const DEFAULT_DATABASE_URL: &str = "postgres://localhost/ig";
 
+/// Default size of the Postgres connection pool
+/// ([`crate::application::config::DatabaseConfig::max_connections`]).
+pub const DEFAULT_DATABASE_MAX_CONNECTIONS: u32 = 5;
+
+/// Default IG REST gateway: the **demo** environment.
+///
+/// Pointing the client at production requires an explicit opt-in (setting
+/// `IG_REST_BASE_URL` or supplying a
+/// [`crate::application::config::RestApiConfig`] directly).
+pub const DEFAULT_REST_BASE_URL: &str = "https://demo-api.ig.com/gateway/deal";
+
+/// Default REST request timeout in seconds
+/// ([`crate::application::config::RestApiConfig::timeout`]).
+pub const DEFAULT_REST_TIMEOUT_SECS: u64 = 30;
+
+/// Default Lightstreamer endpoint: the **demo** environment. Production
+/// requires an explicit opt-in via `IG_WS_URL` or a
+/// [`crate::application::config::WebSocketConfig`] supplied by the caller.
+pub const DEFAULT_WS_URL: &str = "wss://demo-apd.marketdatasystems.com";
+
+/// Default delay between Lightstreamer reconnection attempts, in seconds
+/// ([`crate::application::config::WebSocketConfig::reconnect_interval`]).
+pub const DEFAULT_WS_RECONNECT_INTERVAL_SECS: u64 = 5;
+
+/// Default request budget of the configured rate limiter
+/// ([`crate::application::config::RateLimiterConfig::max_requests`]).
+///
+/// Distinct from the per-endpoint-class limits above: this is the general
+/// non-trading budget applied when nothing else is configured. Not to be
+/// confused with [`FALLBACK_RATE_LIMIT_MAX_REQUESTS`], which is the floor
+/// applied when a caller configures a budget of zero.
+pub const DEFAULT_CONFIG_RATE_LIMIT_MAX_REQUESTS: u32 = 4;
+
+/// Default period of the configured rate limiter, in seconds
+/// ([`crate::application::config::RateLimiterConfig::period_seconds`]).
+pub const DEFAULT_CONFIG_RATE_LIMIT_PERIOD_SECONDS: u64 = 12;
+
+/// Default burst size of the configured rate limiter
+/// ([`crate::application::config::RateLimiterConfig::burst_size`]).
+///
+/// Not to be confused with [`DEFAULT_RATE_LIMIT_BURST_SIZE`], which is the
+/// fallback applied when a caller configures a burst size of zero.
+pub const DEFAULT_CONFIG_RATE_LIMIT_BURST_SIZE: u32 = 3;
+
+/// Default IG API version used for authentication when `IG_API_VERSION` is not
+/// set: v3 (OAuth).
+pub const DEFAULT_API_VERSION: u8 = 3;
+
 /// Lifetime of an IG API v2 (CST / X-SECURITY-TOKEN) session, in seconds
 /// (21600 = 6 hours).
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! ig-client = "0.12.1"
+//! ig-client = "0.12.2"
 //! tokio = { version = "1", features = ["full"] }  # Async runtime
 //! tracing = "0.1"                                  # Logging facade
 //! # Optional, only if you use the PostgreSQL persistence layer:
@@ -51,7 +51,10 @@
 //! ```
 //!
 //! You do not need to add `dotenv` yourself — `Config::new()` loads a local
-//! `.env` file internally.
+//! `.env` file internally. If your application supplies its own configuration
+//! and must not read a `.env` file or the `IG_*` namespace, use
+//! `Config::from_credentials()` with `Client::with_config()` instead (see
+//! [Programmatic configuration](#programmatic-configuration-embedders)).
 //!
 //! ### Requirements
 //!
@@ -88,6 +91,71 @@
 //! Live examples and integration tests default to the IG **demo** environment;
 //! pointing anything at production requires an explicit opt-in via
 //! `IG_REST_BASE_URL` / `IG_WS_URL`.
+//!
+//! ### Programmatic configuration (embedders)
+//!
+//! There are two configuration paths and they do not mix:
+//!
+//! - `Config::new()` / `Client::try_new()` — the **convenience path**. Loads a
+//!   local `.env` file and reads the global `IG_*` namespace, as above.
+//! - `Config::from_credentials()` / `Client::with_config()` — the **injection
+//!   path**. Reads no environment variable and loads no `.env` file, for an
+//!   embedding application that owns its configuration source (its own
+//!   namespaced variables, a config file, a secrets manager). Useful under
+//!   `#![forbid(unsafe_code)]`, where pre-populating `IG_*` is not an option
+//!   because `std::env::set_var` is `unsafe` on edition 2024.
+//!
+//! ```rust,no_run
+//! use ig_client::prelude::*;
+//!
+//! // Fail fast on a missing variable: an empty credential would only surface
+//! // later as a confusing authentication failure. Never log the value.
+//! fn required_var(name: &str) -> Result<String, AppError> {
+//!     std::env::var(name).map_err(|_| AppError::InvalidInput(format!("{name} is not set")))
+//! }
+//!
+//! # fn main() -> Result<(), AppError> {
+//! let credentials = Credentials::new(
+//!     required_var("MYAPP_IG_USERNAME")?,
+//!     required_var("MYAPP_IG_PASSWORD")?,
+//!     required_var("MYAPP_IG_ACCOUNT_ID")?,
+//!     required_var("MYAPP_IG_API_KEY")?,
+//! );
+//!
+//! // Struct update overrides individual sections and stays env-free,
+//! // because the base value is the env-free constructor.
+//! let config = Config {
+//!     rest_api: RestApiConfig {
+//!         base_url: "https://demo-api.ig.com/gateway/deal".to_string(),
+//!         timeout: 30,
+//!     },
+//!     ..Config::from_credentials(credentials)
+//! };
+//!
+//! let client = Client::with_config(config)?;
+//! println!("REST base URL: {}", client.config().rest_api.base_url);
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! Non-credential fields default to the IG **demo** endpoints; see
+//! `examples/simples/src/bin/client_with_config.rs` for a runnable version.
+//!
+//! For streaming, build the streamer from the injected client with
+//! `StreamerClient::with_client(&client)` — `StreamerClient::new()` goes
+//! through `Client::try_new()` and therefore back to `.env` / `IG_*`.
+//!
+//! Two knobs are still resolved from the process environment on the injected
+//! path, because they are not part of `Config`:
+//!
+//! - Retry policy — `MAX_RETRY_COUNT` and `RETRY_DELAY_SECS` are read per
+//!   request via `RetryConfig::default()`; unset means the crate defaults.
+//! - `IG_PRICING_ADAPTER` — the Lightstreamer price adapter name, defaulting
+//!   to `Pricing` when unset.
+//!
+//! Neither carries a credential, and both have safe defaults, so an embedder
+//! that sets neither variable is unaffected. Moving them into `Config` is a
+//! breaking change scheduled for a future minor release.
 //!
 //! ## Usage
 //!

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -44,7 +44,7 @@ pub use crate::application::auth::{Auth, Session};
 
 // Configuration
 pub use crate::application::config::{
-    Config, Credentials, RateLimiterConfig, RestApiConfig, WebSocketConfig,
+    Config, Credentials, DatabaseConfig, RateLimiterConfig, RestApiConfig, WebSocketConfig,
 };
 
 // Rate limiter

--- a/tests/unit/application/test_client.rs
+++ b/tests/unit/application/test_client.rs
@@ -1,4 +1,5 @@
 use ig_client::application::client::Client;
+use ig_client::application::config::{Config, Credentials, RestApiConfig};
 use ig_client::application::interfaces::market::MarketService;
 use ig_client::error::AppError;
 
@@ -31,8 +32,51 @@ async fn get_multiple_market_details_more_than_50_returns_error() {
 
 #[test]
 fn client_try_new_succeeds() {
-    // `try_new` is the sole constructor and must not panic; it returns the
-    // built client on a healthy TLS backend.
+    // `try_new` is the environment convenience constructor and must not panic;
+    // it returns the built client on a healthy TLS backend.
     let result = Client::try_new();
     assert!(result.is_ok(), "client try_new should succeed");
+}
+
+#[test]
+fn test_client_with_config_uses_injected_base_url() {
+    // The injected values differ from the crate defaults and from anything the
+    // `IG_*` namespace or a `.env` file could plausibly hold, so seeing them on
+    // the built client proves the config came from the caller, not the
+    // environment. No env var is mutated: `set_var` is `unsafe` on edition 2024
+    // and racy under the parallel test harness.
+    let credentials = Credentials::new(
+        "embedder-user".to_string(),
+        "embedder-password".to_string(),
+        "EMBEDDER-ACC".to_string(),
+        "embedder-api-key".to_string(),
+    );
+    let config = Config {
+        rest_api: RestApiConfig {
+            base_url: "https://injected.example.invalid/gateway/deal".to_string(),
+            timeout: 11,
+        },
+        ..Config::from_credentials(credentials)
+    };
+
+    let client = Client::with_config(config).expect("client with_config should succeed");
+
+    assert_eq!(
+        client.config().rest_api.base_url,
+        "https://injected.example.invalid/gateway/deal"
+    );
+    assert_eq!(client.config().rest_api.timeout, 11);
+    assert_eq!(client.config().credentials.username, "embedder-user");
+    assert_eq!(client.config().credentials.account_id, "EMBEDDER-ACC");
+}
+
+#[test]
+fn test_client_try_new_still_uses_environment_config() {
+    // Back-compat: `try_new` keeps reading the environment / `.env` path and is
+    // unaffected by the new injection constructor.
+    let client = Client::try_new().expect("client try_new should succeed");
+    assert_eq!(
+        client.config().rest_api.base_url,
+        Config::new().rest_api.base_url
+    );
 }


### PR DESCRIPTION
## Summary

Closes #81.

`Client::try_new()` was the only constructor and hardcoded its configuration
source: `Config::default()` → `Config::new()` calls `dotenv()` and reads the
global `IG_*` namespace. An embedding application that owns its own
configuration — namespaced env vars, no `.env` loading, `#![forbid(unsafe_code)]`
on edition 2024 where `std::env::set_var` is `unsafe` — had no supported way to
build a `Client`.

This adds the injection path. `try_new()` is unchanged and remains the `.env` /
`IG_*` convenience path.

## Public API (additive only)

| Item | Purpose |
|---|---|
| `Client::with_config(Config) -> Result<Self, AppError>` | Build a client from a caller-supplied config; no `dotenv()`, no `IG_*` |
| `Client::config() -> &Config` / `HttpClient::config() -> &Config` | Effective configuration (used to verify which environment the client points at) |
| `Config::from_credentials(Credentials) -> Config` | Env-free config constructor |
| `Credentials::new(username, password, account_id, api_key)` | Credentials without caring about session tokens |
| `Default` for `RestApiConfig` / `WebSocketConfig` / `RateLimiterConfig` / `DatabaseConfig` | Env-free section defaults |
| `DEFAULT_REST_BASE_URL`, `DEFAULT_REST_TIMEOUT_SECS`, `DEFAULT_WS_URL`, `DEFAULT_WS_RECONNECT_INTERVAL_SECS`, `DEFAULT_CONFIG_RATE_LIMIT_*`, `DEFAULT_DATABASE_MAX_CONNECTIONS`, `DEFAULT_API_VERSION` | The defaults, named |

`DatabaseConfig` was added to the prelude so the documented struct-update
override works for every section. Nothing removed, no signature changed, no
field added to a public struct — `cargo-semver-checks` sees no break, hence the
patch bump to 0.12.2.

## Notable decisions

- **The two paths cannot drift.** The new `Default` impls hold the literals and
  `Config::new()` now uses them as its `get_env_or_default` fallbacks.
  `Config::new()`'s behaviour is otherwise byte-for-byte unchanged (same values,
  same inferred types, same `dotenv()` call and the same four `error!` warnings).
- **Honest scope of "env-free".** Two knobs live outside `Config` and are still
  resolved from the process environment on the injected path: the retry policy
  (`MAX_RETRY_COUNT` / `RETRY_DELAY_SECS`, read per request by
  `RetryConfig::default()`) and `IG_PRICING_ADAPTER` in the streaming price path.
  Neither carries a credential and both have safe defaults, so an embedder that
  sets neither is unaffected. This is documented rather than fixed here: moving
  them into `Config` adds public fields, which is breaking for struct-literal
  construction and belongs in 0.13.0.
- **Streaming needs no change** — `StreamerClient::with_client(&client)` already
  reuses an injected client's session. The docs point at it, since
  `StreamerClient::new()` would go back through `try_new()`.
- **`config()` and secrets.** `Config`'s `Debug`/`Display` redact credentials and
  the DB URL, but its `Serialize` impl does not; both accessors' docs say so
  explicitly.

## Tests

`507 passed; 0 failed` (270 lib + 226 `tests/unit` + 11 doctests; 16 live tests
ignored as designed).

New: 4 unit tests in `config.rs` (env-free construction, struct-update override,
section defaults match the constants) and 2 in
`tests/unit/application/test_client.rs` (injected `base_url`/timeout/credentials
survive; `try_new` still follows the environment). No test mutates the
environment — `set_var` is `unsafe` on edition 2024 and racy under the parallel
harness — so the injected values are chosen so they cannot coincide with
anything the environment holds.

Runnable demo: `examples/simples/src/bin/client_with_config.rs`, reading an
embedder-owned `MYAPP_IG_*` namespace and failing fast on a missing variable.

## Review notes

`secrets-auditor`: leak free, no P1. Its P2 (doc snippets used
`unwrap_or_default()`, turning a missing password into an empty credential) is
fixed — the snippets now fail fast like the runnable example.

`architect`: fixed in this PR — the runtime-env caveat above, the `Serialize`
footgun wording, `DatabaseConfig` in the prelude, a doc comment on
`impl Default for Config` warning that it does load `.env`, the `api_version`
field doc (it claimed auto-detect; login actually falls back to v2), `#[inline]`
on the accessors, demo instead of live gateway URLs in examples/tests, and
`doc/RATE_LIMITER.md`, whose published defaults (60/60/10) contradicted the real
ones (4/12/3). Left as follow-ups: the stale `doc/NEW_CLIENT_API.md` /
`INTEGRATION_GUIDE.md` / `AUTHENTICATION.md` (pre-existing rot), threading
`RetryConfig` into `Config`, and the `DEFAULT_RATE_LIMIT_*` constant renames —
all breaking or out of scope for one issue.

## Checks

`make pre-push` clean: clippy `-D warnings` across all targets and features,
`cargo fmt --check`, full test suite, `README.md` regenerated via `cargo readme`,
`cargo clippy -W missing-docs`. `cargo package` succeeds.