### PR TITLE
Fix costs history empty results: IG silently caps pageSize (#87)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ig-client"
-version = "0.14.0"
+version = "0.14.1"
 edition = "2024"
 authors = ["Joaquin Bejar <jb@taunais.com>"]
 description = "This crate provides a client for the IG Markets API"

--- a/src/application/client.rs
+++ b/src/application/client.rs
@@ -1245,7 +1245,11 @@ impl CostsService for Client {
     ) -> Result<CostsHistoryResponse, AppError> {
         // IG requires pageSize (400 without it) and parses from/to as
         // ISO-8601 instants with a zone designator (500 without one).
-        const PAGE_SIZE: u32 = 500;
+        // pageSize is silently capped: above ~50 IG returns correct
+        // pagination metadata (totalElements/totalPages) but an EMPTY
+        // costsAndChargesHistory list (observed on demo with 100 and 500;
+        // 50 returns entries). Keep the page size at 50.
+        const PAGE_SIZE: u32 = 50;
         let from = ensure_zone_designator(from);
         let to = ensure_zone_designator(to);
         let mut all_entries = Vec::new();


### PR DESCRIPTION
IG silently caps the costs-history `pageSize`: above ~50 it returns correct pagination metadata (`totalElements`/`totalPages`) but an **empty** `costsAndChargesHistory` list (observed on demo with 100 and 500; 50 returns entries). 0.14.0 used `pageSize=500`, so every call came back empty despite reporting elements. Lowered to 50 — pagination already follows `totalPages`, so full windows are unaffected. Version 0.14.0 → 0.14.1. Follow-up to #88.