### PR TITLE
fix: resolve rustdoc intra-doc links in streaming module docs

### DIFF
--- a/src/application/interfaces/listener.rs
+++ b/src/application/interfaces/listener.rs
@@ -8,10 +8,13 @@
 //!
 //! `lightstreamer-rs` 1.0 delivers updates as a [`Stream`] rather than through
 //! a listener trait, but this crate's own callback surface is unchanged:
-//! [`Listener::new`] still takes a `Fn(&T) -> ListenerResult`. What used to be
-//! an upstream trait implementation is now [`Listener::spawn`], which pumps the
-//! stream and invokes the callback for every update, and
-//! [`Listener::on_item_update`], which applies the callback to a single update.
+//! [`Listener::new`](crate::application::interfaces::listener::Listener::new)
+//! still takes a `Fn(&T) -> ListenerResult`. What used to be an upstream trait
+//! implementation is now
+//! [`Listener::spawn`](crate::application::interfaces::listener::Listener::spawn),
+//! which pumps the stream and invokes the callback for every update, and
+//! [`Listener::on_item_update`](crate::application::interfaces::listener::Listener::on_item_update),
+//! which applies the callback to a single update.
 //!
 //! [`Stream`]: futures::Stream
 

--- a/src/application/streaming_convert.rs
+++ b/src/application/streaming_convert.rs
@@ -8,14 +8,16 @@
 //!
 //! The presentation DTOs stay transport-agnostic: they expose pure
 //! `from_fields(..)` constructors that take plain field maps. This module is the
-//! only place that depends on `lightstreamer_rs`; it reads an [`ItemUpdate`] and
+//! only place that depends on `lightstreamer_rs`; it reads an
+//! [`ItemUpdate`](lightstreamer_rs::ItemUpdate) and
 //! feeds the extracted metadata / field maps into those pure constructors.
 //!
 //! # The seam
 //!
-//! [`ItemUpdate`] is the streaming crate's own type: it borrows from the
-//! subscription schema, has no public constructor, and models a field value as
-//! [`FieldValue`] rather than a string. [`StreamingUpdate`] is this crate's
+//! [`ItemUpdate`](lightstreamer_rs::ItemUpdate) is the streaming crate's own
+//! type: it borrows from the subscription schema, has no public constructor, and
+//! models a field value as [`FieldValue`](lightstreamer_rs::FieldValue) rather
+//! than a string. [`StreamingUpdate`](crate::application::streaming_convert::StreamingUpdate) is this crate's
 //! owned, constructible mirror of it, and every conversion below goes through
 //! it. That keeps the DTO parsers testable without a live session, and keeps
 //! the null-versus-empty distinction explicit at exactly one place:


### PR DESCRIPTION
## Problem

The **Features** workflow failed on `main` (commit 8801dd9). The
`cargo doc -p ig-client --no-deps <feature-combo>` step runs with
`RUSTDOCFLAGS: -D warnings` and aborted with exit 101:

```
error: unresolved link to `Listener::new` / `Listener::spawn` / `Listener::on_item_update`
error: unresolved link to `ItemUpdate` (x2) / `FieldValue` / `StreamingUpdate`
  = note: no item named `...` in scope
```

The module-level `//!` docs added in the lightstreamer-rs 1.0 migration
(PR #85) used bare shortcut links that rustdoc could not resolve in the
module scope. This broke every feature combination that enables
`streaming`.

## Fix

Give each link an explicit target:

- `src/application/streaming_convert.rs` — `[ItemUpdate](lightstreamer_rs::ItemUpdate)`,
  `[FieldValue](lightstreamer_rs::FieldValue)`,
  `[StreamingUpdate](crate::application::streaming_convert::StreamingUpdate)`
- `src/application/interfaces/listener.rs` — `Listener::new` / `spawn` /
  `on_item_update` via their full `crate::` paths

## Verification

- `cargo doc -p ig-client --no-deps` with `-D warnings` passes for all
  four combos: `--no-default-features`, `persistence`, `streaming`,
  `--all-features`
- `cargo fmt --check` clean
- Docs-only change; no build impact