### PR TITLE
feat: gate the streaming and persistence stacks behind Cargo features

### DIFF
--- a/.github/workflows/features.yml
+++ b/.github/workflows/features.yml
@@ -1,0 +1,94 @@
+name: Features
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+    branches:
+      - main
+      - 'release/**'
+
+# Cancel any in-flight jobs for the same PR/branch so there's only one active
+# at a time
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  features:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        features:
+          - "--no-default-features"
+          - "--no-default-features --features persistence"
+          - "--no-default-features --features streaming"
+          - "--all-features"
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y make libfontconfig1-dev pkg-config build-essential
+
+      - name: Build (${{ matrix.features }})
+        run: cargo build -p ig-client ${{ matrix.features }}
+
+      - name: Clippy (${{ matrix.features }})
+        run: cargo clippy -p ig-client --all-targets ${{ matrix.features }} -- -D warnings
+
+      - name: Test (${{ matrix.features }})
+        run: cargo test -p ig-client ${{ matrix.features }}
+
+      # Intra-doc links can point at items that only exist under some feature
+      # combination; rustdoc only reports that in the combination that lacks them.
+      - name: Doc (${{ matrix.features }})
+        run: cargo doc -p ig-client --no-deps ${{ matrix.features }}
+        env:
+          RUSTDOCFLAGS: -D warnings
+
+  dependency-graph:
+    name: no-default-features dependency graph is clean
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y make libfontconfig1-dev pkg-config build-essential
+
+      - name: Assert each optional dependency appears only with its feature
+        run: |
+          FAILED=0
+          check() {
+            FEATURES="$1"; CRATE="$2"; EXPECTED="$3"
+            TREE="$(cargo tree -p ig-client $FEATURES -e normal)" || exit 1
+            if echo "$TREE" | grep -q "$CRATE"; then FOUND=present; else FOUND=absent; fi
+            if [ "$FOUND" != "$EXPECTED" ]; then
+              echo "::error::$CRATE is $FOUND in the '$FEATURES' dependency graph, expected $EXPECTED"
+              FAILED=1
+            else
+              echo "ok: $CRATE $FOUND with '$FEATURES'"
+            fi
+          }
+          # lightstreamer-rs is GPL-3.0-only: it must appear only with `streaming`.
+          check "--no-default-features" lightstreamer-rs absent
+          check "--no-default-features --features persistence" lightstreamer-rs absent
+          check "--no-default-features --features streaming" lightstreamer-rs present
+          check "--no-default-features" sqlx absent
+          check "--no-default-features --features streaming" sqlx absent
+          check "--no-default-features --features persistence" sqlx present
+          exit $FAILED

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ig-client"
-version = "0.12.2"
+version = "0.12.3"
 edition = "2024"
 authors = ["Joaquin Bejar <jb@taunais.com>"]
 description = "This crate provides a client for the IG Markets API"
@@ -25,6 +25,20 @@ include = [
     "Docker/**/*",
 ]
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
+[features]
+# Both heavy legs are on by default, so existing users are unaffected.
+default = ["persistence", "streaming"]
+# PostgreSQL persistence (`ig_client::storage`) via sqlx.
+persistence = ["dep:sqlx"]
+# Real-time Lightstreamer streaming (`StreamerClient`, `DynamicMarketStreamer`).
+# `lightstreamer-rs` is GPL-3.0-only, so a permissively-licensed consumer that
+# only needs the REST path can turn this off and keep it out of its graph.
+streaming = ["dep:lightstreamer-rs"]
+
 [dependencies]
 tokio = { workspace = true}
 chrono = { workspace = true}
@@ -33,11 +47,11 @@ tracing-subscriber = { workspace = true}
 serde = { workspace = true}
 serde_json = { workspace = true}
 reqwest ={ workspace = true}
-sqlx = { workspace = true}
+sqlx = { workspace = true, optional = true }
 async-trait = { workspace = true}
 regex = { workspace = true}
 dotenv = { workspace = true}
-lightstreamer-rs = { workspace = true}
+lightstreamer-rs = { workspace = true, optional = true }
 lazy_static = { workspace = true}
 nanoid = { workspace = true}
 pretty-simple-display = { workspace = true}
@@ -86,7 +100,7 @@ members = [
 
 [workspace.dependencies]
 ig-client=  { path = "." }
-tokio = { version = "1.52", features = ["rt", "rt-multi-thread", "macros", "time", "signal"] }
+tokio = { version = "1.52", features = ["rt", "rt-multi-thread", "macros", "sync", "time", "signal"] }
 chrono = { version = "0.4", features = ["serde"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,44 @@ fix:
 	cargo fix --allow-staged --allow-dirty
 
 .PHONY: pre-push
-pre-push: fix fmt lint-fix test readme doc
+pre-push: fix fmt lint-fix test readme doc check-features
+
+# Build, lint and test every supported feature combination for the `ig-client`
+# package (scoped with -p so the workspace example crates, which depend on
+# default features, are not dragged into --no-default-features builds), then
+# assert that lightstreamer-rs (GPL-3.0-only) and sqlx stay out of the
+# --no-default-features dependency graph.
+.PHONY: check-features
+check-features:
+	@for features in "--no-default-features" "--no-default-features --features persistence" "--no-default-features --features streaming" "--all-features"; do \
+		echo "==> cargo build -p ig-client $$features"; \
+		cargo build -p ig-client $$features || exit 1; \
+		echo "==> cargo clippy -p ig-client --all-targets $$features -- -D warnings"; \
+		cargo clippy -p ig-client --all-targets $$features -- -D warnings || exit 1; \
+		echo "==> cargo test -p ig-client $$features"; \
+		cargo test -p ig-client $$features || exit 1; \
+		echo "==> cargo doc -p ig-client --no-deps $$features"; \
+		RUSTDOCFLAGS="-D warnings" cargo doc -p ig-client --no-deps $$features || exit 1; \
+	done
+	@echo "==> dependency-graph assertions"
+	@FAILED=0; \
+	check() { \
+		TREE="$$(cargo tree -p ig-client $$1 -e normal)" || exit 1; \
+		if echo "$$TREE" | grep -q "$$2"; then FOUND=present; else FOUND=absent; fi; \
+		if [ "$$FOUND" != "$$3" ]; then \
+			echo "$$2 is $$FOUND in the '$$1' dependency graph, expected $$3"; \
+			FAILED=1; \
+		else \
+			echo "ok: $$2 $$FOUND with '$$1'"; \
+		fi; \
+	}; \
+	check "--no-default-features" lightstreamer-rs absent; \
+	check "--no-default-features --features persistence" lightstreamer-rs absent; \
+	check "--no-default-features --features streaming" lightstreamer-rs present; \
+	check "--no-default-features" sqlx absent; \
+	check "--no-default-features --features streaming" sqlx absent; \
+	check "--no-default-features --features persistence" sqlx present; \
+	exit $$FAILED
 
 .PHONY: doc
 doc:

--- a/README.md
+++ b/README.md
@@ -39,15 +39,17 @@ idiomatic Rust API.
 - **Client Sentiment**: Sentiment for single, multiple, and related markets.
 - **Indicative Costs**: Costs and charges for opening, closing, or editing
   positions, plus cost history.
-- **Real-time Streaming**: Market, price, trade, and account updates over
-  Lightstreamer, with thread-safe dynamic subscription management.
+- **Real-time Streaming** (feature `streaming`, on by default): Market,
+  price, trade, and account updates over Lightstreamer, with thread-safe
+  dynamic subscription management.
 - **Rate Limiting**: `governor`-backed pacing configured per IG's trading vs
   non-trading budgets.
 - **Finite Retry**: Exponential backoff with jitter via `RetryConfig`
   (bounded — no unbounded retry loops).
 - **Type Safety**: Strongly typed request / response DTOs and domain enums.
 - **Async**: Built on `tokio` with a shared, pooled `reqwest` client.
-- **Persistence (optional)**: PostgreSQL storage via `sqlx`.
+- **Persistence** (feature `persistence`, on by default): PostgreSQL storage
+  via `sqlx`.
 
 ### Installation
 
@@ -55,7 +57,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-ig-client = "0.12.2"
+ig-client = "0.12.3"
 tokio = { version = "1", features = ["full"] }  # Async runtime
 tracing = "0.1"                                  # Logging facade
 # Optional, only if you use the PostgreSQL persistence layer:
@@ -67,6 +69,45 @@ You do not need to add `dotenv` yourself — `Config::new()` loads a local
 and must not read a `.env` file or the `IG_*` namespace, use
 `Config::from_credentials()` with `Client::with_config()` instead (see
 [Programmatic configuration](#programmatic-configuration-embedders)).
+
+#### Cargo features
+
+| Feature | Default | Pulls in | Gives you |
+|---|---|---|---|
+| `streaming` | on | `lightstreamer-rs` | `StreamerClient`, `DynamicMarketStreamer`, the `ItemUpdate` adapters, `application::interfaces::listener` |
+| `persistence` | on | `sqlx` | the `storage` module: `MarketDatabaseService`, historical prices, connection pooling |
+
+Both are on by default, so the crate behaves exactly as before unless you
+opt out. Turn them off for a REST/poll-only client:
+
+```toml
+[dependencies]
+ig-client = { version = "0.12.3", default-features = false }
+```
+
+That leaves `Client`, `Client::with_config`, every REST service trait
+(`MarketService`, `AccountService`, `OrderService`, …), the DTOs and the
+rate limiter fully available, with neither `lightstreamer-rs` nor `sqlx` in
+the dependency graph. Two reasons to care:
+
+- **License**: `lightstreamer-rs` is **GPL-3.0-only**. A permissively
+  licensed (MIT / Apache-2.0) consumer with a copyleft-rejecting
+  `cargo deny` policy cannot take it, and with `streaming` off it never
+  enters the graph.
+- **Build weight**: `sqlx` brings a full PostgreSQL driver that a
+  market-data-only integration never uses.
+
+Turning `streaming` off removes the streaming client types; the
+`Streaming*Field` selectors and the presentation DTOs are plain data types
+and stay available either way. Turning `persistence` off removes everything
+under `storage` except `storage::config` (a re-export of the sqlx-free
+`application::config::DatabaseConfig`), along with the `AppError::Db`
+variant.
+
+One side effect worth knowing: `sqlx` enables `tracing`'s `log` feature, so
+with `persistence` on this crate's events are also emitted as `log` records.
+With it off they are tracing events only, which matters if your application
+collects logs through the `log` facade.
 
 #### Requirements
 
@@ -150,9 +191,9 @@ println!("REST base URL: {}", client.config().rest_api.base_url);
 Non-credential fields default to the IG **demo** endpoints; see
 `examples/simples/src/bin/client_with_config.rs` for a runnable version.
 
-For streaming, build the streamer from the injected client with
-`StreamerClient::with_client(&client)` — `StreamerClient::new()` goes
-through `Client::try_new()` and therefore back to `.env` / `IG_*`.
+For streaming (feature `streaming`), build the streamer from the injected
+client with `StreamerClient::with_client(&client)` — `StreamerClient::new()`
+goes through `Client::try_new()` and therefore back to `.env` / `IG_*`.
 
 Two knobs are still resolved from the process environment on the injected
 path, because they are not part of `Config`:
@@ -249,6 +290,8 @@ async fn main() -> Result<(), AppError> {
 ```
 
 #### Real-time streaming
+
+*Requires the default `streaming` feature.*
 
 `DynamicMarketStreamer` wraps the lower-level `StreamerClient` and manages
 subscriptions in a thread-safe way. Its constructor is **synchronous** — it
@@ -359,8 +402,8 @@ The crate is organized as a module-oriented library under `src/`:
   DTOs, and the retry policy. Serde only; no I/O.
 - **`presentation`** — domain entities per area: account, chart, instrument,
   market, order, price, trade, transaction. Serde only; no I/O.
-- **`storage`** — optional PostgreSQL persistence via `sqlx` (sits on top of
-  `model` / `presentation`).
+- **`storage`** — PostgreSQL persistence via `sqlx`, behind the
+  `persistence` feature (sits on top of `model` / `presentation`).
 - **`utils`** — leaf helpers: env-var config, logging, finance (P&L), parsing,
   deal-reference id generation.
 - **`error`** — canonical typed error enums: `AppError`, `AuthError`, and
@@ -390,7 +433,7 @@ src/
 │   └── dynamic_streamer.rs  # DynamicMarketStreamer (subscriptions)
 ├── model/             # Pure DTOs: requests, responses, streaming, retry
 ├── presentation/      # Domain entities (account, market, order, price, …)
-├── storage/           # Optional PostgreSQL persistence via sqlx
+├── storage/           # PostgreSQL persistence via sqlx (feature `persistence`)
 ├── utils/             # config, logger, finance, parsing, id helpers
 ├── constants.rs       # Endpoint paths, header names, defaults
 ├── error.rs           # AppError / AuthError / FetchError
@@ -427,6 +470,31 @@ Contributions are welcome:
 
 Please make sure your code passes all tests and linting checks before
 submitting a pull request.
+
+## What's New in 0.12.3
+
+- The crate now has Cargo **features**, both on by default so existing users are
+  unaffected ([#83](https://github.com/joaquinbejar/ig-client/issues/83)):
+  - `streaming` — the Lightstreamer leg (`StreamerClient`,
+    `DynamicMarketStreamer`, `Listener`, the `ItemUpdate` adapters), pulling in
+    `lightstreamer-rs`.
+  - `persistence` — the `storage` module, pulling in `sqlx`.
+- `ig-client = { version = "0.12.3", default-features = false }` gives a
+  REST/poll-only client with **neither** crate in the dependency graph. This
+  matters for licensing: `lightstreamer-rs` is GPL-3.0-only, so a permissively
+  licensed consumer with a copyleft-rejecting `cargo deny` policy previously
+  could not depend on `ig-client` at all.
+- Fixed two latent dependencies on features that only arrived transitively:
+  - Two modules imported `tracing::log::debug`, which resolved only because
+    `sqlx` enabled `tracing`'s `log` feature. These are now native `tracing`
+    events. **Behaviour change:** `tracing::log::debug` emitted a `log` record,
+    and `setup_logger` installs no `log` bridge, so those two `.env`-loading
+    messages were previously discarded — they now appear at DEBUG. Relatedly,
+    the streaming listener's per-tick payload line moved from DEBUG to TRACE:
+    it fires on every tick and renders account payloads (P&L, equity, margin).
+  - `tokio`'s `sync` feature is now declared explicitly. The crate uses
+    `tokio::sync` on the REST path but was receiving the feature only through
+    `reqwest`'s own dependencies.
 
 ## What's New in 0.12.2
 

--- a/README.tpl
+++ b/README.tpl
@@ -12,6 +12,31 @@
 
 {{readme}}
 
+## What's New in 0.12.3
+
+- The crate now has Cargo **features**, both on by default so existing users are
+  unaffected ([#83](https://github.com/joaquinbejar/ig-client/issues/83)):
+  - `streaming` — the Lightstreamer leg (`StreamerClient`,
+    `DynamicMarketStreamer`, `Listener`, the `ItemUpdate` adapters), pulling in
+    `lightstreamer-rs`.
+  - `persistence` — the `storage` module, pulling in `sqlx`.
+- `ig-client = { version = "0.12.3", default-features = false }` gives a
+  REST/poll-only client with **neither** crate in the dependency graph. This
+  matters for licensing: `lightstreamer-rs` is GPL-3.0-only, so a permissively
+  licensed consumer with a copyleft-rejecting `cargo deny` policy previously
+  could not depend on `ig-client` at all.
+- Fixed two latent dependencies on features that only arrived transitively:
+  - Two modules imported `tracing::log::debug`, which resolved only because
+    `sqlx` enabled `tracing`'s `log` feature. These are now native `tracing`
+    events. **Behaviour change:** `tracing::log::debug` emitted a `log` record,
+    and `setup_logger` installs no `log` bridge, so those two `.env`-loading
+    messages were previously discarded — they now appear at DEBUG. Relatedly,
+    the streaming listener's per-tick payload line moved from DEBUG to TRACE:
+    it fires on every tick and renders account payloads (P&L, equity, margin).
+  - `tokio`'s `sync` feature is now declared explicitly. The crate uses
+    `tokio::sync` on the REST path but was receiving the feature only through
+    `reqwest`'s own dependencies.
+
 ## What's New in 0.12.2
 
 - `Client::with_config(config)` builds a client from a caller-supplied

--- a/doc/INTEGRATION_GUIDE.md
+++ b/doc/INTEGRATION_GUIDE.md
@@ -11,6 +11,11 @@ ERROR: Response body: {"errorCode":"error.security.oauth-token-invalid"}
 
 This means your OAuth access token has expired and needs to be refreshed. This guide explains how to integrate automatic token refresh into your existing application.
 
+> **Cargo features**: token refresh is part of the REST/session path and works
+> with `default-features = false`. The default-ON `streaming` and `persistence`
+> features only add the Lightstreamer client and the `storage` module
+> respectively.
+
 ## Understanding the Issue
 
 OAuth tokens (API v3) expire after a certain period. When a token expires:

--- a/doc/NEW_CLIENT_API.md
+++ b/doc/NEW_CLIENT_API.md
@@ -10,6 +10,22 @@ The new `Client` API provides a dramatically simplified interface for using the 
 - ✅ Transparent error handling and retry logic
 - ✅ Simple, clean API for making requests
 
+## Cargo features
+
+Everything documented here — `Client`, `Client::with_config` and the REST
+service traits — is available with **no features enabled**. Two default-ON
+features gate the heavy legs:
+
+- `streaming` (pulls `lightstreamer-rs`, GPL-3.0-only) — `StreamerClient`,
+  `DynamicMarketStreamer`, `Listener`.
+- `persistence` (pulls `sqlx`) — the `storage` module.
+
+For a REST/poll-only client with neither crate in the dependency graph:
+
+```toml
+ig-client = { version = "0.12.3", default-features = false }
+```
+
 ## Quick Start
 
 ### Basic Usage

--- a/src/application/client.rs
+++ b/src/application/client.rs
@@ -38,32 +38,45 @@ use crate::model::responses::{
     ClosePositionResponse, CreateOrderResponse, CreateWorkingOrderResponse, UpdatePositionResponse,
 };
 use crate::model::retry::backoff_delay;
+#[cfg(feature = "streaming")]
 use crate::model::streaming::{
     StreamingAccountDataField, StreamingChartField, StreamingMarketField, StreamingPriceField,
     get_streaming_account_data_fields, get_streaming_chart_fields, get_streaming_market_fields,
     get_streaming_price_fields,
 };
+#[cfg(feature = "streaming")]
 use crate::presentation::account::AccountFields;
+#[cfg(feature = "streaming")]
 use crate::presentation::chart::{ChartData, ChartScale};
 use crate::presentation::market::{MarketData, MarketDetails};
+#[cfg(feature = "streaming")]
 use crate::presentation::price::PriceData;
+#[cfg(feature = "streaming")]
 use crate::presentation::trade::TradeFields;
 use async_trait::async_trait;
 use futures::StreamExt;
+#[cfg(feature = "streaming")]
 use lightstreamer_rs::client::{LightstreamerClient, LogType, Transport};
+#[cfg(feature = "streaming")]
 use lightstreamer_rs::subscription::{
     ChannelSubscriptionListener, Snapshot, Subscription, SubscriptionMode,
 };
+#[cfg(feature = "streaming")]
 use lightstreamer_rs::utils::{LightstreamerError, setup_signal_hook};
 use reqwest::StatusCode;
 use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Duration;
+#[cfg(feature = "streaming")]
 use tokio::sync::{Mutex, Notify, mpsc};
+#[cfg(feature = "streaming")]
 use tokio::task::JoinHandle;
 use tokio::time::sleep;
-use tracing::{debug, error, info, warn};
+#[cfg(feature = "streaming")]
+use tracing::error;
+use tracing::{debug, info, warn};
 
+#[cfg(feature = "streaming")]
 const MAX_CONNECTION_ATTEMPTS: u64 = 3;
 
 /// Maximum number of concurrent `get_market_details` requests issued while
@@ -79,6 +92,7 @@ const MARKET_DETAILS_CONCURRENCY: usize = 6;
 /// This is not a dedicated error discriminant: `lightstreamer-rs` surfaces it
 /// as free-form text embedded in a server error payload, so it can only be
 /// matched best-effort (see [`is_graceful_close`]).
+#[cfg(feature = "streaming")]
 const GRACEFUL_CLOSE_MARKER: &str = "No more requests to fulfill";
 
 /// Returns `true` if `error` represents a graceful, server-initiated close
@@ -92,6 +106,7 @@ const GRACEFUL_CLOSE_MARKER: &str = "No more requests to fulfill";
 /// classify the typed error on the variants that can carry a server-supplied
 /// reason and match [`GRACEFUL_CLOSE_MARKER`] against the variant's message
 /// payload directly — never against the `Debug` representation.
+#[cfg(feature = "streaming")]
 #[must_use]
 #[inline]
 fn is_graceful_close(error: &LightstreamerError) -> bool {
@@ -118,6 +133,7 @@ fn is_graceful_close(error: &LightstreamerError) -> bool {
 ///
 /// The returned [`JoinHandle`] must be aborted once all connections have
 /// finished so the forwarder does not outlive them.
+#[cfg(feature = "streaming")]
 #[must_use]
 fn spawn_shutdown_fanout(source: Arc<Notify>, targets: Vec<Arc<Notify>>) -> JoinHandle<()> {
     tokio::spawn(async move {
@@ -134,6 +150,7 @@ fn spawn_shutdown_fanout(source: Arc<Notify>, targets: Vec<Arc<Notify>>) -> Join
 /// Awaiting after `abort` guarantees each task has fully stopped before we
 /// return; the [`tokio::task::JoinError`] produced by cancellation is expected
 /// and ignored.
+#[cfg(feature = "streaming")]
 async fn abort_and_drain_tasks(tasks: &mut Vec<JoinHandle<()>>) {
     for handle in tasks.drain(..) {
         handle.abort();
@@ -223,8 +240,8 @@ impl Client {
     /// sets neither is unaffected.
     ///
     /// For streaming, pair this with
-    /// [`StreamerClient::with_client`](crate::application::client::StreamerClient::with_client):
-    /// [`StreamerClient::new`](crate::application::client::StreamerClient::new)
+    /// `StreamerClient::with_client`:
+    /// `StreamerClient::new`
     /// builds its own client via [`try_new`](Self::try_new) and would go back
     /// to the `.env` / `IG_*` path.
     ///
@@ -1324,6 +1341,8 @@ impl OperationsService for Client {
 ///   Uses the "Pricing" adapter.
 ///
 /// Each connection type can be managed independently and runs in parallel.
+#[cfg(feature = "streaming")]
+#[cfg_attr(docsrs, doc(cfg(feature = "streaming")))]
 pub struct StreamerClient {
     account_id: String,
     market_streamer_client: Option<Arc<Mutex<LightstreamerClient>>>,
@@ -1339,6 +1358,7 @@ pub struct StreamerClient {
     converter_tasks: Vec<JoinHandle<()>>,
 }
 
+#[cfg(feature = "streaming")]
 impl StreamerClient {
     /// Creates a new streaming client instance with its own REST session.
     ///
@@ -2093,6 +2113,7 @@ impl StreamerClient {
     }
 }
 
+#[cfg(feature = "streaming")]
 impl Drop for StreamerClient {
     /// Aborts any converter tasks that were not already torn down by
     /// [`StreamerClient::disconnect`], so dropping the client never orphans a
@@ -2156,7 +2177,13 @@ mod tests {
             StatusCode::BAD_REQUEST
         )));
     }
+}
 
+// The streaming helpers these tests exercise only exist with the `streaming`
+// feature, so they live in their own gated module rather than behind per-test
+// attributes.
+#[cfg(all(test, feature = "streaming"))]
+mod streaming_tests {
     use super::{
         GRACEFUL_CLOSE_MARKER, abort_and_drain_tasks, is_graceful_close, spawn_shutdown_fanout,
     };

--- a/src/application/config.rs
+++ b/src/application/config.rs
@@ -10,8 +10,7 @@ use dotenv::dotenv;
 use pretty_simple_display::{DebugPretty, DisplaySimple};
 use serde::{Deserialize, Serialize};
 use std::env;
-use tracing::error;
-use tracing::log::debug;
+use tracing::{debug, error};
 
 /// Configuration for database connections
 ///

--- a/src/application/interfaces/listener.rs
+++ b/src/application/interfaces/listener.rs
@@ -8,8 +8,7 @@ use crate::error::AppError;
 use lightstreamer_rs::subscription::{ItemUpdate, SubscriptionListener};
 use std::fmt::{Debug, Display};
 use std::sync::Arc;
-use tracing::log::debug;
-use tracing::{error, info};
+use tracing::{error, info, trace};
 
 /// Result type for listener operations that don't return a value but may return an error
 pub type ListenerResult = Result<(), AppError>;
@@ -78,8 +77,10 @@ where
         let data: T = T::from(update);
 
         match self.callback(&data) {
-            Ok(_) => debug!("{data}"),
-            Err(e) => error!("Error in trade data callback: {}", e),
+            // TRACE, not DEBUG: this fires on every streaming tick and renders
+            // the whole payload (account updates carry P&L, equity and margin).
+            Ok(_) => trace!(update = %data, "streaming item update"),
+            Err(e) => error!(error = %e, "streaming callback failed"),
         }
     }
 

--- a/src/application/interfaces/mod.rs
+++ b/src/application/interfaces/mod.rs
@@ -3,6 +3,8 @@ pub mod account;
 /// Indicative costs and charges service interface
 pub mod costs;
 /// Listener interface for streaming data
+#[cfg(feature = "streaming")]
+#[cfg_attr(docsrs, doc(cfg(feature = "streaming")))]
 pub mod listener;
 /// Market service interface
 pub mod market;

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -5,6 +5,8 @@ pub mod client;
 /// Application configuration module
 pub mod config;
 /// Dynamic market streamer with thread-safe subscription management
+#[cfg(feature = "streaming")]
+#[cfg_attr(docsrs, doc(cfg(feature = "streaming")))]
 pub mod dynamic_streamer;
 /// HTTP client and request execution with rate limiting and finite retry
 pub mod http;
@@ -15,4 +17,6 @@ pub mod market_hierarchy;
 /// Rate limiter module for API request throttling
 pub mod rate_limiter;
 /// Adapters from Lightstreamer `ItemUpdate` to presentation-layer DTOs
+#[cfg(feature = "streaming")]
+#[cfg_attr(docsrs, doc(cfg(feature = "streaming")))]
 pub mod streaming_convert;

--- a/src/error.rs
+++ b/src/error.rs
@@ -11,7 +11,7 @@ use std::io;
 /// # Deprecated
 /// This enum is dead: no library code constructs or returns it. Every fetch,
 /// network, database, and parse failure surfaces through [`AppError`] instead
-/// ([`AppError::Network`], [`AppError::Db`], [`AppError::Deserialization`]).
+/// ([`AppError::Network`], `AppError::Db`, [`AppError::Deserialization`]).
 /// It is kept only for backward compatibility and will be removed in a future
 /// release — migrate to [`AppError`].
 #[deprecated(
@@ -24,6 +24,7 @@ pub enum FetchError {
     #[error("network error: {0}")]
     Reqwest(#[from] reqwest::Error),
     /// Database error from sqlx
+    #[cfg(feature = "persistence")]
     #[error("db error: {0}")]
     Sqlx(#[from] sqlx::Error),
     /// Error during parsing
@@ -128,6 +129,7 @@ pub enum AppError {
     #[error("unexpected http status: {0}")]
     Unexpected(StatusCode),
     /// Database error from sqlx
+    #[cfg(feature = "persistence")]
     #[error("db error: {0}")]
     Db(#[from] sqlx::Error),
     /// Unauthorized access error
@@ -201,6 +203,7 @@ impl From<String> for AppError {
     }
 }
 
+#[cfg(feature = "streaming")]
 impl From<lightstreamer_rs::utils::LightstreamerError> for AppError {
     #[cold]
     fn from(e: lightstreamer_rs::utils::LightstreamerError) -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,15 +27,17 @@
 //! - **Client Sentiment**: Sentiment for single, multiple, and related markets.
 //! - **Indicative Costs**: Costs and charges for opening, closing, or editing
 //!   positions, plus cost history.
-//! - **Real-time Streaming**: Market, price, trade, and account updates over
-//!   Lightstreamer, with thread-safe dynamic subscription management.
+//! - **Real-time Streaming** (feature `streaming`, on by default): Market,
+//!   price, trade, and account updates over Lightstreamer, with thread-safe
+//!   dynamic subscription management.
 //! - **Rate Limiting**: `governor`-backed pacing configured per IG's trading vs
 //!   non-trading budgets.
 //! - **Finite Retry**: Exponential backoff with jitter via `RetryConfig`
 //!   (bounded — no unbounded retry loops).
 //! - **Type Safety**: Strongly typed request / response DTOs and domain enums.
 //! - **Async**: Built on `tokio` with a shared, pooled `reqwest` client.
-//! - **Persistence (optional)**: PostgreSQL storage via `sqlx`.
+//! - **Persistence** (feature `persistence`, on by default): PostgreSQL storage
+//!   via `sqlx`.
 //!
 //! ## Installation
 //!
@@ -43,7 +45,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! ig-client = "0.12.2"
+//! ig-client = "0.12.3"
 //! tokio = { version = "1", features = ["full"] }  # Async runtime
 //! tracing = "0.1"                                  # Logging facade
 //! # Optional, only if you use the PostgreSQL persistence layer:
@@ -55,6 +57,45 @@
 //! and must not read a `.env` file or the `IG_*` namespace, use
 //! `Config::from_credentials()` with `Client::with_config()` instead (see
 //! [Programmatic configuration](#programmatic-configuration-embedders)).
+//!
+//! ### Cargo features
+//!
+//! | Feature | Default | Pulls in | Gives you |
+//! |---|---|---|---|
+//! | `streaming` | on | `lightstreamer-rs` | `StreamerClient`, `DynamicMarketStreamer`, the `ItemUpdate` adapters, `application::interfaces::listener` |
+//! | `persistence` | on | `sqlx` | the `storage` module: `MarketDatabaseService`, historical prices, connection pooling |
+//!
+//! Both are on by default, so the crate behaves exactly as before unless you
+//! opt out. Turn them off for a REST/poll-only client:
+//!
+//! ```toml
+//! [dependencies]
+//! ig-client = { version = "0.12.3", default-features = false }
+//! ```
+//!
+//! That leaves `Client`, `Client::with_config`, every REST service trait
+//! (`MarketService`, `AccountService`, `OrderService`, …), the DTOs and the
+//! rate limiter fully available, with neither `lightstreamer-rs` nor `sqlx` in
+//! the dependency graph. Two reasons to care:
+//!
+//! - **License**: `lightstreamer-rs` is **GPL-3.0-only**. A permissively
+//!   licensed (MIT / Apache-2.0) consumer with a copyleft-rejecting
+//!   `cargo deny` policy cannot take it, and with `streaming` off it never
+//!   enters the graph.
+//! - **Build weight**: `sqlx` brings a full PostgreSQL driver that a
+//!   market-data-only integration never uses.
+//!
+//! Turning `streaming` off removes the streaming client types; the
+//! `Streaming*Field` selectors and the presentation DTOs are plain data types
+//! and stay available either way. Turning `persistence` off removes everything
+//! under `storage` except `storage::config` (a re-export of the sqlx-free
+//! `application::config::DatabaseConfig`), along with the `AppError::Db`
+//! variant.
+//!
+//! One side effect worth knowing: `sqlx` enables `tracing`'s `log` feature, so
+//! with `persistence` on this crate's events are also emitted as `log` records.
+//! With it off they are tracing events only, which matters if your application
+//! collects logs through the `log` facade.
 //!
 //! ### Requirements
 //!
@@ -141,9 +182,9 @@
 //! Non-credential fields default to the IG **demo** endpoints; see
 //! `examples/simples/src/bin/client_with_config.rs` for a runnable version.
 //!
-//! For streaming, build the streamer from the injected client with
-//! `StreamerClient::with_client(&client)` — `StreamerClient::new()` goes
-//! through `Client::try_new()` and therefore back to `.env` / `IG_*`.
+//! For streaming (feature `streaming`), build the streamer from the injected
+//! client with `StreamerClient::with_client(&client)` — `StreamerClient::new()`
+//! goes through `Client::try_new()` and therefore back to `.env` / `IG_*`.
 //!
 //! Two knobs are still resolved from the process environment on the injected
 //! path, because they are not part of `Config`:
@@ -241,6 +282,8 @@
 //!
 //! ### Real-time streaming
 //!
+//! *Requires the default `streaming` feature.*
+//!
 //! `DynamicMarketStreamer` wraps the lower-level `StreamerClient` and manages
 //! subscriptions in a thread-safe way. Its constructor is **synchronous** — it
 //! only wires up in-memory channels; the network connection is established later
@@ -250,6 +293,7 @@
 //! use ig_client::prelude::*;
 //! use std::collections::HashSet;
 //!
+//! # #[cfg(feature = "streaming")]
 //! #[tokio::main]
 //! async fn main() -> Result<(), AppError> {
 //!     // Fields to receive on each market tick.
@@ -272,6 +316,8 @@
 //!     }
 //!     Ok(())
 //! }
+//! # #[cfg(not(feature = "streaming"))]
+//! # fn main() {}
 //! ```
 //!
 //! ## Available Services
@@ -350,8 +396,8 @@
 //!   DTOs, and the retry policy. Serde only; no I/O.
 //! - **`presentation`** — domain entities per area: account, chart, instrument,
 //!   market, order, price, trade, transaction. Serde only; no I/O.
-//! - **`storage`** — optional PostgreSQL persistence via `sqlx` (sits on top of
-//!   `model` / `presentation`).
+//! - **`storage`** — PostgreSQL persistence via `sqlx`, behind the
+//!   `persistence` feature (sits on top of `model` / `presentation`).
 //! - **`utils`** — leaf helpers: env-var config, logging, finance (P&L), parsing,
 //!   deal-reference id generation.
 //! - **`error`** — canonical typed error enums: `AppError`, `AuthError`, and
@@ -381,7 +427,7 @@
 //! │   └── dynamic_streamer.rs  # DynamicMarketStreamer (subscriptions)
 //! ├── model/             # Pure DTOs: requests, responses, streaming, retry
 //! ├── presentation/      # Domain entities (account, market, order, price, …)
-//! ├── storage/           # Optional PostgreSQL persistence via sqlx
+//! ├── storage/           # PostgreSQL persistence via sqlx (feature `persistence`)
 //! ├── utils/             # config, logger, finance, parsing, id helpers
 //! ├── constants.rs       # Endpoint paths, header names, defaults
 //! ├── error.rs           # AppError / AuthError / FetchError
@@ -418,6 +464,10 @@
 //!
 //! Please make sure your code passes all tests and linting checks before
 //! submitting a pull request.
+
+// Enables the "Available on crate feature ..." badges on docs.rs. Inert on
+// stable: nothing sets `docsrs` outside the docs.rs builder.
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 /// Core application logic and services
 pub mod application;

--- a/src/model/streaming.rs
+++ b/src/model/streaming.rs
@@ -13,6 +13,9 @@
 //! - Account data (P&L, margin, equity)
 
 use serde::{Deserialize, Serialize};
+// Used by the `streaming`-gated field-selector helpers below, and by the test
+// module in every feature configuration.
+#[cfg(any(feature = "streaming", test))]
 use std::collections::HashSet;
 use std::fmt::{Debug, Display};
 
@@ -80,6 +83,7 @@ impl Display for StreamingMarketField {
 ///
 /// A `Vec<String>` where each `String` is the exact IG Lightstreamer wire name
 /// of a `StreamingMarketField` from the input set.
+#[cfg(feature = "streaming")]
 pub(crate) fn get_streaming_market_fields(fields: &HashSet<StreamingMarketField>) -> Vec<String> {
     // `Display` (via the `Debug` impl above) emits the exact IG Lightstreamer
     // wire field name for every variant, so no fallible serialization is needed.
@@ -382,6 +386,7 @@ impl Display for StreamingPriceField {
 ///
 /// A `Vec<String>` where each `String` is the exact IG Lightstreamer wire name
 /// of a `StreamingPriceField` from the input set.
+#[cfg(feature = "streaming")]
 pub(crate) fn get_streaming_price_fields(fields: &HashSet<StreamingPriceField>) -> Vec<String> {
     // `Display` (via the `Debug` impl above) is the single source of truth for
     // the exact IG Lightstreamer wire field name of every variant, so no
@@ -459,6 +464,7 @@ impl Display for StreamingAccountDataField {
 ///
 /// A `Vec<String>` where each `String` is the exact IG Lightstreamer wire name
 /// of a `StreamingAccountDataField` from the input set.
+#[cfg(feature = "streaming")]
 pub(crate) fn get_streaming_account_data_fields(
     fields: &HashSet<StreamingAccountDataField>,
 ) -> Vec<String> {
@@ -583,6 +589,7 @@ impl std::fmt::Display for StreamingChartField {
 ///
 /// A `Vec<String>` of exact IG Lightstreamer wire field names for
 /// subscriptions.
+#[cfg(feature = "streaming")]
 pub(crate) fn get_streaming_chart_fields(fields: &HashSet<StreamingChartField>) -> Vec<String> {
     // `Display` (via the `Debug` impl above) emits the exact IG Lightstreamer
     // wire field name for every variant, so no fallible serialization is needed.
@@ -631,6 +638,7 @@ mod tests {
         assert_eq!(format!("{}", StreamingMarketField::Offer), "OFFER");
     }
 
+    #[cfg(feature = "streaming")]
     #[test]
     fn test_get_streaming_market_fields_empty() {
         let fields: HashSet<StreamingMarketField> = HashSet::new();
@@ -638,6 +646,7 @@ mod tests {
         assert!(result.is_empty());
     }
 
+    #[cfg(feature = "streaming")]
     #[test]
     fn test_get_streaming_market_fields_single() {
         let mut fields = HashSet::new();
@@ -647,6 +656,7 @@ mod tests {
         assert!(result.contains(&"BID".to_string()));
     }
 
+    #[cfg(feature = "streaming")]
     #[test]
     fn test_get_streaming_market_fields_multiple() {
         let mut fields = HashSet::new();
@@ -660,6 +670,7 @@ mod tests {
         assert!(result.contains(&"HIGH".to_string()));
     }
 
+    #[cfg(feature = "streaming")]
     #[test]
     fn test_get_streaming_account_data_fields_wire_names() {
         // Pins the exact IG Lightstreamer wire names produced by the getter
@@ -720,6 +731,7 @@ mod tests {
         assert_eq!(format!("{}", StreamingAccountDataField::Equity), "EQUITY");
     }
 
+    #[cfg(feature = "streaming")]
     #[test]
     fn test_get_streaming_account_fields_empty() {
         let fields: HashSet<StreamingAccountDataField> = HashSet::new();
@@ -727,6 +739,7 @@ mod tests {
         assert!(result.is_empty());
     }
 
+    #[cfg(feature = "streaming")]
     #[test]
     fn test_get_streaming_account_fields_multiple() {
         let mut fields = HashSet::new();
@@ -761,6 +774,7 @@ mod tests {
         assert_eq!(format!("{}", StreamingChartField::Ofr), "OFR");
     }
 
+    #[cfg(feature = "streaming")]
     #[test]
     fn test_get_streaming_chart_fields_empty() {
         let fields: HashSet<StreamingChartField> = HashSet::new();
@@ -768,6 +782,7 @@ mod tests {
         assert!(result.is_empty());
     }
 
+    #[cfg(feature = "streaming")]
     #[test]
     fn test_get_streaming_chart_fields_multiple() {
         let mut fields = HashSet::new();
@@ -1134,6 +1149,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "streaming")]
     #[test]
     fn test_get_streaming_price_fields_uses_display_wire_names() {
         // The price getter now derives wire names from `Display`; pin a couple of

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -17,10 +17,13 @@
 //! let markets = client.search_markets("EUR").await?;
 //! ```
 //!
-//! The prelude is self-sufficient for the streaming API: `StreamerClient`,
-//! `DynamicMarketStreamer`, the `Streaming*Field` selectors and the
+//! With the default `streaming` feature enabled, the prelude is self-sufficient
+//! for the streaming API too: `StreamerClient`, `DynamicMarketStreamer`, the
+//! `Streaming*Field` selectors and the
 //! [`PriceData`](crate::presentation::price::PriceData) DTO all resolve from a
-//! single glob import, with no extra `use` lines.
+//! single glob import, with no extra `use` lines. The `Streaming*Field`
+//! selectors and the presentation DTOs are plain data types and stay available
+//! even with `streaming` off; only the client types go away.
 //!
 //! ```rust
 //! use ig_client::prelude::*;
@@ -28,6 +31,8 @@
 //! // Both the streaming client type and the price DTO resolve through the
 //! // prelude alone — no additional imports are required.
 //! fn accepts_price(_price: &PriceData) {}
+//!
+//! # #[cfg(feature = "streaming")]
 //! fn returns_streamer(client: StreamerClient) -> StreamerClient {
 //!     client
 //! }
@@ -53,6 +58,7 @@ pub use crate::application::rate_limiter::{RateLimitClass, RateLimiter};
 // Service interfaces
 pub use crate::application::interfaces::account::AccountService;
 pub use crate::application::interfaces::costs::CostsService;
+#[cfg(feature = "streaming")]
 pub use crate::application::interfaces::listener::ListenerResult;
 pub use crate::application::interfaces::market::MarketService;
 pub use crate::application::interfaces::operations::OperationsService;
@@ -60,8 +66,10 @@ pub use crate::application::interfaces::order::OrderService;
 pub use crate::application::interfaces::sentiment::SentimentService;
 pub use crate::application::interfaces::watchlist::WatchlistService;
 
-// Streaming client and subscription manager
+// Streaming client and subscription manager (feature `streaming`)
+#[cfg(feature = "streaming")]
 pub use crate::application::client::StreamerClient;
+#[cfg(feature = "streaming")]
 pub use crate::application::dynamic_streamer::DynamicMarketStreamer;
 
 // Error handling
@@ -104,8 +112,11 @@ pub use crate::application::market_hierarchy::{
     build_market_hierarchy, extract_markets_from_hierarchy,
 };
 pub use crate::presentation::order::{Direction, Status};
+// Persistence layer (feature `persistence`)
+#[cfg(feature = "persistence")]
 pub use crate::storage::market_database::MarketDatabaseService;
 
+#[cfg(feature = "persistence")]
 pub use crate::storage::utils::{create_connection_pool, create_database_config_from_env};
 
 /// Result type alias for IG client operations

--- a/src/presentation/account.rs
+++ b/src/presentation/account.rs
@@ -922,7 +922,7 @@ impl AccountData {
     /// This is transport-agnostic: it takes plain field maps rather than a
     /// Lightstreamer `ItemUpdate`, so the presentation layer carries no
     /// dependency on the streaming transport. The `ItemUpdate` adapter lives in
-    /// [`crate::application::streaming_convert`].
+    /// `application::streaming_convert` (feature `streaming`).
     ///
     /// # Arguments
     /// * `item_name` - Subscription item name (`None` when subscribed by position)

--- a/src/presentation/chart.rs
+++ b/src/presentation/chart.rs
@@ -234,7 +234,7 @@ impl ChartData {
     /// This is transport-agnostic: it takes plain field maps rather than a
     /// Lightstreamer `ItemUpdate`, so the presentation layer carries no
     /// dependency on the streaming transport. The `ItemUpdate` adapter lives in
-    /// [`crate::application::streaming_convert`]. The chart scale is derived from
+    /// `application::streaming_convert` (feature `streaming`). The chart scale is derived from
     /// the third `:`-separated segment of the item name (`CHART:{epic}:{scale}`).
     ///
     /// # Arguments

--- a/src/presentation/market.rs
+++ b/src/presentation/market.rs
@@ -424,7 +424,7 @@ impl PresentationMarketData {
     /// This is transport-agnostic: it takes plain field maps rather than a
     /// Lightstreamer `ItemUpdate`, so the presentation layer carries no
     /// dependency on the streaming transport. The `ItemUpdate` adapter lives in
-    /// [`crate::application::streaming_convert`].
+    /// `application::streaming_convert` (feature `streaming`).
     ///
     /// # Arguments
     /// * `item_name` - Subscription item name (`None` when subscribed by position)

--- a/src/presentation/price.rs
+++ b/src/presentation/price.rs
@@ -623,7 +623,7 @@ impl PriceData {
     /// This is transport-agnostic: it takes plain field maps rather than a
     /// Lightstreamer `ItemUpdate`, so the presentation layer carries no
     /// dependency on the streaming transport. The `ItemUpdate` adapter lives in
-    /// [`crate::application::streaming_convert`].
+    /// `application::streaming_convert` (feature `streaming`).
     ///
     /// # Arguments
     /// * `item_name` - Subscription item name (`None` when subscribed by position)

--- a/src/presentation/trade.rs
+++ b/src/presentation/trade.rs
@@ -203,7 +203,7 @@ impl TradeData {
     /// This is transport-agnostic: it takes plain field maps rather than a
     /// Lightstreamer `ItemUpdate`, so the presentation layer carries no
     /// dependency on the streaming transport. The `ItemUpdate` adapter lives in
-    /// [`crate::application::streaming_convert`].
+    /// `application::streaming_convert` (feature `streaming`).
     ///
     /// # Arguments
     /// * `item_name` - Subscription item name (`None` when subscribed by position)

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,10 +1,18 @@
 /// Module containing database configuration structures
 pub mod config;
 /// Historical prices storage and retrieval
+#[cfg(feature = "persistence")]
+#[cfg_attr(docsrs, doc(cfg(feature = "persistence")))]
 pub mod historical_prices;
 /// Market data database operations
+#[cfg(feature = "persistence")]
+#[cfg_attr(docsrs, doc(cfg(feature = "persistence")))]
 pub mod market_database;
 /// Market hierarchy persistence models
+#[cfg(feature = "persistence")]
+#[cfg_attr(docsrs, doc(cfg(feature = "persistence")))]
 pub mod market_persistence;
 /// Storage utility functions
+#[cfg(feature = "persistence")]
+#[cfg_attr(docsrs, doc(cfg(feature = "persistence")))]
 pub mod utils;

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -2,4 +2,5 @@ mod account_tests;
 mod auth_tests;
 mod common;
 mod market_tests;
+#[cfg(feature = "persistence")]
 mod storage_tests;

--- a/tests/unit/application/mod.rs
+++ b/tests/unit/application/mod.rs
@@ -2,4 +2,6 @@ mod test_auth;
 mod test_auth_flow;
 mod test_client;
 mod test_http_request;
+// Exercises `Listener`, which wraps a `lightstreamer-rs` `SubscriptionListener`.
+#[cfg(feature = "streaming")]
 mod test_listener;

--- a/tests/unit/error_tests.rs
+++ b/tests/unit/error_tests.rs
@@ -1,6 +1,7 @@
 use ig_client::error::{AppError, AuthError};
 use reqwest::StatusCode;
 use serde_json::Error as JsonError;
+#[cfg(feature = "persistence")]
 use sqlx::Error as SqlxError;
 use std::error::Error;
 use std::fmt::{self, Display};
@@ -61,6 +62,7 @@ fn test_app_error_from_serde_json_error() {
 }
 
 #[test]
+#[cfg(feature = "persistence")]
 fn test_app_error_from_sqlx_error() {
     // Create a SqlxError (using a simple variant since we can't easily create a real one)
     let sqlx_error = SqlxError::RowNotFound;
@@ -353,6 +355,13 @@ fn test_fetch_error_display() {
     let fetch_error = FetchError::Parser("parsing failed".to_string());
     assert_display_contains(&fetch_error, "parser error");
     assert_display_contains(&fetch_error, "parsing failed");
+}
+
+#[test]
+#[cfg(feature = "persistence")]
+#[allow(deprecated)] // FetchError is deprecated; this pins its Display until removal.
+fn test_fetch_error_sqlx_display() {
+    use ig_client::error::FetchError;
 
     let fetch_error = FetchError::Sqlx(SqlxError::RowNotFound);
     assert_display_contains(&fetch_error, "db error");

--- a/tests/unit/mod.rs
+++ b/tests/unit/mod.rs
@@ -2,5 +2,6 @@ mod application;
 mod error_tests;
 mod model;
 mod presentation;
+#[cfg(feature = "persistence")]
 mod storage;
 mod utils;

--- a/tests/unit/presentation/mod.rs
+++ b/tests/unit/presentation/mod.rs
@@ -1,7 +1,11 @@
 mod serialization_tests;
+#[cfg(feature = "streaming")]
 mod test_account;
+#[cfg(feature = "streaming")]
 mod test_chart;
 mod test_market;
+#[cfg(feature = "streaming")]
 mod test_price;
+#[cfg(feature = "streaming")]
 mod test_trade;
 mod test_transaction;


### PR DESCRIPTION
## Summary

Closes #83.

`lightstreamer-rs` is **GPL-3.0-only** and was a non-optional dependency, so
every crate depending on `ig-client` inherited a copyleft crate in its tree. A
permissively-licensed consumer with a copyleft-rejecting `cargo deny` policy
could not depend on `ig-client` at all, even when it only needed the REST
`MarketService` path. `sqlx` was likewise unconditional and is dead weight for a
market-data-only integration.

Two features, **both ON by default** — existing users and all 13 example crates
are unaffected:

| Feature | Default | Pulls in | Gates |
|---|---|---|---|
| `streaming` | on | `lightstreamer-rs` | `StreamerClient`, `DynamicMarketStreamer`, `interfaces::listener`, the `ItemUpdate` → DTO adapters |
| `persistence` | on | `sqlx` | everything under `storage` except `storage::config` (a re-export of the sqlx-free `DatabaseConfig`) |

```toml
ig-client = { version = "0.12.3", default-features = false }
```

gives a REST-capable client — `Client`, `Client::with_config`, every service
trait, the DTOs, the rate limiter — with **neither crate in the dependency
graph**.

Per the issue comment, only the `streaming` gate was a hard blocker (the
consumer raised their MSRV and wants sqlx 0.9); `persistence` is included
because it is in the issue's written acceptance criteria.

## Two latent bugs found along the way

Both are the same class — the crate depending on a Cargo feature that only
arrived transitively:

1. **`tracing::log::debug`** in `config.rs` and `listener.rs` resolved only
   because `sqlx` enabled `tracing`'s `log` feature. Now native `tracing`
   events. **This is a behaviour change**: `tracing::log::debug` emitted a `log`
   record and `setup_logger` installs no `log` bridge, so those two
   `.env`-loading messages were previously discarded and now appear at DEBUG.
   The streaming listener's per-tick line moved DEBUG → TRACE, since it fires on
   every tick and renders account payloads (P&L, equity, margin).
2. **`tokio`'s `sync` feature was never declared.** The REST path uses
   `tokio::sync` (`auth.rs`, `client.rs`) but the feature reached us only through
   `reqwest`'s own dependencies (`hyper`, `tokio-util`, `deadpool`) — previously
   also via sqlx. Now declared explicitly.

## Gating approach

Whole-module gates where possible (`dynamic_streamer`, `streaming_convert`,
`listener`, the four sqlx-coupled `storage` modules). `client.rs` needs
item-level gates because REST-only code — `is_transient_confirmation_error`,
`MARKET_DETAILS_CONCURRENCY`, the `Client` struct and its seven service impls —
is textually interleaved between the streaming helpers and `StreamerClient`; a
naive top/bottom split would gate the wrong items.

`AppError::WebSocketError` is a plain `String` variant, so **no streaming error
variant ever disappears** — only the `From<LightstreamerError>` impl is gated.
`AppError::Db` and the deprecated `FetchError::Sqlx` do disappear without
`persistence`; `cargo-semver-checks` runs `--all-features` and is unaffected.

## Tests

Every combination, `0 failed`:

| Configuration | lib | unit_tests | doctests |
|---|---|---|---|
| default (= all) | 270 | 227 | 11 |
| `--no-default-features` | 198 | 170 | 11 |
| `+ persistence` | 238 | 176 | 11 |
| `+ streaming` | 230 | 221 | 11 |

Test modules are gated at the `mod` line, except `error_tests.rs`, which is
gated per function so its non-sqlx coverage keeps running everywhere. Note that
`tests/unit/presentation/{test_account,test_chart,test_price,test_trade}.rs`
live under `presentation/` but actually exercise the `streaming_convert`
adapters, so they gate under `streaming` — no pure-DTO coverage is lost.

## CI

New `Features` workflow: build + clippy + test + `cargo doc` (with
`RUSTDOCFLAGS=-D warnings`, since intra-doc links resolve differently per
combination) across all four configurations, every invocation scoped with
`-p ig-client`. A second job asserts each optional dependency appears **exactly
when its feature does**, in both directions:

```
ok: lightstreamer-rs absent with '--no-default-features'
ok: lightstreamer-rs absent with '--no-default-features --features persistence'
ok: lightstreamer-rs present with '--no-default-features --features streaming'
ok: sqlx absent with '--no-default-features'
ok: sqlx absent with '--no-default-features --features streaming'
ok: sqlx present with '--no-default-features --features persistence'
```

`make check-features` mirrors it and is wired into `pre-push`. Heads-up: that
makes `pre-push` noticeably slower locally (four full build/clippy/test/doc
cycles) — say the word and I'll move it to CI-only.

## Review notes

`resilience-reviewer`: 0 P1/P2, "OK to commit" — confirmed every gated helper
gates as a whole unit, no caller survives ungated, and `Drop for StreamerClient`
shares its struct's gate (the leak-class bug this could have introduced). It
caught the listener logging change, fixed as described above.

`architect`: confirmed the gating is item-correct and the default build is
feature-node identical to `main`. It found the undeclared `tokio/sync`, which is
fixed here. Also applied from its punch list: docs.rs metadata + `doc(cfg)`
badges, per-combination CI assertions, a `cargo tree` failure that the Makefile
silently swallowed, corrected docs (`storage::config` survives; `Listener` is
not in the prelude), structured log fields, and de-linked intra-doc links that
pointed at feature-gated items.

Follow-ups deliberately left out of scope: `AppError` is not `#[non_exhaustive]`,
so the gated `Db` variant makes downstream exhaustive matches feature-dependent
(breaking change to fix); `storage/utils.rs` holds three sqlx-free helpers that
disappear with `persistence`; `tokio/signal` is declared crate-wide but only
streaming and the examples use it.

## Checks

`make pre-push` clean, including the full feature matrix. `cargo package`
succeeds. Workspace examples all still build unchanged.