### PR TITLE
Fix get_costs_history: real IG contract, pagination, instant bounds (#87)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ig-client"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2024"
 authors = ["Joaquin Bejar <jb@taunais.com>"]
 description = "This crate provides a client for the IG Markets API"

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-ig-client = "0.13.0"
+ig-client = "0.12.3"
 tokio = { version = "1", features = ["full"] }  # Async runtime
 tracing = "0.1"                                  # Logging facade
 # Optional, only if you use the PostgreSQL persistence layer:
@@ -82,7 +82,7 @@ opt out. Turn them off for a REST/poll-only client:
 
 ```toml
 [dependencies]
-ig-client = { version = "0.13.0", default-features = false }
+ig-client = { version = "0.12.3", default-features = false }
 ```
 
 That leaves `Client`, `Client::with_config`, every REST service trait
@@ -471,30 +471,6 @@ Contributions are welcome:
 Please make sure your code passes all tests and linting checks before
 submitting a pull request.
 
-## What's New in 0.13.0
-
-- **`lightstreamer-rs` is now the MIT `1.0`.** The streaming leg previously
-  pulled in `lightstreamer-rs` 0.3.x, which was **GPL-3.0-only**; `1.0` is a
-  from-scratch clean-room rewrite under **MIT**. A permissively-licensed
-  consumer with a copyleft-rejecting `cargo deny` policy can now depend on
-  `ig-client` with `streaming` on. Turning `streaming` off is henceforth a
-  build-weight choice, not a licence one.
-- **Breaking (streaming surface).** The upstream rewrite replaced its
-  listener-trait delivery with typed streams, so the seam this crate exposes
-  changed:
-  - The boundary DTO is now `StreamingUpdate` (a crate-owned, owned, serde
-    type), re-exported from the prelude. It replaces the previously re-exported
-    upstream `ItemUpdate`. Implement `From<&StreamingUpdate>` to plug your own
-    type into `Listener<T>` — the callback `Listener<T>` surface is unchanged.
-  - The internal `Arc<Mutex<LightstreamerClient>>` became a plain `Arc<Client>`
-    (the upstream client is `Send + Sync` and takes `&self`), and the
-    string-sniffing graceful-close detection is gone: a clean shutdown is now a
-    typed `ClosedReason::ByClient`.
-  - Reconnection consequences are surfaced honestly: `SessionEvent::Connected`
-    carries a `Continuity`, and a *replaced* session (stale derived state) is
-    distinguished from a preserved or recovered one.
-- REST, persistence, rate-limiting, retry and the DTOs are unchanged.
-
 ## What's New in 0.12.3
 
 - The crate now has Cargo **features**, both on by default so existing users are
@@ -504,12 +480,10 @@ submitting a pull request.
     `lightstreamer-rs`.
   - `persistence` — the `storage` module, pulling in `sqlx`.
 - `ig-client = { version = "0.12.3", default-features = false }` gives a
-  REST/poll-only client with **neither** crate in the dependency graph. When
-  this feature landed it also mattered for licensing — `lightstreamer-rs` was
-  GPL-3.0-only up to 0.3.x, so a permissively licensed consumer with a
-  copyleft-rejecting `cargo deny` policy could not depend on `ig-client` with
-  `streaming` on. Since `lightstreamer-rs` 1.0 that reason is gone (it is MIT);
-  turning `streaming` off is now purely a build-weight choice.
+  REST/poll-only client with **neither** crate in the dependency graph. This
+  matters for licensing: `lightstreamer-rs` is GPL-3.0-only, so a permissively
+  licensed consumer with a copyleft-rejecting `cargo deny` policy previously
+  could not depend on `ig-client` at all.
 - Fixed two latent dependencies on features that only arrived transitively:
   - Two modules imported `tracing::log::debug`, which resolved only because
     `sqlx` enabled `tracing`'s `log` feature. These are now native `tracing`

--- a/examples/costs/src/bin/costs_history.rs
+++ b/examples/costs/src/bin/costs_history.rs
@@ -36,23 +36,31 @@ async fn main() -> Result<(), AppError> {
     match client.get_costs_history(from, to).await {
         Ok(history) => {
             println!(
-                "\n{:<15} {:<20} {:<25} {:>12} {:>8}",
-                "DATE", "DEAL REF", "EPIC", "COST", "CCY"
+                "\n{:<25} {:<8} {:<10} {:<30} {:<38}",
+                "CREATED", "TYPE", "DIRECTION", "INSTRUMENT", "QUOTE REFERENCE"
             );
-            println!("{}", "-".repeat(80));
+            println!("{}", "-".repeat(115));
 
-            for cost in &history.costs {
+            for entry in &history.costs_and_charges_history {
                 println!(
-                    "{:<15} {:<20} {:<25} {:>12.2} {:>8}",
-                    cost.date,
-                    cost.deal_reference.as_deref().unwrap_or("-"),
-                    cost.epic.as_deref().unwrap_or("-"),
-                    cost.total_cost.unwrap_or(0.0),
-                    cost.currency.as_deref().unwrap_or("-")
+                    "{:<25} {:<8} {:<10} {:<30} {:<38}",
+                    entry.created_timestamp.as_deref().unwrap_or("-"),
+                    entry.entry_type.as_deref().unwrap_or("-"),
+                    entry.direction.as_deref().unwrap_or("-"),
+                    entry.instrument_name.as_deref().unwrap_or("-"),
+                    entry.indicative_quote_reference.as_deref().unwrap_or("-")
                 );
             }
 
-            println!("\nTotal cost entries: {}", history.costs.len());
+            println!(
+                "\nTotal cost entries: {} ({} pages upstream)",
+                history.costs_and_charges_history.len(),
+                history.pagination.total_pages
+            );
+            println!(
+                "Amounts are not inline: fetch each disclosure document via \
+                 get_durable_medium(quote_reference)."
+            );
         }
         Err(e) => {
             println!("Error getting costs history: {}", e);

--- a/src/application/client.rs
+++ b/src/application/client.rs
@@ -125,6 +125,35 @@ fn is_transient_confirmation_error(err: &AppError) -> bool {
     }
 }
 
+/// Appends a `Z` zone designator to a zone-less ISO-8601 timestamp.
+///
+/// IG's costs-history endpoint parses `from`/`to` as ISO-8601 instants and
+/// rejects zone-less timestamps with a 500 (`could not be parsed at index
+/// 19`). Callers across this crate pass the same zone-less local ISO form
+/// the other history endpoints accept (`2026-01-01T00:00:00`), so this
+/// helper appends `Z` when no designator (`Z` or a `±hh:mm` offset after
+/// the time part) is present. Inputs that already carry a designator pass
+/// through unchanged.
+#[must_use]
+fn ensure_zone_designator(raw: &str) -> String {
+    let trimmed = raw.trim();
+    if trimmed.ends_with('Z') {
+        return trimmed.to_string();
+    }
+    let Some(time_index) = trimmed.find('T') else {
+        // Date-only input: expand to midnight UTC.
+        return format!("{trimmed}T00:00:00Z");
+    };
+    let has_offset = trimmed
+        .get(time_index..)
+        .is_some_and(|time_part| time_part.contains('+') || time_part.contains('-'));
+    if has_offset {
+        trimmed.to_string()
+    } else {
+        format!("{trimmed}Z")
+    }
+}
+
 /// Main client for interacting with IG Markets API
 ///
 /// This client provides a unified interface for all IG Markets API operations,
@@ -1214,11 +1243,43 @@ impl CostsService for Client {
         from: &str,
         to: &str,
     ) -> Result<CostsHistoryResponse, AppError> {
-        let path = format!("indicativecostsandcharges/history/from/{}/to/{}", from, to);
-        info!("Getting costs history from {} to {}", from, to);
-        let result: CostsHistoryResponse = self.http_client.get(&path, Some(1)).await?;
-        debug!("Costs history obtained: {} entries", result.costs.len());
-        Ok(result)
+        // IG requires pageSize (400 without it) and parses from/to as
+        // ISO-8601 instants with a zone designator (500 without one).
+        const PAGE_SIZE: u32 = 500;
+        let from = ensure_zone_designator(from);
+        let to = ensure_zone_designator(to);
+        let mut all_entries = Vec::new();
+        let mut current_page: u32 = 1;
+        #[allow(unused_assignments)]
+        let mut last_pagination = None;
+
+        loop {
+            let path = format!(
+                "indicativecostsandcharges/history/from/{}/to/{}?pageSize={}&pageNumber={}",
+                from, to, PAGE_SIZE, current_page
+            );
+            info!("Getting costs history page {}", current_page);
+
+            let result: CostsHistoryResponse = self.http_client.get(&path, Some(1)).await?;
+
+            let total_pages = result.pagination.total_pages;
+            last_pagination = Some(result.pagination);
+            all_entries.extend(result.costs_and_charges_history);
+
+            if i64::from(current_page) >= total_pages {
+                break;
+            }
+            current_page += 1;
+        }
+
+        debug!("Costs history obtained: {} entries", all_entries.len());
+
+        Ok(CostsHistoryResponse {
+            pagination: last_pagination.ok_or_else(|| {
+                AppError::InvalidInput("Could not retrieve pagination".to_string())
+            })?,
+            costs_and_charges_history: all_entries,
+        })
     }
 
     async fn get_durable_medium(
@@ -2053,9 +2114,42 @@ impl Drop for StreamerClient {
 
 #[cfg(test)]
 mod tests {
-    use super::is_transient_confirmation_error;
+    use super::{ensure_zone_designator, is_transient_confirmation_error};
     use crate::error::AppError;
     use reqwest::StatusCode;
+
+    #[test]
+    fn test_ensure_zone_designator_appends_z_when_missing() {
+        assert_eq!(
+            ensure_zone_designator("2026-01-01T00:00:00"),
+            "2026-01-01T00:00:00Z"
+        );
+        assert_eq!(
+            ensure_zone_designator(" 2026-01-01T00:00:00 "),
+            "2026-01-01T00:00:00Z"
+        );
+    }
+
+    #[test]
+    fn test_ensure_zone_designator_expands_date_only_to_midnight_utc() {
+        assert_eq!(ensure_zone_designator("2026-01-01"), "2026-01-01T00:00:00Z");
+    }
+
+    #[test]
+    fn test_ensure_zone_designator_keeps_existing_designator() {
+        assert_eq!(
+            ensure_zone_designator("2026-01-01T00:00:00Z"),
+            "2026-01-01T00:00:00Z"
+        );
+        assert_eq!(
+            ensure_zone_designator("2026-01-01T00:00:00+01:00"),
+            "2026-01-01T00:00:00+01:00"
+        );
+        assert_eq!(
+            ensure_zone_designator("2026-01-01T00:00:00-05:00"),
+            "2026-01-01T00:00:00-05:00"
+        );
+    }
 
     #[test]
     fn test_confirmation_error_rate_limit_is_transient() {

--- a/src/application/interfaces/costs.rs
+++ b/src/application/interfaces/costs.rs
@@ -62,14 +62,24 @@ pub trait CostsService: Send + Sync {
         request: &EditCostsRequest,
     ) -> Result<IndicativeCostsResponse, AppError>;
 
-    /// Returns historical costs and charges for a date range
+    /// Returns historical costs and charges for a date range, handling
+    /// pagination automatically (the full window is returned).
+    ///
+    /// IG parses the bounds as ISO-8601 instants; a zone-less timestamp
+    /// (e.g. `"2023-01-01T00:00:00"`) is accepted and treated as UTC — the
+    /// implementation appends the required `Z` designator when missing —
+    /// and a date-only bound (e.g. `"2023-01-01"`) expands to midnight UTC.
+    ///
+    /// Entries carry no cost amounts inline: each references its disclosure
+    /// document via `indicative_quote_reference`, retrievable with
+    /// [`CostsService::get_durable_medium`].
     ///
     /// # Arguments
-    /// * `from` - Start date in ISO format (e.g., "2023-01-01")
-    /// * `to` - End date in ISO format (e.g., "2023-12-31")
+    /// * `from` - Window start, ISO-8601 (e.g., "2023-01-01T00:00:00" or "2023-01-01T00:00:00Z")
+    /// * `to` - Window end, same format
     ///
     /// # Returns
-    /// * `Ok(CostsHistoryResponse)` - Historical costs data
+    /// * `Ok(CostsHistoryResponse)` - Historical costs entries for the whole window
     /// * `Err(AppError)` - If the request fails
     async fn get_costs_history(
         &self,

--- a/src/model/responses.rs
+++ b/src/model/responses.rs
@@ -972,28 +972,58 @@ pub struct CostBreakdown {
     pub amount: Option<f64>,
 }
 
-/// Response containing historical costs
+/// Response containing paginated costs and charges history
+///
+/// Captured shape (demo, 2026-07-23): `{"pagination": {...},
+/// "costsAndChargesHistory": [...]}`. Entries carry **no amounts inline** —
+/// each references its disclosure document via `indicativeQuoteReference`,
+/// retrievable with `get_durable_medium`.
 #[derive(DebugPretty, Clone, Serialize, Deserialize, Default)]
 pub struct CostsHistoryResponse {
-    /// List of historical costs
-    pub costs: Vec<HistoricalCost>,
+    /// Pagination metadata
+    #[serde(default)]
+    pub pagination: CostsHistoryPagination,
+    /// Costs and charges entries for the requested window
+    #[serde(rename = "costsAndChargesHistory", default)]
+    pub costs_and_charges_history: Vec<CostsHistoryEntry>,
 }
 
-/// Historical cost entry
+/// Pagination metadata of the costs history response
 #[derive(DebugPretty, Clone, Serialize, Deserialize, Default)]
-pub struct HistoricalCost {
-    /// Date of the cost
-    pub date: String,
-    /// Deal reference
-    #[serde(rename = "dealReference")]
-    pub deal_reference: Option<String>,
-    /// Epic of the instrument
-    pub epic: Option<String>,
-    /// Total cost amount
-    #[serde(rename = "totalCost")]
-    pub total_cost: Option<f64>,
-    /// Currency
-    pub currency: Option<String>,
+pub struct CostsHistoryPagination {
+    /// Page size requested
+    #[serde(rename = "pageSize", default)]
+    pub page_size: i64,
+    /// Current page number (1-based)
+    #[serde(rename = "pageNumber", default)]
+    pub page_number: i64,
+    /// Total number of pages available
+    #[serde(rename = "totalPages", default)]
+    pub total_pages: i64,
+    /// Total number of entries across all pages
+    #[serde(rename = "totalElements", default)]
+    pub total_elements: i64,
+}
+
+/// One costs and charges history entry
+#[derive(DebugPretty, Clone, Serialize, Deserialize, Default)]
+pub struct CostsHistoryEntry {
+    /// Entry type (e.g. `TRADE`)
+    #[serde(rename = "type", default)]
+    pub entry_type: Option<String>,
+    /// Deal direction (`BUY` / `SELL`)
+    #[serde(default)]
+    pub direction: Option<String>,
+    /// Instrument name (may be empty)
+    #[serde(rename = "instrumentName", default)]
+    pub instrument_name: Option<String>,
+    /// Creation timestamp (ISO-8601, no zone designator)
+    #[serde(rename = "createdTimestamp", default)]
+    pub created_timestamp: Option<String>,
+    /// Reference of the disclosure document holding the actual amounts
+    /// (retrieve with `get_durable_medium`)
+    #[serde(rename = "indicativeQuoteReference", default)]
+    pub indicative_quote_reference: Option<String>,
 }
 
 /// Response containing a durable medium document
@@ -1424,27 +1454,66 @@ mod tests {
 
     #[test]
     fn test_costs_history_response_deserialize_and_roundtrip() {
+        // Captured from demo indicativecostsandcharges/history (2026-07-23),
+        // truncated to one entry; quote reference shape-preservingly redacted.
         let json = r#"{
-            "costs": [
+            "pagination": {"pageSize": 10, "pageNumber": 1, "totalPages": 23, "totalElements": 224},
+            "costsAndChargesHistory": [
                 {
-                    "date": "2025-07-01",
-                    "dealReference": "REFFAKEC1",
-                    "epic": "IX.D.FTSE.DAILY.IP",
-                    "totalCost": 5.5,
-                    "currency": "GBP"
+                    "type": "TRADE",
+                    "direction": "SELL",
+                    "instrumentName": "",
+                    "createdTimestamp": "2026-01-12T14:38:46.401",
+                    "indicativeQuoteReference": "00000000-2a79-4710-aa44-000000000000"
                 }
             ]
         }"#;
 
         let resp: CostsHistoryResponse = serde_json::from_str(json).expect("deserialize failed");
-        assert_eq!(resp.costs.len(), 1);
-        let cost = &resp.costs[0];
-        assert_eq!(cost.date, "2025-07-01");
-        assert_eq!(cost.deal_reference.as_deref(), Some("REFFAKEC1"));
-        assert_eq!(cost.total_cost, Some(5.5));
+        assert_eq!(resp.pagination.page_size, 10);
+        assert_eq!(resp.pagination.total_pages, 23);
+        assert_eq!(resp.pagination.total_elements, 224);
+        assert_eq!(resp.costs_and_charges_history.len(), 1);
+        let entry = &resp.costs_and_charges_history[0];
+        assert_eq!(entry.entry_type.as_deref(), Some("TRADE"));
+        assert_eq!(entry.direction.as_deref(), Some("SELL"));
+        assert_eq!(entry.instrument_name.as_deref(), Some(""));
+        assert_eq!(
+            entry.created_timestamp.as_deref(),
+            Some("2026-01-12T14:38:46.401")
+        );
+        assert_eq!(
+            entry.indicative_quote_reference.as_deref(),
+            Some("00000000-2a79-4710-aa44-000000000000")
+        );
 
         let re = roundtrip(&resp);
-        assert_eq!(re.costs[0].epic.as_deref(), Some("IX.D.FTSE.DAILY.IP"));
+        assert_eq!(re.pagination.total_elements, 224);
+        assert_eq!(
+            re.costs_and_charges_history[0].entry_type.as_deref(),
+            Some("TRADE")
+        );
+    }
+
+    #[test]
+    fn test_costs_history_response_minimal_payload_defaults() {
+        // An empty-window response and a fully minimal object must both parse.
+        let empty_window: CostsHistoryResponse = serde_json::from_str(
+            r#"{"pagination":{"pageSize":20,"pageNumber":1,"totalPages":0,"totalElements":0},"costsAndChargesHistory":[]}"#,
+        )
+        .expect("empty-window payload must deserialize");
+        assert!(empty_window.costs_and_charges_history.is_empty());
+        assert_eq!(empty_window.pagination.total_pages, 0);
+
+        let minimal: CostsHistoryResponse =
+            serde_json::from_str("{}").expect("minimal payload must deserialize");
+        assert!(minimal.costs_and_charges_history.is_empty());
+        assert_eq!(minimal.pagination.page_number, 0);
+
+        let minimal_entry: CostsHistoryEntry =
+            serde_json::from_str("{}").expect("minimal entry must deserialize");
+        assert_eq!(minimal_entry.entry_type, None);
+        assert_eq!(minimal_entry.indicative_quote_reference, None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`CostsService::get_costs_history` never worked against the real IG API: every call failed before returning data (missing mandatory `pageSize`, zone-less timestamps rejected), and the response DTO modeled a payload shape the API never returns. Verified with raw probes against demo (2026-07-23) and fixed end-to-end; the previously failing calls now return 200 and parse.

## Changes

- `get_costs_history` sends `pageSize=500` / `pageNumber` and follows `pagination.totalPages`, returning the full window — same auto-pagination pattern as `get_transactions`. IG `Version` header stays `1`; the call remains in the non-trading rate-limit class.
- `from`/`to` normalization: IG parses the path bounds as ISO-8601 instants and 500s without a zone designator. A zone-less timestamp gets `Z` appended, a date-only bound expands to `T00:00:00Z`, and inputs already carrying `Z` or a `±hh:mm` offset pass through unchanged.
- `CostsHistoryResponse` replaced with the captured real shape: `pagination {pageSize, pageNumber, totalPages, totalElements}` + `costsAndChargesHistory` entries `{type, direction, instrumentName, createdTimestamp, indicativeQuoteReference}`. Entries carry **no amounts inline** — each references its disclosure document, retrievable via the existing `get_durable_medium`; this is now documented on the trait and in the example.
- Trait docs fixed (previous examples showed date formats IG rejects) and `examples/costs/costs_history` updated to the real fields.

## Technical decisions

- **`HistoricalCost` removed** rather than kept as a deprecated alias: its fields (`totalCost`, `dealReference`, `epic`, `currency`) do not exist in the real payload, so any code compiled against it was already broken at runtime. 0.13.0 is an unreleased breaking-change window.
- Response fields use `#[serde(default)]` so an empty-window response and future field omissions deserialize instead of erroring; the captured payload proves all present fields.
- Pagination cursor uses `u32` with an `i64` comparison against IG's `totalPages` — no unchecked arithmetic on the cursor.

## Public API impact

- Removed: `HistoricalCost`.
- Changed: `CostsHistoryResponse` (was `{costs: Vec<HistoricalCost>}`, now `pagination` + `costs_and_charges_history`).
- Added: `CostsHistoryPagination`, `CostsHistoryEntry` (exported via the existing `model::responses` re-exports / prelude glob).
- `README.md` regenerated via `make readme`. The `semver` CI check is expected to flag the breaking change — intended within the unreleased 0.13.0 window.
- Known downstream: libcommon's `AccountCostEntry::from_ig(&HistoricalCost)` (pinned to 0.12.x, adapts when bumping to 0.13).

## Testing

- [x] Unit tests added or updated (`ensure_zone_designator`: append-Z, keep-designator, date-only expansion)
- [x] Round-trip serde tests from captured IG payloads for new / changed DTOs (full captured payload + empty-window + minimal `{}`)
- [x] Live-API tests under `tests/integration/` remain env-gated (never run in CI)
- [x] `make pre-push` run locally and clean
- Live verification against demo: previously-failing window returns 200 and parses; wide window (224 elements, 23 pages upstream) captured and used as the fixture.

## Checklist

- [x] Code follows `rules/global_rules.md` and `CLAUDE.md`
- [x] All `pub` items have `///` documentation; `# Errors` on fallible functions
- [x] No `.unwrap()` / `.expect()` / unchecked indexing in production code
- [x] Checked arithmetic on protocol counters (retry counters, pagination cursors, allowance counts)
- [x] No `unsafe` introduced (banned crate-wide)
- [x] Module boundaries respected (`model` / `presentation` stay I/O-free; `application` has no deps on `storage`)
- [x] No new dependencies added without explicit approval
- [x] `tracing` only for logging — no credentials / tokens / CST / X-SECURITY-TOKEN in logs, errors, or fixtures
- [x] Retry stays finite — no unbounded retry loops (pagination bounded by `totalPages`)
- [x] `src/lib.rs` docs + `README.md` (via `make readme`) updated if user-visible

Closes #87
