### PR TITLE
fix: proactive key rotation, single token per request, typed allowances

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ig-client"
-version = "0.16.0"
+version = "0.16.1"
 edition = "2024"
 authors = ["Joaquin Bejar <jb@taunais.com>"]
 description = "This crate provides a client for the IG Markets API"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ig-client"
-version = "0.17.0"
+version = "0.16.2"
 edition = "2024"
 authors = ["Joaquin Bejar <jb@taunais.com>"]
 description = "This crate provides a client for the IG Markets API"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ig-client"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2024"
 authors = ["Joaquin Bejar <jb@taunais.com>"]
 description = "This crate provides a client for the IG Markets API"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ig-client"
-version = "0.16.2"
+version = "0.17.0"
 edition = "2024"
 authors = ["Joaquin Bejar <jb@taunais.com>"]
 description = "This crate provides a client for the IG Markets API"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ig-client"
-version = "0.16.1"
+version = "0.16.2"
 edition = "2024"
 authors = ["Joaquin Bejar <jb@taunais.com>"]
 description = "This crate provides a client for the IG Markets API"

--- a/README.md
+++ b/README.md
@@ -149,8 +149,8 @@ distinct because they call for different responses:
 | `RateLimitExceeded` | a bare 429 with no allowance body | not read as a per-key rejection |
 
 Rotation is enabled for non-trading REST only. Creating, amending and closing
-orders stay pinned to slot 0, so consecutive orders travel on one key and one
-session: that traffic is metered against the account, so moving it buys nothing
+orders stay pinned to the primary slot — the key whose session the client
+exposes — so consecutive orders travel on one key and one session: that traffic is metered against the account, so moving it buys nothing
 and would scatter order history across sessions.
 
 On top of the per-key budgets the pool paces against an account-wide one, fixed

--- a/README.md
+++ b/README.md
@@ -153,10 +153,15 @@ orders stay pinned to slot 0, so consecutive orders travel on one key and one
 session: that traffic is metered against the account, so moving it buys nothing
 and would scatter order history across sessions.
 
-On top of the per-key budgets the pool paces against an account-wide one,
-derived as `keys x max_requests` capped at IG's documented 30 requests/minute
-per account. With a single key it never binds, so single-key behaviour is
-unchanged.
+On top of the per-key budgets the pool paces against an account-wide one, fixed
+at IG's documented 30 requests per 60 seconds. It is charged **per physical
+request**, immediately before each send: logins, token refreshes and every
+retry pay it, not just the data calls.
+
+That budget coordinates **one process only**. It is an in-process token bucket,
+so two services authenticating the same IG account each pace themselves to the
+ceiling and together exceed it — keep an account inside one process, or give
+each service its own account.
 
 A single key (no comma) behaves exactly as before.
 

--- a/README.md
+++ b/README.md
@@ -158,12 +158,30 @@ at IG's documented 30 requests per 60 seconds. It is charged **per physical
 request**, immediately before each send: logins, token refreshes and every
 retry pay it, not just the data calls.
 
-That budget coordinates **one process only**. It is an in-process token bucket,
-so two services authenticating the same IG account each pace themselves to the
-ceiling and together exceed it — keep an account inside one process, or give
-each service its own account.
+Non-trading and historical traffic share that one bucket, because IG's
+per-account non-trading allowance is a single budget — giving each class its own
+would let market data and `/prices` each run to 30/min. Trading does not charge
+it: IG meters orders against a separate trading allowance.
 
-A single key (no comma) behaves exactly as before.
+The bucket is shared **per process and per account**, so several `HttpClient`s
+in one service built for the same account share it. It does **not** coordinate
+across processes: two services authenticating the same IG account hold two
+buckets and together exceed the ceiling. Enforcing it there needs a distributed
+limiter, or an account per service.
+
+### Upgrading from 0.15
+
+A single key (no comma) keeps the same routing — one key, one session — but two
+behaviours changed for every configuration:
+
+- An `exceeded-api-key-allowance` 403 now **fails fast** instead of being retried
+  three times with backoff. Waiting ~76 s on a key that has just said it is empty
+  helps nobody; with a pool the caller rotates instead, and with one key it learns
+  sooner. Callers that relied on the retry need to handle
+  `AppError::ApiKeyAllowanceExceeded` themselves.
+- The account-wide bucket applies even to a single key, at 30 requests per 60
+  seconds with a burst of 1. A client configured for a faster per-key rate is now
+  capped by it.
 
 `Config::new()` reads configuration from the environment (and a local `.env`
 file, if present). Create a `.env` file in your project root with the

--- a/README.md
+++ b/README.md
@@ -149,8 +149,14 @@ distinct because they call for different responses:
 | `RateLimitExceeded` | a bare 429 with no allowance body | not read as a per-key rejection |
 
 Rotation is enabled for non-trading REST only. Creating, amending and closing
-orders stay pinned to one key: that traffic is metered against the account, so
-moving it buys nothing and would scatter order history across sessions.
+orders stay pinned to slot 0, so consecutive orders travel on one key and one
+session: that traffic is metered against the account, so moving it buys nothing
+and would scatter order history across sessions.
+
+On top of the per-key budgets the pool paces against an account-wide one,
+derived as `keys x max_requests` capped at IG's documented 30 requests/minute
+per account. With a single key it never binds, so single-key behaviour is
+unchanged.
 
 A single key (no comma) behaves exactly as before.
 

--- a/README.md
+++ b/README.md
@@ -127,15 +127,32 @@ list and the client spreads requests across them:
 IG_API_KEY=key1,key2,key3
 ```
 
-Each key gets its own session and its own rate-limiter budget, and every request
-is served by the key with spare capacity. If IG still rejects one for exceeding
-its allowance, that key is parked for a minute and the request is retried
-immediately on another instead of waiting out a backoff.
+Each key gets its own session and its own rate-limiter budget — one limiter
+shared by that key's login and its data requests, because IG counts both against
+the same allowance.
+
+Spreading is **proactive**: a request goes to a key that can serve it right now,
+picked round-robin among the equally available ones, and the token is reserved
+at selection and carried through to the send, so one request costs exactly one
+token. When no key has a token, the client waits on all of them at once and
+takes whichever refills first rather than queueing on an arbitrary one.
+
+Being rejected is the safety net, not the mechanism. The allowance errors are
+distinct because they call for different responses:
+
+| Error | Meaning | Response |
+|---|---|---|
+| `ApiKeyAllowanceExceeded` | this key's budget | park the key for a minute, retry on another immediately |
+| `AccountAllowanceExceeded` | the account's budget | every key shares it, so rotating cannot help |
+| `TradingAllowanceExceeded` | the account's trading budget | never rotates |
+| `HistoricalDataAllowanceExceeded` | weekly data-point quota | never rotates |
+| `RateLimitExceeded` | a bare 429 with no allowance body | not read as a per-key rejection |
+
+Rotation is enabled for non-trading REST only. Creating, amending and closing
+orders stay pinned to one key: that traffic is metered against the account, so
+moving it buys nothing and would scatter order history across sessions.
 
 A single key (no comma) behaves exactly as before.
-
-Note that the trading allowance is metered per *account*, not per key, so the
-pool raises throughput for market data — not for order placement.
 
 `Config::new()` reads configuration from the environment (and a local `.env`
 file, if present). Create a `.env` file in your project root with the

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -4,6 +4,9 @@
    Date: 4/9/24
 ******************************************************************************/
 
+//! Criterion benchmarks for the hot paths: rate-limiter pacing, request
+//! construction and DTO deserialization.
+
 use criterion::criterion_main;
 
 mod bench;

--- a/src/application/auth.rs
+++ b/src/application/auth.rs
@@ -155,9 +155,30 @@ impl Auth {
     /// Returns [`AppError::Network`] if the underlying `reqwest` client cannot
     /// be built (e.g. the system TLS backend fails to initialize).
     pub fn try_new(config: Arc<Config>) -> Result<Self, AppError> {
-        let client = Client::builder().user_agent(USER_AGENT).build()?;
-
         let rate_limiter = RateLimiter::new(&config.rate_limiter);
+        Self::with_rate_limiter(config, rate_limiter)
+    }
+
+    /// Builds an `Auth` that paces against a caller-supplied limiter.
+    ///
+    /// IG meters its allowance per API key, and a login is one of the requests
+    /// it counts. When a key's session and its data requests pace against
+    /// separate limiters, the key's real budget is the sum of the two and IG
+    /// rejects requests the client believed were within budget. Sharing one
+    /// limiter per key is what makes the local pacing match the remote one.
+    ///
+    /// # Arguments
+    /// * `config` - Configuration containing credentials and API settings
+    /// * `rate_limiter` - The limiter owned by this key
+    ///
+    /// # Errors
+    /// Returns [`AppError::Network`] if the underlying `reqwest` client cannot
+    /// be built (e.g. the system TLS backend fails to initialize).
+    pub fn with_rate_limiter(
+        config: Arc<Config>,
+        rate_limiter: RateLimiter,
+    ) -> Result<Self, AppError> {
+        let client = Client::builder().user_agent(USER_AGENT).build()?;
 
         Ok(Self {
             config,

--- a/src/application/auth.rs
+++ b/src/application/auth.rs
@@ -220,6 +220,19 @@ impl Auth {
         self.ws_info().await.unwrap_or_default()
     }
 
+    /// Whether a session is cached and not within its refresh margin.
+    ///
+    /// Lets a caller tell "this key can send right now" from "this key would
+    /// have to log in first" without triggering the login. The key pool needs
+    /// that distinction: probing every key with `get_session` would
+    /// authenticate the whole pool to serve one request.
+    pub async fn has_ready_session(&self) -> bool {
+        let session = self.session.read().await;
+        session.as_ref().is_some_and(|sess| {
+            !sess.needs_token_refresh(Some(proactive_refresh_margin_secs(sess)))
+        })
+    }
+
     /// Gets the current session, ensuring tokens are valid
     ///
     /// This method automatically refreshes expired OAuth tokens or re-authenticates if needed.
@@ -227,6 +240,9 @@ impl Auth {
     /// # Returns
     /// * `Ok(Session)` - Valid session with fresh tokens
     /// * `Err(AppError)` - If authentication fails
+    ///
+    /// # Errors
+    /// Returns [`AppError`] when login or token refresh fails.
     pub async fn get_session(&self) -> Result<Session, AppError> {
         let session = self.session.read().await;
 

--- a/src/application/auth.rs
+++ b/src/application/auth.rs
@@ -13,7 +13,7 @@
 //! - Automatic re-authentication when tokens expire
 
 use crate::application::config::Config;
-use crate::application::http::make_http_request;
+use crate::application::http::{Pacing, make_http_request_with_account};
 use crate::application::rate_limiter::RateLimiter;
 use crate::constants::USER_AGENT;
 use crate::error::{AppError, AuthError};
@@ -138,6 +138,9 @@ pub struct Auth {
     // `Arc`, so it is shared directly without an outer `RwLock`: the limiter is
     // configured once at construction and never write-swapped.
     rate_limiter: RateLimiter,
+    /// Budget shared with every other key of the account, charged on each
+    /// `/session` call just as it is on data requests: IG counts a login too.
+    account_limiter: Option<RateLimiter>,
 }
 
 impl Auth {
@@ -157,6 +160,21 @@ impl Auth {
     pub fn try_new(config: Arc<Config>) -> Result<Self, AppError> {
         let rate_limiter = RateLimiter::new(&config.rate_limiter);
         Self::with_rate_limiter(config, rate_limiter)
+    }
+
+    /// Builds an `Auth` paced against both this key's limiter and the
+    /// account-wide one.
+    ///
+    /// # Errors
+    /// Returns [`AppError::Network`] if the HTTP client cannot be built.
+    pub fn with_limiters(
+        config: Arc<Config>,
+        rate_limiter: RateLimiter,
+        account_limiter: RateLimiter,
+    ) -> Result<Self, AppError> {
+        let mut auth = Self::with_rate_limiter(config, rate_limiter)?;
+        auth.account_limiter = Some(account_limiter);
+        Ok(auth)
     }
 
     /// Builds an `Auth` that paces against a caller-supplied limiter.
@@ -185,6 +203,7 @@ impl Auth {
             client,
             session: Arc::new(RwLock::new(None)),
             rate_limiter,
+            account_limiter: None,
         })
     }
 
@@ -218,6 +237,15 @@ impl Auth {
     )]
     pub async fn get_ws_info(&self) -> WebsocketInfo {
         self.ws_info().await.unwrap_or_default()
+    }
+
+    /// The budgets a `/session` request must pass: this key's, then the
+    /// account's.
+    fn pacing(&self) -> Pacing<'_> {
+        Pacing {
+            key: &self.rate_limiter,
+            account: self.account_limiter.as_ref(),
+        }
     }
 
     /// Whether a session is cached and not within its refresh margin.
@@ -335,9 +363,9 @@ impl Auth {
             ("Version", "2"),
         ];
 
-        let response = make_http_request(
+        let response = make_http_request_with_account(
             &self.client,
-            &self.rate_limiter,
+            self.pacing(),
             Method::POST,
             &url,
             headers,
@@ -428,9 +456,9 @@ impl Auth {
             ("Version", "3"),
         ];
 
-        let response = make_http_request(
+        let response = make_http_request_with_account(
             &self.client,
-            &self.rate_limiter,
+            self.pacing(),
             Method::POST,
             &url,
             headers,
@@ -509,7 +537,7 @@ impl Auth {
     ///
     /// It cannot loop back through the 401 handler: [`login`](Self::login) issues
     /// its HTTP requests through
-    /// [`make_http_request`] directly, not
+    /// [`make_http_request_with_account`] directly, not
     /// through the [`HttpClient`](crate::application::http::HttpClient) refresh-and-replay
     /// path, so a 401 encountered *during* login surfaces as a typed error rather
     /// than recursing into `force_refresh`.
@@ -587,9 +615,9 @@ impl Auth {
             headers.push(("X-SECURITY-TOKEN", x_security_token.as_str()));
         }
 
-        let response = make_http_request(
+        let response = make_http_request_with_account(
             &self.client,
-            &self.rate_limiter,
+            self.pacing(),
             Method::PUT,
             &url,
             headers,
@@ -731,9 +759,9 @@ impl Auth {
             }
         }
 
-        match make_http_request(
+        match make_http_request_with_account(
             &self.client,
-            &self.rate_limiter,
+            self.pacing(),
             Method::DELETE,
             &url,
             headers,

--- a/src/application/config.rs
+++ b/src/application/config.rs
@@ -658,13 +658,19 @@ mod redaction_tests {
     #[test]
     fn test_api_keys_comma_separated_list_yields_pool() {
         let c = Credentials::new("u".into(), "p".into(), "ACC".into(), "a,b,c".into());
-        assert_eq!(c.api_keys(), vec!["a".to_string(), "b".to_string(), "c".to_string()]);
+        assert_eq!(
+            c.api_keys(),
+            vec!["a".to_string(), "b".to_string(), "c".to_string()]
+        );
     }
 
     #[test]
     fn test_api_keys_trims_whitespace_and_drops_empty_entries() {
         let c = Credentials::new("u".into(), "p".into(), "ACC".into(), " a , b , ,c, ".into());
-        assert_eq!(c.api_keys(), vec!["a".to_string(), "b".to_string(), "c".to_string()]);
+        assert_eq!(
+            c.api_keys(),
+            vec!["a".to_string(), "b".to_string(), "c".to_string()]
+        );
     }
 
     #[test]

--- a/src/application/http.rs
+++ b/src/application/http.rs
@@ -22,6 +22,8 @@ use reqwest::Client as HttpInternalClient;
 use reqwest::{Client, Method, Response, StatusCode};
 use serde::Serialize;
 use serde::de::DeserializeOwned;
+use std::collections::HashMap;
+use std::sync::OnceLock;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex as StdMutex};
 use std::time::{Duration, Instant};
@@ -50,6 +52,14 @@ pub struct HttpClient {
     /// N times the account's allowance and the account limit would be found the
     /// hard way.
     account_limiter: RateLimiter,
+    /// The slot whose session this client exposes, and the one trading is
+    /// pinned to.
+    ///
+    /// Normally 0. It moves when construction had to rotate because the first
+    /// key could not authenticate: pointing `auth`, `ws_info` and order traffic
+    /// at a key that failed to log in would break exactly the paths that cannot
+    /// retry elsewhere.
+    primary: usize,
     /// Round-robin starting point for slot selection.
     ///
     /// Without it every caller scans the pool from index 0, so concurrent
@@ -107,9 +117,20 @@ impl<'a> Pacing<'a> {
     /// Called immediately before the send and never earlier: taken at selection
     /// time it would be held across a wait of up to a full period, letting
     /// permits pile up and burst past the ceiling once the waits resolve.
+    ///
+    /// Non-trading and historical traffic charge the **same** bucket, because
+    /// IG's per-account non-trading allowance is one budget: giving each class
+    /// its own account bucket would let `/prices` and market data each run to
+    /// 30/min and together exceed it. Trading does not charge it at all — IG
+    /// meters order traffic against a separate trading allowance, and pacing it
+    /// against the non-trading ceiling would throttle orders behind bulk reads.
     async fn charge_account(&self, class: RateLimitClass) {
+        if class == RateLimitClass::Trading {
+            return;
+        }
         if let Some(account) = self.account {
-            account.wait_for(class).await;
+            // One flat bucket: the class is deliberately collapsed.
+            account.wait_for(RateLimitClass::NonTrading).await;
         }
     }
 }
@@ -188,13 +209,17 @@ impl HttpClient {
         // Build the pool first: every slot owns a single-key `Config`, so the
         // client's own `Auth` is slot 0's rather than one built from the raw
         // config, whose `api_key` may be the whole comma-separated list.
-        let account_limiter = Self::build_account_limiter();
+        let account_limiter = Self::build_account_limiter(&config.credentials.account_id);
         let (auth, pool) = Self::build_pool(&config, &account_limiter)?;
 
         // Log in on the first key that will have us: an allowance rejection on
         // one key says nothing about the others, so construction rotates too
-        // rather than failing on slot 0.
-        Self::login_any(&pool).await?;
+        // rather than failing on slot 0. Whichever key answered becomes the
+        // primary, so the session this client exposes is one that exists.
+        let primary = Self::login_any(&pool).await?;
+        let auth = pool
+            .get(primary)
+            .map_or_else(|| auth.clone(), |slot| slot.auth.clone());
 
         Ok(Self {
             auth,
@@ -202,6 +227,7 @@ impl HttpClient {
             config,
             pool,
             account_limiter,
+            primary,
             cursor: AtomicUsize::new(0),
         })
     }
@@ -219,7 +245,7 @@ impl HttpClient {
             .build()?;
         // Same as `new`: the client's `Auth` is the pool's first slot, never an
         // `Auth` built from a config whose `api_key` is the whole pool list.
-        let account_limiter = Self::build_account_limiter();
+        let account_limiter = Self::build_account_limiter(&config.credentials.account_id);
         let (auth, pool) = Self::build_pool(&config, &account_limiter)?;
 
         Ok(Self {
@@ -228,6 +254,7 @@ impl HttpClient {
             config,
             pool,
             account_limiter,
+            primary: 0,
             cursor: AtomicUsize::new(0),
         })
     }
@@ -314,17 +341,32 @@ impl HttpClient {
     /// period silently raise it. The burst is one, so the allowance is spent
     /// evenly instead of discharging thirty requests at once and then stalling.
     ///
-    /// **This coordinates one process only.** It is an in-process token bucket,
-    /// so two services authenticating the same IG account each pace themselves
-    /// to the ceiling and together exceed it. Keeping an account inside one
-    /// process, or giving each service its own account, is what actually
-    /// enforces it.
-    fn build_account_limiter() -> RateLimiter {
-        RateLimiter::new(&RateLimiterConfig {
-            max_requests: ACCOUNT_MAX_REQUESTS_PER_MINUTE,
-            period_seconds: ACCOUNT_PERIOD_SECONDS,
-            burst_size: 1,
-        })
+    /// Shared per process **and per account**: every `HttpClient` built for the
+    /// same `account_id` gets the same bucket, so two clients in one service do
+    /// not each pace to the full ceiling.
+    ///
+    /// **It does not coordinate across processes.** Two services authenticating
+    /// the same IG account hold two buckets and together exceed the ceiling.
+    /// Enforcing it across services needs a distributed limiter, or an account
+    /// per service — which is the arrangement this codebase actually uses.
+    fn build_account_limiter(account_id: &str) -> RateLimiter {
+        static ACCOUNT_LIMITERS: OnceLock<StdMutex<HashMap<String, RateLimiter>>> = OnceLock::new();
+
+        let registry = ACCOUNT_LIMITERS.get_or_init(|| StdMutex::new(HashMap::new()));
+        let mut guard = match registry.lock() {
+            Ok(g) => g,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        guard
+            .entry(account_id.to_string())
+            .or_insert_with(|| {
+                RateLimiter::new(&RateLimiterConfig {
+                    max_requests: ACCOUNT_MAX_REQUESTS_PER_MINUTE,
+                    period_seconds: ACCOUNT_PERIOD_SECONDS,
+                    burst_size: 1,
+                })
+            })
+            .clone()
     }
 
     /// Logs in on the first key of the pool that accepts us.
@@ -333,13 +375,19 @@ impl HttpClient {
     /// about the other keys; failing construction on slot 0 would throw the
     /// whole pool away over one spent key.
     ///
+    /// # Returns
+    ///
+    /// The index of the slot that authenticated. The caller adopts it as the
+    /// client's primary: leaving `auth` on a key that could not log in would
+    /// point streaming, `ws_info` and trading at the exhausted key.
+    ///
     /// # Errors
     /// Returns the last key's error when no key could authenticate.
-    async fn login_any(pool: &[KeySlot]) -> Result<(), AppError> {
+    async fn login_any(pool: &[KeySlot]) -> Result<usize, AppError> {
         let mut last: Option<AppError> = None;
-        for slot in pool {
+        for (index, slot) in pool.iter().enumerate() {
             match slot.auth.login().await {
-                Ok(_) => return Ok(()),
+                Ok(_) => return Ok(index),
                 Err(e @ AppError::ApiKeyAllowanceExceeded) => {
                     slot.mark_exhausted();
                     warn!(
@@ -393,12 +441,13 @@ impl HttpClient {
         // Trading stays pinned to one slot, so two consecutive orders always
         // travel on the same key and the same session.
         if class == RateLimitClass::Trading {
-            if tried.contains(&0) {
+            let primary = self.primary.min(self.pool.len().saturating_sub(1));
+            if tried.contains(&primary) {
                 return Ok(None);
             }
-            self.pool[0].rate_limiter.reserve(class).await;
-            self.pool[0].auth.get_session().await?;
-            return Ok(Some(0));
+            self.pool[primary].rate_limiter.reserve(class).await;
+            self.pool[primary].auth.get_session().await?;
+            return Ok(Some(primary));
         }
 
         let len = self.pool.len();

--- a/src/application/http.rs
+++ b/src/application/http.rs
@@ -13,7 +13,7 @@
 //! layer must not perform I/O.
 
 use crate::application::auth::{Auth, Session, WebsocketInfo};
-use crate::application::config::Config;
+use crate::application::config::{Config, RateLimiterConfig};
 use crate::application::rate_limiter::{RateLimitClass, RateLimiter};
 use crate::constants::USER_AGENT;
 use crate::error::AppError;
@@ -43,6 +43,13 @@ pub struct HttpClient {
     /// [`RateLimiter`] as the fields above, so a single-key configuration keeps
     /// the historical behaviour exactly.
     pool: Vec<KeySlot>,
+    /// Budget shared by the whole pool.
+    ///
+    /// IG documents a per-account ceiling on top of the per-key one, and every
+    /// key here authenticates the same account. Without this, N keys would pace
+    /// N times the account's allowance and the account limit would be found the
+    /// hard way.
+    account_limiter: RateLimiter,
     /// Round-robin starting point for slot selection.
     ///
     /// Without it every caller scans the pool from index 0, so concurrent
@@ -74,6 +81,13 @@ struct KeySlot {
 /// long that the pool shrinks under sustained load.
 const KEY_COOLDOWN: Duration = Duration::from_secs(60);
 
+/// IG's documented non-trading ceiling for one account, in requests per minute.
+///
+/// Measurement never reached it — four keys sustained 32/min with no rejection —
+/// but it is the published limit, so the pool paces below it rather than
+/// discovering it in production.
+const ACCOUNT_MAX_REQUESTS_PER_MINUTE: u32 = 30;
+
 /// Renders an API key for logs as its first eight characters.
 ///
 /// Enough to tell the pool's keys apart when reading a trace, never enough to
@@ -93,6 +107,15 @@ impl KeySlot {
             Err(poisoned) => poisoned.into_inner(),
         };
         guard.is_some_and(|until| Instant::now() < until)
+    }
+
+    /// When this slot's cooldown ends, if it is in one.
+    fn cooldown_deadline(&self) -> Option<Instant> {
+        let guard = match self.cooldown_until.lock() {
+            Ok(g) => g,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        guard.filter(|&until| Instant::now() < until)
     }
 
     /// Marks the key as exhausted for [`KEY_COOLDOWN`].
@@ -130,6 +153,7 @@ impl HttpClient {
         // client's own `Auth` is slot 0's rather than one built from the raw
         // config, whose `api_key` may be the whole comma-separated list.
         let (auth, pool) = Self::build_pool(&config)?;
+        let account_limiter = Self::build_account_limiter(&config, pool.len());
 
         // Perform initial login on the first key of the pool
         auth.login().await?;
@@ -139,6 +163,7 @@ impl HttpClient {
             http_client,
             config,
             pool,
+            account_limiter,
             cursor: AtomicUsize::new(0),
         })
     }
@@ -157,12 +182,14 @@ impl HttpClient {
         // Same as `new`: the client's `Auth` is the pool's first slot, never an
         // `Auth` built from a config whose `api_key` is the whole pool list.
         let (auth, pool) = Self::build_pool(&config)?;
+        let account_limiter = Self::build_account_limiter(&config, pool.len());
 
         Ok(Self {
             auth,
             http_client,
             config,
             pool,
+            account_limiter,
             cursor: AtomicUsize::new(0),
         })
     }
@@ -230,6 +257,40 @@ impl HttpClient {
         Ok((auth, pool))
     }
 
+    /// Builds the pool-wide budget that models IG's per-account ceiling.
+    ///
+    /// The per-key budget is what the config expresses, so the account's is
+    /// derived from it: `keys x max_requests`, capped at
+    /// [`ACCOUNT_MAX_REQUESTS_PER_MINUTE`]. With one key it is never the binding
+    /// constraint, which keeps single-key behaviour unchanged; with many it
+    /// stops the pool from pacing past what the account allows.
+    fn build_account_limiter(config: &Arc<Config>, keys: usize) -> RateLimiter {
+        let per_key = config.rate_limiter.max_requests;
+        let keys = u32::try_from(keys).unwrap_or(u32::MAX);
+        let aggregate = per_key.saturating_mul(keys);
+
+        let period = config.rate_limiter.period_seconds.max(1);
+        // Scale the documented per-minute ceiling to the configured period so
+        // the comparison is like for like.
+        let ceiling = u32::try_from(
+            u64::from(ACCOUNT_MAX_REQUESTS_PER_MINUTE)
+                .saturating_mul(period)
+                .div_ceil(60),
+        )
+        .unwrap_or(u32::MAX)
+        .max(1);
+
+        let max_requests = aggregate.min(ceiling);
+        RateLimiter::new(&RateLimiterConfig {
+            max_requests,
+            period_seconds: config.rate_limiter.period_seconds,
+            // The burst is the bucket's capacity, so leaving the per-key burst
+            // here would let the pool discharge far more than the ceiling in one
+            // go and the cap would only bind on the average.
+            burst_size: config.rate_limiter.burst_size.min(max_requests),
+        })
+    }
+
     /// Reserves a token from a usable key, waiting only if every key is empty.
     ///
     /// This is the proactive half of the pool: a key is left before it is
@@ -237,11 +298,19 @@ impl HttpClient {
     /// already given up one token, so the caller owes exactly one request and
     /// must not pace it again.
     ///
-    /// Selection starts at a shared round-robin cursor so concurrent callers
-    /// walk the pool from different points instead of all piling onto the first
-    /// key. Keys in cooldown are skipped; when none can serve immediately, the
-    /// pool waits on *all* candidates at once and takes whichever refills
-    /// first, rather than blocking on an arbitrary one.
+    /// Trading never spreads. Order traffic is metered against the account, so
+    /// rotating buys nothing, and keeping it on one key keeps a position's
+    /// requests inside one session — which is what makes a reconciliation
+    /// possible. Trading therefore always uses slot 0 and does not touch the
+    /// cursor.
+    ///
+    /// For everything else, selection starts at a shared round-robin cursor so
+    /// concurrent callers walk the pool from different points instead of piling
+    /// onto the first key. It runs in two passes so that serving one request
+    /// never authenticates the whole pool: first the keys that already hold a
+    /// session, then — only if none of those had a token — a single key that
+    /// still has to log in. When nothing can serve, the pool waits on every
+    /// candidate at once and takes whichever refills first.
     ///
     /// # Returns
     ///
@@ -250,18 +319,29 @@ impl HttpClient {
     ///
     /// # Errors
     ///
-    /// Returns whatever [`Auth::get_session`] reports when the winning key
-    /// cannot authenticate.
+    /// Returns whatever [`Auth::get_session`] reports when the chosen key
+    /// cannot authenticate, unless that is a per-key allowance rejection: that
+    /// one parks the key and moves on, because another key can still serve.
     async fn reserve_slot(
         &self,
         class: RateLimitClass,
         tried: &[usize],
     ) -> Result<Option<usize>, AppError> {
+        // Trading stays pinned to one slot, so two consecutive orders always
+        // travel on the same key and the same session.
+        if class == RateLimitClass::Trading {
+            if tried.contains(&0) {
+                return Ok(None);
+            }
+            self.account_limiter.reserve(class).await;
+            self.pool[0].rate_limiter.reserve(class).await;
+            self.pool[0].auth.get_session().await?;
+            return Ok(Some(0));
+        }
+
         let len = self.pool.len();
         let start = self.cursor.fetch_add(1, Ordering::Relaxed);
 
-        // Rotate the walk order so that, under concurrency, two callers do not
-        // both hand their request to slot 0.
         let candidates: Vec<usize> = (0..len)
             .map(|offset| start.wrapping_add(offset) % len)
             .filter(|i| !tried.contains(i))
@@ -270,33 +350,87 @@ impl HttpClient {
             return Ok(None);
         }
 
-        // Fast path: someone can serve right now. The session is established
-        // first and the token taken only once it holds, so a failed login costs
-        // its own request and never a data token that is not spent.
+        // The account-wide budget is shared by every key, so it is charged once
+        // per request regardless of which key ends up serving it.
+        self.account_limiter.reserve(class).await;
+
+        // Pass 1: keys that can send without logging in first.
         for &i in &candidates {
             let slot = &self.pool[i];
-            if slot.in_cooldown() {
+            if slot.in_cooldown() || !slot.auth.has_ready_session().await {
                 continue;
             }
-            // `governor` has no way to look at a bucket without taking from it,
-            // so the order is what protects the token: authenticate first, take
-            // the token second. A key that turns out to be empty has at most had
-            // its session established, which it needs anyway.
-            slot.auth.get_session().await?;
             if slot.rate_limiter.try_reserve(class) {
                 return Ok(Some(i));
             }
         }
 
-        // Everything is empty (or cooling down). Wait on every candidate at
-        // once and keep the first token to appear; the losing futures are
-        // dropped before they take one.
+        // Pass 2: at most one key is authenticated, and only when no ready key
+        // had a token. A login that hits this key's allowance parks it and the
+        // next candidate is tried, rather than burning three backoffs here.
+        for &i in &candidates {
+            let slot = &self.pool[i];
+            if slot.in_cooldown() || slot.auth.has_ready_session().await {
+                continue;
+            }
+            match slot.auth.get_session().await {
+                Ok(_) => {}
+                Err(AppError::ApiKeyAllowanceExceeded) if self.pool.len() > 1 => {
+                    slot.mark_exhausted();
+                    warn!(
+                        key = %redact_key(&slot.api_key),
+                        "API key allowance exhausted during login, trying another key"
+                    );
+                    continue;
+                }
+                Err(e) => return Err(e),
+            }
+            if slot.rate_limiter.try_reserve(class) {
+                return Ok(Some(i));
+            }
+            // Authenticated but out of tokens: fall through to the wait below
+            // rather than logging in yet another key.
+            break;
+        }
+
+        // Nothing can serve now. Wait on the keys that are not cooling down; if
+        // every one of them is, wait out the shortest cooldown first so the
+        // pool honours it instead of hammering a key IG has already refused.
         let live: Vec<usize> = candidates
             .iter()
             .copied()
             .filter(|&i| !self.pool[i].in_cooldown())
             .collect();
-        let waiting = if live.is_empty() { candidates } else { live };
+
+        let waiting = if live.is_empty() {
+            if let Some(until) = candidates
+                .iter()
+                .filter_map(|&i| self.pool[i].cooldown_deadline())
+                .min()
+            {
+                let now = Instant::now();
+                if until > now {
+                    debug!(
+                        wait_ms = (until - now).as_millis(),
+                        "every key is cooling down"
+                    );
+                    tokio::time::sleep(until - now).await;
+                }
+            }
+            candidates
+        } else {
+            live
+        };
+
+        // Prefer keys that already hold a session: if one of those refills
+        // first, serving this request costs no extra login.
+        let mut ready = Vec::with_capacity(waiting.len());
+        for &i in &waiting {
+            if self.pool[i].auth.has_ready_session().await {
+                ready.push(i);
+            }
+        }
+        let waiting = if ready.is_empty() { waiting } else { ready };
 
         let waits: Vec<_> = waiting
             .iter()
@@ -311,9 +445,9 @@ impl HttpClient {
 
         let (winner, _, _) = futures::future::select_all(waits).await;
 
-        // The token for the winner is already spent, so a login failure here
-        // does cost it. Establishing the session before the wait is not an
-        // option: which key wins is only known once one refills.
+        // The winner's token is already spent, so a login failure here does cost
+        // it. Establishing the session earlier is not possible: which key wins
+        // is only known once one refills.
         self.pool[winner].auth.get_session().await?;
         Ok(Some(winner))
     }
@@ -446,24 +580,14 @@ impl HttpClient {
         version: Option<u8>,
         extra_headers: &[(&str, &str)],
     ) -> Result<T, AppError> {
-        match self
-            .request_internal(method.clone(), path, &body, version, extra_headers)
-            .await
-        {
-            Ok(response) => self.parse_response(response).await,
-            Err(AppError::OAuthTokenExpired) => {
-                warn!("OAuth token expired, forcing refresh and retrying once");
-                // Force a fresh login so the single replay below never resends
-                // the same server-invalidated token. This match arm is not a
-                // loop: the replay happens exactly once.
-                self.auth.force_refresh().await?;
-                let response = self
-                    .request_internal(method, path, &body, version, extra_headers)
-                    .await?;
-                self.parse_response(response).await
-            }
-            Err(e) => Err(e),
-        }
+        // The refresh-and-replay lives in `request_internal`, which knows which
+        // slot's session IG rejected. Refreshing here would always refresh slot
+        // 0, so an expired token on any other key of the pool would be replayed
+        // unchanged and fail again.
+        let response = self
+            .request_internal(method, path, &body, version, extra_headers)
+            .await?;
+        self.parse_response(response).await
     }
 
     /// Builds and sends a single HTTP request against the IG API.
@@ -499,6 +623,8 @@ impl HttpClient {
         let may_rotate = class == RateLimitClass::NonTrading && self.pool.len() > 1;
 
         let mut tried: Vec<usize> = Vec::with_capacity(self.pool.len());
+        // One replay after a forced refresh, never a loop of them.
+        let mut replayed = false;
 
         loop {
             let Some(idx) = self.reserve_slot(class, &tried).await? else {
@@ -528,14 +654,31 @@ impl HttpClient {
                 .await;
 
             match result {
-                // Per-key allowance: this key is spent, another one is not.
-                Err(AppError::ApiKeyAllowanceExceeded) if rotate => {
+                // Per-key allowance: this key is spent. Mark it either way, so a
+                // key IG has just refused is not handed the next request even
+                // when there is nowhere left to rotate for this one.
+                Err(AppError::ApiKeyAllowanceExceeded) => {
                     slot.mark_exhausted();
+                    if !rotate {
+                        return Err(AppError::ApiKeyAllowanceExceeded);
+                    }
                     warn!(
                         key = %redact_key(&slot.api_key),
                         of = self.pool.len(),
                         "API key allowance exhausted, rotating to another key"
                     );
+                }
+                // The token IG rejected belongs to this slot's session, so the
+                // refresh has to happen on that slot - not on the client's own
+                // `auth`, which is slot 0 and may be a different key entirely.
+                Err(AppError::OAuthTokenExpired) if !replayed => {
+                    warn!(
+                        key = %redact_key(&slot.api_key),
+                        "OAuth token expired, refreshing this key's session and replaying once"
+                    );
+                    slot.auth.force_refresh().await?;
+                    replayed = true;
+                    tried.pop();
                 }
                 // Account and trading allowances belong to the account every key
                 // authenticates, and a bare 429 does not say which budget ran
@@ -843,14 +986,22 @@ pub async fn make_http_request_reserved<B: Serialize>(
                 // it, so each one gets its own error instead of collapsing into
                 // a single "rate limited".
                 if body_text.contains("exceeded-api-key-allowance") {
+                    // Fail fast rather than spending ~76 s of backoff on a key
+                    // that has just said it is empty. With a pool the caller
+                    // rotates immediately - including on `/session`, where the
+                    // backoff used to be paid before any rotation could happen -
+                    // and with a single key the caller learns sooner.
                     warn!("api key allowance exceeded");
-                    AppError::ApiKeyAllowanceExceeded
+                    return Err(AppError::ApiKeyAllowanceExceeded);
                 } else if body_text.contains("exceeded-account-trading-allowance") {
                     warn!("account trading allowance exceeded");
                     return Err(AppError::TradingAllowanceExceeded);
                 } else if body_text.contains("exceeded-account-allowance") {
+                    // Every key of a pool authenticates this same account, so
+                    // retrying here only spends more of an allowance that is
+                    // already gone. Fail fast and let the caller back off.
                     warn!("account allowance exceeded");
-                    AppError::AccountAllowanceExceeded
+                    return Err(AppError::AccountAllowanceExceeded);
                 } else {
                     error!(status = ?status, "forbidden");
                     return Err(AppError::Unexpected(status));

--- a/src/application/http.rs
+++ b/src/application/http.rs
@@ -469,6 +469,11 @@ impl HttpClient {
                 continue;
             }
             if slot.rate_limiter.try_reserve(class) {
+                // An already-authenticated key is just as valid a primary as one
+                // that had to log in. Promoting only in pass 2 left trading and
+                // streaming pointing at a parked primary whenever the fallback
+                // happened to hold a session already.
+                self.promote_primary_if_needed(i);
                 return Ok(Some(i));
             }
         }
@@ -903,9 +908,9 @@ impl HttpClient {
     ///
     /// # Errors
     ///
-    /// Returns [`AppError::UnsupportedWithKeyPool`] when the client was built
-    /// with more than one API key, and whatever [`Auth::switch_account`]
-    /// reports otherwise.
+    /// Returns [`AppError::InvalidInput`] when the client was built with more
+    /// than one API key, and whatever [`Auth::switch_account`] reports
+    /// otherwise.
     ///
     /// Switching is refused with a pool because it cannot be done coherently
     /// here: each key holds its own session, so switching only the primary
@@ -922,9 +927,10 @@ impl HttpClient {
         default_account: Option<bool>,
     ) -> Result<(), AppError> {
         if self.pool.len() > 1 {
-            return Err(AppError::UnsupportedWithKeyPool(
-                "switch_account cannot be applied coherently to a multi-key pool; \
-                 build one client per account"
+            return Err(AppError::InvalidInput(
+                "switch_account cannot be applied coherently to a multi-key pool: \
+                 each key holds its own session and the account keys the shared \
+                 account-wide budget; build one client per account"
                     .to_string(),
             ));
         }

--- a/src/application/http.rs
+++ b/src/application/http.rs
@@ -81,12 +81,48 @@ struct KeySlot {
 /// long that the pool shrinks under sustained load.
 const KEY_COOLDOWN: Duration = Duration::from_secs(60);
 
-/// IG's documented non-trading ceiling for one account, in requests per minute.
+/// The two budgets every physical request has to pass.
+///
+/// IG meters an allowance per API key *and* one per account, and a pool draws
+/// on both at once: the key's own bucket and the account bucket its keys share.
+/// Both are charged per HTTP request actually sent — logins, token refreshes
+/// and retries included — because that is what IG counts.
+#[derive(Clone, Copy)]
+pub struct Pacing<'a> {
+    /// The budget of the API key serving this request.
+    pub key: &'a RateLimiter,
+    /// The budget shared by every key of the account, when one is configured.
+    pub account: Option<&'a RateLimiter>,
+}
+
+impl<'a> Pacing<'a> {
+    /// Pacing against one key only, with no account-wide budget.
+    #[must_use]
+    pub const fn key_only(key: &'a RateLimiter) -> Self {
+        Self { key, account: None }
+    }
+
+    /// Takes an account token, if an account budget is configured.
+    ///
+    /// Called immediately before the send and never earlier: taken at selection
+    /// time it would be held across a wait of up to a full period, letting
+    /// permits pile up and burst past the ceiling once the waits resolve.
+    async fn charge_account(&self, class: RateLimitClass) {
+        if let Some(account) = self.account {
+            account.wait_for(class).await;
+        }
+    }
+}
+
+/// IG's documented non-trading ceiling for one account.
 ///
 /// Measurement never reached it — four keys sustained 32/min with no rejection —
 /// but it is the published limit, so the pool paces below it rather than
 /// discovering it in production.
 const ACCOUNT_MAX_REQUESTS_PER_MINUTE: u32 = 30;
+
+/// The window [`ACCOUNT_MAX_REQUESTS_PER_MINUTE`] is measured over.
+const ACCOUNT_PERIOD_SECONDS: u64 = 60;
 
 /// Renders an API key for logs as its first eight characters.
 ///
@@ -152,11 +188,13 @@ impl HttpClient {
         // Build the pool first: every slot owns a single-key `Config`, so the
         // client's own `Auth` is slot 0's rather than one built from the raw
         // config, whose `api_key` may be the whole comma-separated list.
-        let (auth, pool) = Self::build_pool(&config)?;
-        let account_limiter = Self::build_account_limiter(&config, pool.len());
+        let account_limiter = Self::build_account_limiter();
+        let (auth, pool) = Self::build_pool(&config, &account_limiter)?;
 
-        // Perform initial login on the first key of the pool
-        auth.login().await?;
+        // Log in on the first key that will have us: an allowance rejection on
+        // one key says nothing about the others, so construction rotates too
+        // rather than failing on slot 0.
+        Self::login_any(&pool).await?;
 
         Ok(Self {
             auth,
@@ -181,8 +219,8 @@ impl HttpClient {
             .build()?;
         // Same as `new`: the client's `Auth` is the pool's first slot, never an
         // `Auth` built from a config whose `api_key` is the whole pool list.
-        let (auth, pool) = Self::build_pool(&config)?;
-        let account_limiter = Self::build_account_limiter(&config, pool.len());
+        let account_limiter = Self::build_account_limiter();
+        let (auth, pool) = Self::build_pool(&config, &account_limiter)?;
 
         Ok(Self {
             auth,
@@ -213,7 +251,10 @@ impl HttpClient {
     /// The pool and the first slot's [`Auth`], which the client adopts as its
     /// own. Returning it here is what guarantees the client never holds an
     /// `Auth` built from the raw multi-key config.
-    fn build_pool(config: &Arc<Config>) -> Result<(Arc<Auth>, Vec<KeySlot>), AppError> {
+    fn build_pool(
+        config: &Arc<Config>,
+        account_limiter: &RateLimiter,
+    ) -> Result<(Arc<Auth>, Vec<KeySlot>), AppError> {
         let keys = config.credentials.api_keys();
         // An empty list means the value held no usable key; keep the raw value
         // so the failure surfaces as IG rejecting it, not as an empty pool.
@@ -231,7 +272,11 @@ impl HttpClient {
             let key_config = Arc::new(key_config);
 
             let key_limiter = RateLimiter::new(&key_config.rate_limiter);
-            let key_auth = Arc::new(Auth::with_rate_limiter(key_config, key_limiter.clone())?);
+            let key_auth = Arc::new(Auth::with_limiters(
+                key_config,
+                key_limiter.clone(),
+                account_limiter.clone(),
+            )?);
             if first_auth.is_none() {
                 first_auth = Some(key_auth.clone());
             }
@@ -252,43 +297,61 @@ impl HttpClient {
         // panic.
         let auth = match first_auth {
             Some(auth) => auth,
-            None => Arc::new(Auth::try_new(config.clone())?),
+            None => Arc::new(Auth::with_limiters(
+                config.clone(),
+                RateLimiter::new(&config.rate_limiter),
+                account_limiter.clone(),
+            )?),
         };
         Ok((auth, pool))
     }
 
     /// Builds the pool-wide budget that models IG's per-account ceiling.
     ///
-    /// The per-key budget is what the config expresses, so the account's is
-    /// derived from it: `keys x max_requests`, capped at
-    /// [`ACCOUNT_MAX_REQUESTS_PER_MINUTE`]. With one key it is never the binding
-    /// constraint, which keeps single-key behaviour unchanged; with many it
-    /// stops the pool from pacing past what the account allows.
-    fn build_account_limiter(config: &Arc<Config>, keys: usize) -> RateLimiter {
-        let per_key = config.rate_limiter.max_requests;
-        let keys = u32::try_from(keys).unwrap_or(u32::MAX);
-        let aggregate = per_key.saturating_mul(keys);
-
-        let period = config.rate_limiter.period_seconds.max(1);
-        // Scale the documented per-minute ceiling to the configured period so
-        // the comparison is like for like.
-        let ceiling = u32::try_from(
-            u64::from(ACCOUNT_MAX_REQUESTS_PER_MINUTE)
-                .saturating_mul(period)
-                .div_ceil(60),
-        )
-        .unwrap_or(u32::MAX)
-        .max(1);
-
-        let max_requests = aggregate.min(ceiling);
+    /// Modelled directly as IG documents it — 30 requests per 60 seconds — not
+    /// derived from the per-key configuration: the account ceiling is a property
+    /// of the account, and scaling it by the configured period made a shorter
+    /// period silently raise it. The burst is one, so the allowance is spent
+    /// evenly instead of discharging thirty requests at once and then stalling.
+    ///
+    /// **This coordinates one process only.** It is an in-process token bucket,
+    /// so two services authenticating the same IG account each pace themselves
+    /// to the ceiling and together exceed it. Keeping an account inside one
+    /// process, or giving each service its own account, is what actually
+    /// enforces it.
+    fn build_account_limiter() -> RateLimiter {
         RateLimiter::new(&RateLimiterConfig {
-            max_requests,
-            period_seconds: config.rate_limiter.period_seconds,
-            // The burst is the bucket's capacity, so leaving the per-key burst
-            // here would let the pool discharge far more than the ceiling in one
-            // go and the cap would only bind on the average.
-            burst_size: config.rate_limiter.burst_size.min(max_requests),
+            max_requests: ACCOUNT_MAX_REQUESTS_PER_MINUTE,
+            period_seconds: ACCOUNT_PERIOD_SECONDS,
+            burst_size: 1,
         })
+    }
+
+    /// Logs in on the first key of the pool that accepts us.
+    ///
+    /// A key whose allowance is exhausted rejects the login, which says nothing
+    /// about the other keys; failing construction on slot 0 would throw the
+    /// whole pool away over one spent key.
+    ///
+    /// # Errors
+    /// Returns the last key's error when no key could authenticate.
+    async fn login_any(pool: &[KeySlot]) -> Result<(), AppError> {
+        let mut last: Option<AppError> = None;
+        for slot in pool {
+            match slot.auth.login().await {
+                Ok(_) => return Ok(()),
+                Err(e @ AppError::ApiKeyAllowanceExceeded) => {
+                    slot.mark_exhausted();
+                    warn!(
+                        key = %redact_key(&slot.api_key),
+                        "API key allowance exhausted at login, trying the next key"
+                    );
+                    last = Some(e);
+                }
+                Err(e) => return Err(e),
+            }
+        }
+        Err(last.unwrap_or(AppError::ApiKeyAllowanceExceeded))
     }
 
     /// Reserves a token from a usable key, waiting only if every key is empty.
@@ -333,7 +396,6 @@ impl HttpClient {
             if tried.contains(&0) {
                 return Ok(None);
             }
-            self.account_limiter.reserve(class).await;
             self.pool[0].rate_limiter.reserve(class).await;
             self.pool[0].auth.get_session().await?;
             return Ok(Some(0));
@@ -349,10 +411,6 @@ impl HttpClient {
         if candidates.is_empty() {
             return Ok(None);
         }
-
-        // The account-wide budget is shared by every key, so it is charged once
-        // per request regardless of which key ends up serving it.
-        self.account_limiter.reserve(class).await;
 
         // Pass 1: keys that can send without logging in first.
         for &i in &candidates {
@@ -731,9 +789,12 @@ impl HttpClient {
             headers.push(("X-SECURITY-TOKEN", token_val.as_str()));
         }
 
-        make_http_request_reserved(
+        make_http_request_paced(
             &self.http_client,
-            &slot.rate_limiter,
+            Pacing {
+                key: &slot.rate_limiter,
+                account: Some(&self.account_limiter),
+            },
             method.clone(),
             url,
             headers,
@@ -892,9 +953,37 @@ pub async fn make_http_request<B: Serialize>(
     body: &Option<B>,
     retry_config: RetryConfig,
 ) -> Result<Response, AppError> {
-    make_http_request_reserved(
+    make_http_request_paced(
         client,
-        rate_limiter,
+        Pacing::key_only(rate_limiter),
+        method,
+        url,
+        headers,
+        body,
+        retry_config,
+        false,
+    )
+    .await
+}
+
+/// Same as [`make_http_request`], but paced against a key budget *and* the
+/// account budget its keys share.
+///
+/// # Errors
+/// Same as [`make_http_request`].
+#[allow(clippy::too_many_arguments)]
+pub async fn make_http_request_with_account<B: Serialize>(
+    client: &Client,
+    pacing: Pacing<'_>,
+    method: Method,
+    url: &str,
+    headers: Vec<(&str, &str)>,
+    body: &Option<B>,
+    retry_config: RetryConfig,
+) -> Result<Response, AppError> {
+    make_http_request_paced(
+        client,
+        pacing,
         method,
         url,
         headers,
@@ -922,6 +1011,41 @@ pub async fn make_http_request_reserved<B: Serialize>(
     retry_config: RetryConfig,
     reserved: bool,
 ) -> Result<Response, AppError> {
+    make_http_request_paced(
+        client,
+        Pacing::key_only(rate_limiter),
+        method,
+        url,
+        headers,
+        body,
+        retry_config,
+        reserved,
+    )
+    .await
+}
+
+/// The one place a request is actually sent, and so the one place both budgets
+/// are charged.
+///
+/// `reserved = true` means the caller already holds this key's token for the
+/// first send. The account budget is never pre-reserved: it is taken here,
+/// immediately before each send, so logins, refreshes and every retry pay it
+/// too.
+///
+/// # Errors
+/// Same as [`make_http_request`].
+#[allow(clippy::too_many_arguments)]
+pub async fn make_http_request_paced<B: Serialize>(
+    client: &Client,
+    pacing: Pacing<'_>,
+    method: Method,
+    url: &str,
+    headers: Vec<(&str, &str)>,
+    body: &Option<B>,
+    retry_config: RetryConfig,
+    reserved: bool,
+) -> Result<Response, AppError> {
+    let rate_limiter = pacing.key;
     let max_retries = retry_config.max_retries();
 
     // Pace this request against the bucket for its endpoint class (trading /
@@ -941,6 +1065,10 @@ pub async fn make_http_request_reserved<B: Serialize>(
         if attempt > 0 || !reserved {
             rate_limiter.wait_for(class).await;
         }
+
+        // Last gate before the wire: the account budget is charged per physical
+        // request, so a retry costs another token just as a first send does.
+        pacing.charge_account(class).await;
 
         debug!(%method, %url, class = ?class, "http request");
 

--- a/src/application/http.rs
+++ b/src/application/http.rs
@@ -22,6 +22,7 @@ use reqwest::Client as HttpInternalClient;
 use reqwest::{Client, Method, Response, StatusCode};
 use serde::Serialize;
 use serde::de::DeserializeOwned;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex as StdMutex};
 use std::time::{Duration, Instant};
 use tracing::{debug, error, warn};
@@ -42,6 +43,12 @@ pub struct HttpClient {
     /// [`RateLimiter`] as the fields above, so a single-key configuration keeps
     /// the historical behaviour exactly.
     pool: Vec<KeySlot>,
+    /// Round-robin starting point for slot selection.
+    ///
+    /// Without it every caller scans the pool from index 0, so concurrent
+    /// requests pile onto the first key while the rest sit idle. Advancing it
+    /// per selection spreads equally-available keys evenly.
+    cursor: AtomicUsize,
 }
 
 /// One API key of the pool, with the session and pacing budget that belong to it.
@@ -119,22 +126,20 @@ impl HttpClient {
         let http_client = HttpInternalClient::builder()
             .user_agent(USER_AGENT)
             .build()?;
-        let rate_limiter = RateLimiter::new(&config.rate_limiter);
+        // Build the pool first: every slot owns a single-key `Config`, so the
+        // client's own `Auth` is slot 0's rather than one built from the raw
+        // config, whose `api_key` may be the whole comma-separated list.
+        let (auth, pool) = Self::build_pool(&config)?;
 
-        // Create Auth instance via the fallible constructor so this path never
-        // panics on a broken TLS backend.
-        let auth = Arc::new(Auth::try_new(config.clone())?);
-
-        // Perform initial login
+        // Perform initial login on the first key of the pool
         auth.login().await?;
-
-        let pool = Self::build_pool(&config, &auth, &rate_limiter)?;
 
         Ok(Self {
             auth,
             http_client,
             config,
             pool,
+            cursor: AtomicUsize::new(0),
         })
     }
 
@@ -149,60 +154,64 @@ impl HttpClient {
         let http_client = HttpInternalClient::builder()
             .user_agent(USER_AGENT)
             .build()?;
-        let rate_limiter = RateLimiter::new(&config.rate_limiter);
-
-        // Create Auth instance via the fallible constructor so the whole
-        // `new_lazy` path (and `Client::try_new` built on it) never panics.
-        let auth = Arc::new(Auth::try_new(config.clone())?);
-
-        let pool = Self::build_pool(&config, &auth, &rate_limiter)?;
+        // Same as `new`: the client's `Auth` is the pool's first slot, never an
+        // `Auth` built from a config whose `api_key` is the whole pool list.
+        let (auth, pool) = Self::build_pool(&config)?;
 
         Ok(Self {
             auth,
             http_client,
             config,
             pool,
+            cursor: AtomicUsize::new(0),
         })
     }
 
     /// Builds one [`KeySlot`] per API key declared in the configuration.
     ///
-    /// The first slot reuses the caller's [`Auth`] and [`RateLimiter`] so a
-    /// single-key setup keeps its existing session and pacing untouched. Every
-    /// additional key gets a cloned `Config` carrying only that key, hence its
-    /// own session and its own budget.
+    /// Every slot — the first included — gets a `Config` carrying **only its own
+    /// key**. The first slot used to reuse the caller's `Auth`, which had been
+    /// built from the original config: with a pool configured, that `Auth`
+    /// carried the whole comma-separated list as its `api_key` and sent it as
+    /// one 3 KB `X-IG-API-KEY` header, which IG answers with 403. The list is a
+    /// pool specification, never a credential.
+    ///
+    /// Each key's session and its data requests share one limiter, because IG
+    /// meters the login against the same per-key allowance as everything else.
     ///
     /// # Errors
-    /// Returns [`AppError::Network`] if an extra key's [`Auth`] cannot be built.
-    fn build_pool(
-        config: &Arc<Config>,
-        auth: &Arc<Auth>,
-        rate_limiter: &RateLimiter,
-    ) -> Result<Vec<KeySlot>, AppError> {
+    /// Returns [`AppError::Network`] if a key's [`Auth`] cannot be built.
+    /// # Returns
+    ///
+    /// The pool and the first slot's [`Auth`], which the client adopts as its
+    /// own. Returning it here is what guarantees the client never holds an
+    /// `Auth` built from the raw multi-key config.
+    fn build_pool(config: &Arc<Config>) -> Result<(Arc<Auth>, Vec<KeySlot>), AppError> {
         let keys = config.credentials.api_keys();
-
-        let first = KeySlot {
-            api_key: keys
-                .first()
-                .cloned()
-                .unwrap_or_else(|| config.credentials.api_key.clone()),
-            auth: auth.clone(),
-            rate_limiter: rate_limiter.clone(),
-            cooldown_until: Arc::new(StdMutex::new(None)),
+        // An empty list means the value held no usable key; keep the raw value
+        // so the failure surfaces as IG rejecting it, not as an empty pool.
+        let keys = if keys.is_empty() {
+            vec![config.credentials.api_key.clone()]
+        } else {
+            keys
         };
 
-        let mut pool = Vec::with_capacity(keys.len().max(1));
-        pool.push(first);
-
-        for key in keys.iter().skip(1) {
+        let mut first_auth: Option<Arc<Auth>> = None;
+        let mut pool = Vec::with_capacity(keys.len());
+        for key in &keys {
             let mut key_config = (**config).clone();
             key_config.credentials.api_key = key.clone();
             let key_config = Arc::new(key_config);
 
+            let key_limiter = RateLimiter::new(&key_config.rate_limiter);
+            let key_auth = Arc::new(Auth::with_rate_limiter(key_config, key_limiter.clone())?);
+            if first_auth.is_none() {
+                first_auth = Some(key_auth.clone());
+            }
             pool.push(KeySlot {
                 api_key: key.clone(),
-                rate_limiter: RateLimiter::new(&key_config.rate_limiter),
-                auth: Arc::new(Auth::try_new(key_config)?),
+                rate_limiter: key_limiter,
+                auth: key_auth,
                 cooldown_until: Arc::new(StdMutex::new(None)),
             });
         }
@@ -210,31 +219,103 @@ impl HttpClient {
         if pool.len() > 1 {
             debug!(keys = pool.len(), "API key pool enabled");
         }
-        Ok(pool)
+
+        // `keys` is non-empty by construction above, so the loop ran at least
+        // once and `first_auth` is set; the fallback keeps this total without a
+        // panic.
+        let auth = match first_auth {
+            Some(auth) => auth,
+            None => Arc::new(Auth::try_new(config.clone())?),
+        };
+        Ok((auth, pool))
     }
 
-    /// Picks the slot to serve the next request.
+    /// Reserves a token from a usable key, waiting only if every key is empty.
     ///
-    /// Prefers a key that is neither cooling down nor out of local tokens, so
-    /// requests spread across the pool and the allowance error never happens in
-    /// the first place. Falls back to any key not yet tried for this request
-    /// (it will simply wait on its limiter), and finally to the first slot.
-    fn select_slot(&self, class: RateLimitClass, tried: &[usize]) -> usize {
-        let fresh = |i: &usize| !tried.contains(i);
+    /// This is the proactive half of the pool: a key is left before it is
+    /// rejected, not after. It returns the index of a slot whose limiter has
+    /// already given up one token, so the caller owes exactly one request and
+    /// must not pace it again.
+    ///
+    /// Selection starts at a shared round-robin cursor so concurrent callers
+    /// walk the pool from different points instead of all piling onto the first
+    /// key. Keys in cooldown are skipped; when none can serve immediately, the
+    /// pool waits on *all* candidates at once and takes whichever refills
+    /// first, rather than blocking on an arbitrary one.
+    ///
+    /// # Returns
+    ///
+    /// The reserved slot's index, or `None` when every candidate was already
+    /// tried for this request.
+    ///
+    /// # Errors
+    ///
+    /// Returns whatever [`Auth::get_session`] reports when the winning key
+    /// cannot authenticate.
+    async fn reserve_slot(
+        &self,
+        class: RateLimitClass,
+        tried: &[usize],
+    ) -> Result<Option<usize>, AppError> {
+        let len = self.pool.len();
+        let start = self.cursor.fetch_add(1, Ordering::Relaxed);
 
-        if let Some(i) = (0..self.pool.len())
-            .filter(fresh)
-            .find(|&i| !self.pool[i].in_cooldown() && self.pool[i].rate_limiter.check_for(class))
-        {
-            return i;
+        // Rotate the walk order so that, under concurrency, two callers do not
+        // both hand their request to slot 0.
+        let candidates: Vec<usize> = (0..len)
+            .map(|offset| start.wrapping_add(offset) % len)
+            .filter(|i| !tried.contains(i))
+            .collect();
+        if candidates.is_empty() {
+            return Ok(None);
         }
-        if let Some(i) = (0..self.pool.len())
-            .filter(fresh)
-            .find(|&i| !self.pool[i].in_cooldown())
-        {
-            return i;
+
+        // Fast path: someone can serve right now. The session is established
+        // first and the token taken only once it holds, so a failed login costs
+        // its own request and never a data token that is not spent.
+        for &i in &candidates {
+            let slot = &self.pool[i];
+            if slot.in_cooldown() {
+                continue;
+            }
+            // `governor` has no way to look at a bucket without taking from it,
+            // so the order is what protects the token: authenticate first, take
+            // the token second. A key that turns out to be empty has at most had
+            // its session established, which it needs anyway.
+            slot.auth.get_session().await?;
+            if slot.rate_limiter.try_reserve(class) {
+                return Ok(Some(i));
+            }
         }
-        (0..self.pool.len()).find(fresh).unwrap_or(0)
+
+        // Everything is empty (or cooling down). Wait on every candidate at
+        // once and keep the first token to appear; the losing futures are
+        // dropped before they take one.
+        let live: Vec<usize> = candidates
+            .iter()
+            .copied()
+            .filter(|&i| !self.pool[i].in_cooldown())
+            .collect();
+        let waiting = if live.is_empty() { candidates } else { live };
+
+        let waits: Vec<_> = waiting
+            .iter()
+            .map(|&i| {
+                let slot = &self.pool[i];
+                Box::pin(async move {
+                    slot.rate_limiter.reserve(class).await;
+                    i
+                })
+            })
+            .collect();
+
+        let (winner, _, _) = futures::future::select_all(waits).await;
+
+        // The token for the winner is already spent, so a login failure here
+        // does cost it. Establishing the session before the wait is not an
+        // option: which key wins is only known once one refills.
+        self.pool[winner].auth.get_session().await?;
+        Ok(Some(winner))
     }
 
     /// Gets WebSocket connection information for Lightstreamer, reusing the
@@ -410,17 +491,29 @@ impl HttpClient {
         };
 
         let class = classify_endpoint(&method, path);
+
+        // Only non-trading REST rotates. Order placement, amendment and closure
+        // stay on one key: they are metered against the account, not the key, so
+        // moving them buys nothing and would spread order traffic over sessions
+        // that a reconciliation has to tell apart afterwards.
+        let may_rotate = class == RateLimitClass::NonTrading && self.pool.len() > 1;
+
         let mut tried: Vec<usize> = Vec::with_capacity(self.pool.len());
 
         loop {
-            let idx = self.select_slot(class, &tried);
+            let Some(idx) = self.reserve_slot(class, &tried).await? else {
+                // Every key has been tried for this request. The last attempt's
+                // error was returned below, so reaching here means the pool ran
+                // out of candidates without one; report the key-level rejection.
+                return Err(AppError::ApiKeyAllowanceExceeded);
+            };
             tried.push(idx);
             let slot = &self.pool[idx];
 
-            // With more than one key left to try, a rejected request is cheaper
-            // to move to another key than to wait out this one's backoff, so the
-            // per-request retry budget is dropped and rotation handles it.
-            let rotate = tried.len() < self.pool.len();
+            // With another key left to try, a rejected request is cheaper to
+            // move than to wait out this one's backoff, so the per-request retry
+            // budget is dropped and rotation handles it.
+            let rotate = may_rotate && tried.len() < self.pool.len();
             let retry = if rotate {
                 RetryConfig {
                     max_retry_count: Some(0),
@@ -435,14 +528,18 @@ impl HttpClient {
                 .await;
 
             match result {
-                Err(AppError::RateLimitExceeded) if rotate => {
+                // Per-key allowance: this key is spent, another one is not.
+                Err(AppError::ApiKeyAllowanceExceeded) if rotate => {
                     slot.mark_exhausted();
                     warn!(
                         key = %redact_key(&slot.api_key),
-                        next_of = self.pool.len(),
+                        of = self.pool.len(),
                         "API key allowance exhausted, rotating to another key"
                     );
                 }
+                // Account and trading allowances belong to the account every key
+                // authenticates, and a bare 429 does not say which budget ran
+                // out. None of them justify burning another key.
                 other => return other,
             }
         }
@@ -450,6 +547,11 @@ impl HttpClient {
 
     /// Issues one request through a specific key slot: its session, its API key
     /// and its own rate-limiter budget.
+    ///
+    /// The caller has already reserved this slot's token, so the send does not
+    /// pace itself again. The session is resolved *before* that token is put on
+    /// the wire, so a failed login costs only the login request it made — never
+    /// an extra token for a data request that is never sent.
     #[allow(clippy::too_many_arguments)]
     async fn request_on_slot<B: Serialize>(
         &self,
@@ -486,7 +588,7 @@ impl HttpClient {
             headers.push(("X-SECURITY-TOKEN", token_val.as_str()));
         }
 
-        make_http_request(
+        make_http_request_reserved(
             &self.http_client,
             &slot.rate_limiter,
             method.clone(),
@@ -494,6 +596,7 @@ impl HttpClient {
             headers,
             body,
             retry,
+            true,
         )
         .await
     }
@@ -646,6 +749,36 @@ pub async fn make_http_request<B: Serialize>(
     body: &Option<B>,
     retry_config: RetryConfig,
 ) -> Result<Response, AppError> {
+    make_http_request_reserved(
+        client,
+        rate_limiter,
+        method,
+        url,
+        headers,
+        body,
+        retry_config,
+        false,
+    )
+    .await
+}
+
+/// Same as [`make_http_request`], but told whether the first send already owns
+/// a token.
+///
+/// `reserved = true` means the caller took a cell from `rate_limiter` for this
+/// request and the first attempt must not take another. Retries always pace
+/// themselves: each one is a fresh request as far as IG is concerned.
+#[allow(clippy::too_many_arguments)]
+pub async fn make_http_request_reserved<B: Serialize>(
+    client: &Client,
+    rate_limiter: &RateLimiter,
+    method: Method,
+    url: &str,
+    headers: Vec<(&str, &str)>,
+    body: &Option<B>,
+    retry_config: RetryConfig,
+    reserved: bool,
+) -> Result<Response, AppError> {
     let max_retries = retry_config.max_retries();
 
     // Pace this request against the bucket for its endpoint class (trading /
@@ -656,11 +789,15 @@ pub async fn make_http_request<B: Serialize>(
     // Bounded loop: `attempt` ranges over [0, max_retries]. Attempt 0 is the
     // first try; each further attempt is a retry. This can never loop forever.
     for attempt in 0..=max_retries {
-        // Pace this request against its class bucket before sending. The limiter
-        // is shared by reference; each governor bucket is internally `Arc`-backed
-        // and parks the future until a slot is free, so there is no lock guard
-        // held across this await.
-        rate_limiter.wait_for(class).await;
+        // Pace this request against its class bucket before sending, unless the
+        // caller already reserved the token for this first send. Reserving and
+        // then waiting again would spend two cells on one request and halve the
+        // effective rate. Every retry is a *new* request to IG and pays its own
+        // token; the limiter is shared by reference and each governor bucket is
+        // internally `Arc`-backed, so no lock guard is held across this await.
+        if attempt > 0 || !reserved {
+            rate_limiter.wait_for(class).await;
+        }
 
         debug!(%method, %url, class = ?class, "http request");
 
@@ -702,12 +839,18 @@ pub async fn make_http_request<B: Serialize>(
                     });
                 }
 
-                if body_text.contains("exceeded-api-key-allowance")
-                    || body_text.contains("exceeded-account-allowance")
-                    || body_text.contains("exceeded-account-trading-allowance")
-                {
-                    warn!(status = ?status, "allowance rate limit hit");
-                    AppError::RateLimitExceeded
+                // Which allowance ran out decides what the caller may do about
+                // it, so each one gets its own error instead of collapsing into
+                // a single "rate limited".
+                if body_text.contains("exceeded-api-key-allowance") {
+                    warn!("api key allowance exceeded");
+                    AppError::ApiKeyAllowanceExceeded
+                } else if body_text.contains("exceeded-account-trading-allowance") {
+                    warn!("account trading allowance exceeded");
+                    return Err(AppError::TradingAllowanceExceeded);
+                } else if body_text.contains("exceeded-account-allowance") {
+                    warn!("account allowance exceeded");
+                    AppError::AccountAllowanceExceeded
                 } else {
                     error!(status = ?status, "forbidden");
                     return Err(AppError::Unexpected(status));
@@ -729,6 +872,9 @@ pub async fn make_http_request<B: Serialize>(
                     // connection closed and amplifies load during retry storms.
                     let _ = response.bytes().await;
                     if other == StatusCode::TOO_MANY_REQUESTS {
+                        // No body to say which budget ran out, so this stays
+                        // generic: reading it as a per-key rejection would burn
+                        // keys for an account-wide limit.
                         warn!(status = ?other, "rate limit (429) hit");
                         AppError::RateLimitExceeded
                     } else {
@@ -1112,7 +1258,10 @@ mod tests {
         let key = "6cb0ae4d738dcf918fa47157858fc0ea11290a5b";
         let shown = redact_key(key);
         assert_eq!(shown, "6cb0ae4d…");
-        assert!(!shown.contains("738dcf91"), "the key body must never be logged");
+        assert!(
+            !shown.contains("738dcf91"),
+            "the key body must never be logged"
+        );
     }
 
     #[test]
@@ -1146,6 +1295,9 @@ mod tests {
 
         // Simulate the cooldown having elapsed.
         *s.cooldown_until.lock().expect("lock") = Some(Instant::now() - Duration::from_secs(1));
-        assert!(!s.in_cooldown(), "the key returns to the pool once it refills");
+        assert!(
+            !s.in_cooldown(),
+            "the key returns to the pool once it refills"
+        );
     }
 }

--- a/src/application/http.rs
+++ b/src/application/http.rs
@@ -55,11 +55,12 @@ pub struct HttpClient {
     /// The slot whose session this client exposes, and the one trading is
     /// pinned to.
     ///
-    /// Normally 0. It moves when construction had to rotate because the first
-    /// key could not authenticate: pointing `auth`, `ws_info` and order traffic
-    /// at a key that failed to log in would break exactly the paths that cannot
-    /// retry elsewhere.
-    primary: usize,
+    /// Starts at 0 and moves whenever that key turns out to be unusable — at
+    /// construction, or later, on the lazy path where the first login only
+    /// happens when a request arrives. Pointing `auth`, `ws_info` and order
+    /// traffic at a key that cannot log in would break exactly the paths that
+    /// have no second key to fall back on.
+    primary: AtomicUsize,
     /// Round-robin starting point for slot selection.
     ///
     /// Without it every caller scans the pool from index 0, so concurrent
@@ -207,7 +208,7 @@ impl HttpClient {
             .user_agent(USER_AGENT)
             .build()?;
         // Build the pool first: every slot owns a single-key `Config`, so the
-        // client's own `Auth` is slot 0's rather than one built from the raw
+        // client's own `Auth` is the primary slot's rather than one built from the raw
         // config, whose `api_key` may be the whole comma-separated list.
         let account_limiter = Self::build_account_limiter(&config.credentials.account_id);
         let (auth, pool) = Self::build_pool(&config, &account_limiter)?;
@@ -227,7 +228,7 @@ impl HttpClient {
             config,
             pool,
             account_limiter,
-            primary,
+            primary: AtomicUsize::new(primary),
             cursor: AtomicUsize::new(0),
         })
     }
@@ -254,7 +255,7 @@ impl HttpClient {
             config,
             pool,
             account_limiter,
-            primary: 0,
+            primary: AtomicUsize::new(0),
             cursor: AtomicUsize::new(0),
         })
     }
@@ -412,8 +413,8 @@ impl HttpClient {
     /// Trading never spreads. Order traffic is metered against the account, so
     /// rotating buys nothing, and keeping it on one key keeps a position's
     /// requests inside one session — which is what makes a reconciliation
-    /// possible. Trading therefore always uses slot 0 and does not touch the
-    /// cursor.
+    /// possible. Trading therefore always uses the primary slot and does not
+    /// touch the cursor.
     ///
     /// For everything else, selection starts at a shared round-robin cursor so
     /// concurrent callers walk the pool from different points instead of piling
@@ -441,7 +442,7 @@ impl HttpClient {
         // Trading stays pinned to one slot, so two consecutive orders always
         // travel on the same key and the same session.
         if class == RateLimitClass::Trading {
-            let primary = self.primary.min(self.pool.len().saturating_sub(1));
+            let primary = self.primary_index();
             if tried.contains(&primary) {
                 return Ok(None);
             }
@@ -492,6 +493,11 @@ impl HttpClient {
                 }
                 Err(e) => return Err(e),
             }
+            // This key just proved it can authenticate. If the incumbent primary
+            // cannot, hand it over: on the lazy path this is the only moment the
+            // client learns which key works, and trading and streaming follow
+            // the primary.
+            self.promote_primary_if_needed(i);
             if slot.rate_limiter.try_reserve(class) {
                 return Ok(Some(i));
             }
@@ -556,6 +562,7 @@ impl HttpClient {
         // it. Establishing the session earlier is not possible: which key wins
         // is only known once one refills.
         self.pool[winner].auth.get_session().await?;
+        self.promote_primary_if_needed(winner);
         Ok(Some(winner))
     }
 
@@ -573,7 +580,7 @@ impl HttpClient {
     /// # Errors
     /// Returns [`AppError`] when the session cannot be retrieved.
     pub async fn ws_info(&self) -> Result<WebsocketInfo, AppError> {
-        self.auth.ws_info().await
+        self.primary_auth().ws_info().await
     }
 
     /// Gets WebSocket connection information for Lightstreamer
@@ -892,13 +899,36 @@ impl HttpClient {
         })
     }
 
-    /// Switches to a different trading account
+    /// Switches to a different trading account.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError::UnsupportedWithKeyPool`] when the client was built
+    /// with more than one API key, and whatever [`Auth::switch_account`]
+    /// reports otherwise.
+    ///
+    /// Switching is refused with a pool because it cannot be done coherently
+    /// here: each key holds its own session, so switching only the primary
+    /// leaves the other slots authenticated against the previous account and a
+    /// non-trading read could rotate onto one of them and answer for the wrong
+    /// account. Switching all of them instead would spend one request per key —
+    /// 74 of them in this codebase's demo setup — against the very allowance the
+    /// pool exists to protect. The account also keys the shared account-wide
+    /// budget, which would have to move with it. Build a client per account
+    /// instead.
     pub async fn switch_account(
         &self,
         account_id: &str,
         default_account: Option<bool>,
     ) -> Result<(), AppError> {
-        self.auth
+        if self.pool.len() > 1 {
+            return Err(AppError::UnsupportedWithKeyPool(
+                "switch_account cannot be applied coherently to a multi-key pool; \
+                 build one client per account"
+                    .to_string(),
+            ));
+        }
+        self.primary_auth()
             .switch_account(account_id, default_account)
             .await?;
         Ok(())
@@ -906,17 +936,60 @@ impl HttpClient {
 
     /// Gets the current session
     pub async fn get_session(&self) -> Result<Session, AppError> {
-        self.auth.get_session().await
+        self.primary_auth().get_session().await
     }
 
     /// Logs out
     pub async fn logout(&self) -> Result<(), AppError> {
-        self.auth.logout().await
+        self.primary_auth().logout().await
     }
 
     /// Gets Auth reference
+    ///
+    /// This is the primary slot's `Auth`, which moves with the primary: the
+    /// session this exposes is always one that authenticated.
     pub fn auth(&self) -> &Auth {
-        &self.auth
+        self.primary_auth()
+    }
+
+    /// The `Auth` of the slot currently acting as primary.
+    fn primary_auth(&self) -> &Arc<Auth> {
+        let index = self.primary_index();
+        self.pool.get(index).map_or(&self.auth, |slot| &slot.auth)
+    }
+
+    /// The primary slot's index, clamped to the pool.
+    fn primary_index(&self) -> usize {
+        self.primary
+            .load(Ordering::Relaxed)
+            .min(self.pool.len().saturating_sub(1))
+    }
+
+    /// Moves the primary onto `index` when the current one cannot serve.
+    ///
+    /// The lazy constructors cannot know which key will authenticate — the
+    /// first login happens when a request arrives — so the primary is settled
+    /// then: the first slot that proves usable takes over if the incumbent is
+    /// parked. Without this, `ws_info`, streaming and trading would keep
+    /// pointing at a key that failed to log in.
+    fn promote_primary_if_needed(&self, index: usize) {
+        let current = self.primary_index();
+        if current == index {
+            return;
+        }
+        let incumbent_usable = self
+            .pool
+            .get(current)
+            .is_some_and(|slot| !slot.in_cooldown());
+        if !incumbent_usable {
+            self.primary.store(index, Ordering::Relaxed);
+            if let Some(slot) = self.pool.get(index) {
+                debug!(
+                    key = %redact_key(&slot.api_key),
+                    "primary key moved to a key that can authenticate"
+                );
+            }
+        }
     }
 
     /// Returns the configuration this HTTP client was built with.

--- a/src/application/rate_limiter.rs
+++ b/src/application/rate_limiter.rs
@@ -256,6 +256,31 @@ impl RateLimiter {
         self.limiter_for(class).check().is_ok()
     }
 
+    /// Takes one token of `class` if the bucket has one right now.
+    ///
+    /// This is the reservation half of pacing: a `true` return means a cell has
+    /// already been consumed and the caller owes the network exactly one
+    /// request. It must therefore not call [`wait_for`](Self::wait_for) again
+    /// for that same request, or the request costs two tokens and the effective
+    /// rate halves.
+    ///
+    /// # Returns
+    ///
+    /// * `true` — a token was taken; send now.
+    /// * `false` — the bucket is empty; nothing was consumed.
+    #[must_use]
+    pub fn try_reserve(&self, class: RateLimitClass) -> bool {
+        self.limiter_for(class).check().is_ok()
+    }
+
+    /// Waits until this bucket can serve `class`, then takes the token.
+    ///
+    /// Same reservation contract as [`try_reserve`](Self::try_reserve): on
+    /// return, one cell is spent and the caller owes exactly one request.
+    pub async fn reserve(&self, class: RateLimitClass) {
+        self.limiter_for(class).until_ready().await;
+    }
+
     /// Waits until a non-trading request can be made according to the rate limit
     ///
     /// Convenience wrapper over [`wait_for`](Self::wait_for) with

--- a/src/error.rs
+++ b/src/error.rs
@@ -167,13 +167,6 @@ pub enum AppError {
     /// Trading traffic stays pinned to one key, so this never rotates.
     #[error("account trading allowance exceeded")]
     TradingAllowanceExceeded,
-    /// The operation cannot be applied coherently to a multi-key pool.
-    ///
-    /// Some operations are per-session, and a pool holds one session per key.
-    /// Applying them to a single slot would leave the rest inconsistent, and
-    /// applying them to all would cost one request per key.
-    #[error("unsupported with an API key pool: {0}")]
-    UnsupportedWithKeyPool(String),
     /// Historical data allowance exhausted (weekly quota of data points)
     ///
     /// The `allowance_expiry` field indicates the number of seconds

--- a/src/error.rs
+++ b/src/error.rs
@@ -167,6 +167,13 @@ pub enum AppError {
     /// Trading traffic stays pinned to one key, so this never rotates.
     #[error("account trading allowance exceeded")]
     TradingAllowanceExceeded,
+    /// The operation cannot be applied coherently to a multi-key pool.
+    ///
+    /// Some operations are per-session, and a pool holds one session per key.
+    /// Applying them to a single slot would leave the rest inconsistent, and
+    /// applying them to all would cost one request per key.
+    #[error("unsupported with an API key pool: {0}")]
+    UnsupportedWithKeyPool(String),
     /// Historical data allowance exhausted (weekly quota of data points)
     ///
     /// The `allowance_expiry` field indicates the number of seconds

--- a/src/error.rs
+++ b/src/error.rs
@@ -142,8 +142,31 @@ pub enum AppError {
     #[error("not found")]
     NotFound,
     /// API rate limit exceeded
+    ///
+    /// Kept for a 429 with no allowance body: the status alone does not say
+    /// which budget ran out, so it must not be read as a per-key rejection.
     #[error("rate limit exceeded")]
     RateLimitExceeded,
+    /// This API key's non-trading allowance is exhausted
+    /// (`error.public-api.exceeded-api-key-allowance`).
+    ///
+    /// IG meters that allowance per key, so another key of the pool can serve
+    /// the request immediately. This is the only allowance error that rotates.
+    #[error("api key allowance exceeded")]
+    ApiKeyAllowanceExceeded,
+    /// The account's non-trading allowance is exhausted
+    /// (`error.public-api.exceeded-account-allowance`).
+    ///
+    /// Every key of the pool authenticates the same account, so rotating cannot
+    /// help: the whole pool has to wait.
+    #[error("account allowance exceeded")]
+    AccountAllowanceExceeded,
+    /// The account's trading allowance is exhausted
+    /// (`error.public-api.exceeded-account-trading-allowance`).
+    ///
+    /// Trading traffic stays pinned to one key, so this never rotates.
+    #[error("account trading allowance exceeded")]
+    TradingAllowanceExceeded,
     /// Historical data allowance exhausted (weekly quota of data points)
     ///
     /// The `allowance_expiry` field indicates the number of seconds

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -1,3 +1,6 @@
+//! Integration tests that talk to IG. They need real credentials in the
+//! environment and are ignored by default.
+
 mod account_tests;
 mod auth_tests;
 mod common;

--- a/tests/unit/application/mod.rs
+++ b/tests/unit/application/mod.rs
@@ -6,5 +6,6 @@ mod test_http_request;
 // user callback. The stream-pumping half (`Listener::spawn`) needs a
 // `lightstreamer_rs::Updates`, which has no public constructor, so it is only
 // reachable from the env-gated live tests.
+mod test_key_pool;
 #[cfg(feature = "streaming")]
 mod test_listener;

--- a/tests/unit/application/test_http_request.rs
+++ b/tests/unit/application/test_http_request.rs
@@ -146,19 +146,20 @@ async fn test_make_http_request_403_historical_allowance_fails_fast() {
 }
 
 #[tokio::test]
-async fn test_make_http_request_403_api_key_allowance_is_rate_limited_and_retried() {
+async fn test_make_http_request_403_api_key_allowance_fails_fast() {
     let server = MockServer::start().await;
     // An API-key allowance breach maps to its own error, distinct from a bare
     // 429: it is the one allowance a key pool can route around, so the caller
-    // has to be able to tell it apart. It IS retried, so all RETRIES + 1
-    // attempts are made before giving up.
+    // has to be able to tell it apart. It fails fast - one attempt - because
+    // retrying a key that just said it is empty costs ~76 s of backoff before
+    // the caller can rotate to a key that is not.
     mount_get(
         &server,
         ResponseTemplate::new(403).set_body_raw(
             r#"{"errorCode":"error.public-api.exceeded-api-key-allowance"}"#,
             "application/json",
         ),
-        RETRIES + 1,
+        1,
     )
     .await;
 

--- a/tests/unit/application/test_http_request.rs
+++ b/tests/unit/application/test_http_request.rs
@@ -148,8 +148,10 @@ async fn test_make_http_request_403_historical_allowance_fails_fast() {
 #[tokio::test]
 async fn test_make_http_request_403_api_key_allowance_is_rate_limited_and_retried() {
     let server = MockServer::start().await;
-    // An API-key allowance breach is a rate limit: it maps to RateLimitExceeded
-    // and IS retried, so all RETRIES + 1 attempts are made before giving up.
+    // An API-key allowance breach maps to its own error, distinct from a bare
+    // 429: it is the one allowance a key pool can route around, so the caller
+    // has to be able to tell it apart. It IS retried, so all RETRIES + 1
+    // attempts are made before giving up.
     mount_get(
         &server,
         ResponseTemplate::new(403).set_body_raw(
@@ -161,8 +163,8 @@ async fn test_make_http_request_403_api_key_allowance_is_rate_limited_and_retrie
     .await;
 
     match get_test_endpoint(&server, fast_retry()).await {
-        Err(AppError::RateLimitExceeded) => {}
-        other => panic!("expected RateLimitExceeded, got {other:?}"),
+        Err(AppError::ApiKeyAllowanceExceeded) => {}
+        other => panic!("expected ApiKeyAllowanceExceeded, got {other:?}"),
     }
 }
 

--- a/tests/unit/application/test_key_pool.rs
+++ b/tests/unit/application/test_key_pool.rs
@@ -1025,3 +1025,125 @@ async fn test_new_fails_when_no_key_can_authenticate() {
         ),
     }
 }
+
+/// The lazy path settles the primary too.
+///
+/// `Client::try_new` and `Client::with_config` build lazily, so the first login
+/// happens when a request arrives rather than at construction. If the first key
+/// is refused then, the primary has to move with it — otherwise trading and
+/// streaming keep pointing at the key that could not authenticate.
+#[tokio::test]
+async fn test_lazy_client_moves_the_primary_to_the_key_that_authenticates() {
+    let server = MockServer::start().await;
+
+    // key-a is refused at login; key-b authenticates.
+    Mock::given(method("POST"))
+        .and(path("/session"))
+        .respond_with(ResponseTemplate::new(403).set_body_json(serde_json::json!({
+            "errorCode": "error.public-api.exceeded-api-key-allowance"
+        })))
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
+    mount_login_ok(&server).await;
+    mount_data_ok(&server).await;
+    Mock::given(method("POST"))
+        .and(path("/positions/otc"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"ok": true})))
+        .mount(&server)
+        .await;
+
+    let client = HttpClient::new_lazy(pool_config_burst(&server.uri(), "key-a,key-b", 20, 1, 20))
+        .expect("client builds");
+
+    // A non-trading read triggers the first login and the rotation.
+    client
+        .get::<Dummy>("/data", Some(1))
+        .await
+        .expect("read served");
+
+    // Trading pins to the primary. It must have followed the rotation.
+    client
+        .post::<_, Dummy>("/positions/otc", serde_json::json!({}), Some(2))
+        .await
+        .expect("order accepted");
+
+    let order_key = server
+        .received_requests()
+        .await
+        .unwrap_or_default()
+        .iter()
+        .filter(|r| r.url.path() == "/positions/otc")
+        .filter_map(|r| {
+            r.headers
+                .get("X-IG-API-KEY")
+                .and_then(|v| v.to_str().ok())
+                .map(str::to_string)
+        })
+        .next_back()
+        .expect("an order was sent");
+    assert_eq!(
+        order_key, "key-b",
+        "the primary followed the key that authenticated on the lazy path"
+    );
+}
+
+/// `switch_account` is refused with a pool rather than silently leaving the
+/// other slots on the previous account.
+#[tokio::test]
+async fn test_switch_account_is_refused_with_a_key_pool() {
+    let server = MockServer::start().await;
+    mount_login_ok(&server).await;
+
+    let client = HttpClient::new_lazy(pool_config_burst(&server.uri(), "key-a,key-b", 20, 1, 20))
+        .expect("client builds");
+
+    let err = client
+        .switch_account("OTHER", Some(false))
+        .await
+        .expect_err("switching is refused with a pool");
+    assert!(
+        matches!(err, AppError::UnsupportedWithKeyPool(_)),
+        "got {err:?}"
+    );
+
+    let switches = server
+        .received_requests()
+        .await
+        .unwrap_or_default()
+        .iter()
+        .filter(|r| r.url.path() == "/session")
+        .filter(|r| r.method == wiremock::http::Method::PUT)
+        .count();
+    assert_eq!(switches, 0, "no key was switched behind the others' backs");
+}
+
+/// A single key is not stopped by the pool guard.
+///
+/// It can still fail for its own reasons — switching is unsupported on OAuth
+/// sessions, which is a pre-existing limitation of `Auth` and unrelated to the
+/// pool — but the refusal must not be `UnsupportedWithKeyPool`.
+#[tokio::test]
+async fn test_switch_account_still_works_with_one_key() {
+    let server = MockServer::start().await;
+    mount_login_ok(&server).await;
+    Mock::given(method("PUT"))
+        .and(path("/session"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "trailingStopsEnabled": false,
+            "dealingEnabled": true,
+            "hasActiveDemoAccounts": true,
+            "hasActiveLiveAccounts": false
+        })))
+        .mount(&server)
+        .await;
+
+    let client = HttpClient::new_lazy(pool_config_burst(&server.uri(), "only-key", 20, 1, 20))
+        .expect("client builds");
+
+    let result = client.switch_account("OTHER", Some(false)).await;
+    assert!(
+        !matches!(result, Err(AppError::UnsupportedWithKeyPool(_))),
+        "the pool guard did not fire for a single key, got {result:?}"
+    );
+}

--- a/tests/unit/application/test_key_pool.rs
+++ b/tests/unit/application/test_key_pool.rs
@@ -488,3 +488,286 @@ async fn test_pool_single_key_keeps_previous_behaviour() {
     let used = keys_used(&server).await;
     assert_eq!(used, vec!["only-key".to_string(), "only-key".to_string()]);
 }
+
+/// A per-key allowance rejection *during login* rotates at once, instead of
+/// spending three backoffs on a key that has already said it is empty.
+#[tokio::test]
+async fn test_pool_key_allowance_during_login_rotates_without_backoff() {
+    let server = MockServer::start().await;
+
+    // The first login attempt is refused for the key's allowance; the next one
+    // succeeds. If the client retried the same key, this test would take the
+    // backoff (tens of seconds) instead of finishing immediately.
+    Mock::given(method("POST"))
+        .and(path("/session"))
+        .respond_with(ResponseTemplate::new(403).set_body_json(serde_json::json!({
+            "errorCode": "error.public-api.exceeded-api-key-allowance"
+        })))
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
+    mount_login_ok(&server).await;
+    mount_data_ok(&server).await;
+
+    let client = HttpClient::new_lazy(pool_config_burst(&server.uri(), "key-a,key-b", 4, 60, 4))
+        .expect("client builds");
+
+    let started = Instant::now();
+    let result = tokio::time::timeout(
+        Duration::from_secs(8),
+        client.get::<Dummy>("/data", Some(1)),
+    )
+    .await;
+
+    assert!(
+        matches!(result, Ok(Ok(_))),
+        "the request succeeded on another key, got {result:?}"
+    );
+    assert!(
+        started.elapsed() < Duration::from_secs(8),
+        "no backoff was paid on the refused key, took {:?}",
+        started.elapsed()
+    );
+
+    let used = keys_used(&server).await;
+    assert_eq!(used.len(), 1, "exactly one data request was sent");
+}
+
+/// Two consecutive trading calls use the same slot. Order traffic is metered
+/// against the account, so spreading it buys nothing and would scatter a
+/// position's requests over sessions a reconciliation then has to match up.
+#[tokio::test]
+async fn test_pool_consecutive_trading_requests_use_the_same_slot() {
+    let server = MockServer::start().await;
+    mount_login_ok(&server).await;
+    Mock::given(method("POST"))
+        .and(path("/positions/otc"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"ok": true})))
+        .mount(&server)
+        .await;
+
+    let client = HttpClient::new_lazy(pool_config_burst(
+        &server.uri(),
+        "key-a,key-b,key-c",
+        20,
+        1,
+        20,
+    ))
+    .expect("client builds");
+
+    for _ in 0..2 {
+        client
+            .post::<_, Dummy>("/positions/otc", serde_json::json!({}), Some(2))
+            .await
+            .expect("order accepted");
+    }
+
+    let orders: Vec<String> = server
+        .received_requests()
+        .await
+        .unwrap_or_default()
+        .iter()
+        .filter(|r| r.url.path() == "/positions/otc")
+        .map(|r| {
+            r.headers
+                .get("X-IG-API-KEY")
+                .and_then(|v| v.to_str().ok())
+                .unwrap_or_default()
+                .to_string()
+        })
+        .collect();
+
+    assert_eq!(orders.len(), 2, "both orders were sent");
+    assert_eq!(
+        orders[0], orders[1],
+        "both used the same key, got {orders:?}"
+    );
+}
+
+/// Serving one request must not authenticate the whole pool. With a burst of 1
+/// a key holds at most one token, so a selection that probes every key with
+/// `get_session` would log every one of them in.
+#[tokio::test]
+async fn test_pool_first_request_does_not_authenticate_every_key() {
+    let server = MockServer::start().await;
+    mount_login_ok(&server).await;
+    mount_data_ok(&server).await;
+
+    let client = HttpClient::new_lazy(pool_config_burst(
+        &server.uri(),
+        "key-a,key-b,key-c,key-d,key-e",
+        10,
+        1,
+        1,
+    ))
+    .expect("client builds");
+
+    client.get::<Dummy>("/data", Some(1)).await.expect("first");
+
+    let logins = server
+        .received_requests()
+        .await
+        .unwrap_or_default()
+        .iter()
+        .filter(|r| r.url.path() == "/session")
+        .count();
+
+    // One login for the key that serves it. A second is possible when that key
+    // turns out to have no token and the wait is won by another key, but the
+    // pool must never authenticate all five to serve one request.
+    assert!(
+        logins <= 2,
+        "one request did not authenticate the pool, got {logins} logins"
+    );
+}
+
+/// When IG refuses the last key too, that key is marked as well: the pool must
+/// not hand the next request straight back to a key that has just said it is
+/// empty.
+#[tokio::test]
+async fn test_pool_last_key_is_also_marked_on_allowance() {
+    let server = MockServer::start().await;
+    mount_login_ok(&server).await;
+    Mock::given(method("GET"))
+        .and(path("/data"))
+        .respond_with(ResponseTemplate::new(403).set_body_json(serde_json::json!({
+            "errorCode": "error.public-api.exceeded-api-key-allowance"
+        })))
+        .mount(&server)
+        .await;
+
+    let client = HttpClient::new_lazy(pool_config_burst(&server.uri(), "key-a,key-b", 20, 1, 20))
+        .expect("client builds");
+
+    let err = client
+        .get::<Dummy>("/data", Some(1))
+        .await
+        .expect_err("every key refused");
+    assert!(
+        matches!(err, AppError::ApiKeyAllowanceExceeded),
+        "got {err:?}"
+    );
+
+    let after_first = keys_used(&server).await.len();
+    assert_eq!(after_first, 2, "both keys were tried once");
+
+    // Both are now in cooldown, so a second call must not send anything more
+    // while it waits for one of them to come back.
+    let second = tokio::time::timeout(
+        Duration::from_millis(300),
+        client.get::<Dummy>("/data", Some(1)),
+    )
+    .await;
+    assert!(second.is_err(), "the second call waited on the cooldown");
+    assert_eq!(
+        keys_used(&server).await.len(),
+        after_first,
+        "no request was sent to a key still in cooldown"
+    );
+}
+
+/// The account allowance is spent for every key at once, so retrying it only
+/// burns more of an allowance that is already gone: exactly one request.
+#[tokio::test]
+async fn test_account_allowance_sends_exactly_one_request() {
+    let server = MockServer::start().await;
+    mount_login_ok(&server).await;
+    Mock::given(method("GET"))
+        .and(path("/data"))
+        .respond_with(ResponseTemplate::new(403).set_body_json(serde_json::json!({
+            "errorCode": "error.public-api.exceeded-account-allowance"
+        })))
+        .mount(&server)
+        .await;
+
+    let client = HttpClient::new_lazy(pool_config_burst(&server.uri(), "key-a", 20, 1, 20))
+        .expect("client builds");
+
+    let err = client
+        .get::<Dummy>("/data", Some(1))
+        .await
+        .expect_err("account allowance is an error");
+    assert!(
+        matches!(err, AppError::AccountAllowanceExceeded),
+        "got {err:?}"
+    );
+    assert_eq!(
+        keys_used(&server).await.len(),
+        1,
+        "one request, no retries against an exhausted account budget"
+    );
+}
+
+/// An expired OAuth token on a key other than the first refreshes *that* key's
+/// session. Refreshing slot 0 instead would replay the same rejected token.
+#[tokio::test]
+async fn test_pool_oauth_refresh_targets_the_failing_slot() {
+    let server = MockServer::start().await;
+    mount_login_ok(&server).await;
+
+    // First data call is answered with an invalidated OAuth token, the next one
+    // succeeds. Two keys with one data token each force the first call onto one
+    // key and make the replay observable.
+    Mock::given(method("GET"))
+        .and(path("/data"))
+        .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+            "errorCode": "error.security.oauth-token-invalid"
+        })))
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
+    mount_data_ok(&server).await;
+
+    let client = HttpClient::new_lazy(pool_config_burst(&server.uri(), "key-a,key-b", 20, 1, 20))
+        .expect("client builds");
+
+    let result = client.get::<Dummy>("/data", Some(1)).await;
+    assert!(result.is_ok(), "the replay succeeded, got {result:?}");
+
+    let used = keys_used(&server).await;
+    assert_eq!(used.len(), 2, "the rejected call plus its replay");
+    assert_eq!(
+        used[0], used[1],
+        "the replay stayed on the key whose token was refreshed, got {used:?}"
+    );
+}
+
+/// The pool paces against an account-wide budget on top of the per-key ones.
+/// Without it, N keys would pace N times what the account allows.
+#[tokio::test]
+async fn test_pool_respects_an_account_wide_budget() {
+    let server = MockServer::start().await;
+    mount_login_ok(&server).await;
+    mount_data_ok(&server).await;
+
+    // Ten keys with a generous per-key budget: the per-key limiters would let
+    // far more through than the account ceiling of 30/minute allows.
+    let keys: Vec<String> = (0..10).map(|i| format!("key-{i}")).collect();
+    let client = HttpClient::new_lazy(pool_config_burst(
+        &server.uri(),
+        &keys.join(","),
+        100,
+        60,
+        100,
+    ))
+    .expect("client builds");
+
+    let mut sent = 0;
+    for _ in 0..40 {
+        match tokio::time::timeout(
+            Duration::from_millis(50),
+            client.get::<Dummy>("/data", Some(1)),
+        )
+        .await
+        {
+            Ok(Ok(_)) => sent += 1,
+            _ => break,
+        }
+    }
+
+    assert!(
+        sent <= 30,
+        "the account ceiling capped the burst at 30/minute, sent {sent}"
+    );
+    assert!(sent > 0, "the pool still served requests");
+}

--- a/tests/unit/application/test_key_pool.rs
+++ b/tests/unit/application/test_key_pool.rs
@@ -154,9 +154,12 @@ async fn test_pool_two_keys_first_two_requests_use_distinct_keys_immediately() {
     let used = keys_used(&server).await;
     assert_eq!(used.len(), 2, "both requests were sent");
     assert_ne!(used[0], used[1], "the two requests used different keys");
+    // Neither request waited on a *key* refill, which is 60 s here. Four
+    // physical requests (two logins, two data) still pass the account gate at
+    // one per two seconds, so the floor is around six seconds, not zero.
     assert!(
-        elapsed < Duration::from_secs(5),
-        "neither request waited on a refill, took {elapsed:?}"
+        elapsed < Duration::from_secs(20),
+        "neither request waited on a key refill, took {elapsed:?}"
     );
 }
 
@@ -732,16 +735,24 @@ async fn test_pool_oauth_refresh_targets_the_failing_slot() {
     );
 }
 
-/// The pool paces against an account-wide budget on top of the per-key ones.
-/// Without it, N keys would pace N times what the account allows.
+/// Every request the server received, whatever its path.
+///
+/// The account budget is charged per *physical* request, so counting only
+/// `/data` would miss the logins, refreshes and retries it also has to pay for.
+async fn all_requests(server: &MockServer) -> usize {
+    server.received_requests().await.unwrap_or_default().len()
+}
+
+/// The account ceiling caps everything the process sends, logins included.
+///
+/// Ten keys with a generous per-key budget would otherwise pace ten times what
+/// the account allows.
 #[tokio::test]
-async fn test_pool_respects_an_account_wide_budget() {
+async fn test_account_budget_caps_every_physical_request() {
     let server = MockServer::start().await;
     mount_login_ok(&server).await;
     mount_data_ok(&server).await;
 
-    // Ten keys with a generous per-key budget: the per-key limiters would let
-    // far more through than the account ceiling of 30/minute allows.
     let keys: Vec<String> = (0..10).map(|i| format!("key-{i}")).collect();
     let client = HttpClient::new_lazy(pool_config_burst(
         &server.uri(),
@@ -752,22 +763,171 @@ async fn test_pool_respects_an_account_wide_budget() {
     ))
     .expect("client builds");
 
-    let mut sent = 0;
     for _ in 0..40 {
-        match tokio::time::timeout(
+        if tokio::time::timeout(
             Duration::from_millis(50),
             client.get::<Dummy>("/data", Some(1)),
         )
         .await
+        .is_err()
         {
-            Ok(Ok(_)) => sent += 1,
-            _ => break,
+            break;
         }
     }
 
+    let total = all_requests(&server).await;
     assert!(
-        sent <= 30,
-        "the account ceiling capped the burst at 30/minute, sent {sent}"
+        total <= 30,
+        "the account ceiling capped every request, not just the data ones: {total} sent"
     );
-    assert!(sent > 0, "the pool still served requests");
+    assert!(total > 0, "the pool still served requests");
+}
+
+/// Logins draw on the account budget too. Ten keys logging in cannot exceed the
+/// ceiling just because each one has its own key budget.
+#[tokio::test]
+async fn test_account_budget_covers_logins() {
+    let server = MockServer::start().await;
+    mount_login_ok(&server).await;
+    mount_data_ok(&server).await;
+
+    let keys: Vec<String> = (0..10).map(|i| format!("key-{i}")).collect();
+    // Per-key burst of 1 forces a login on many keys, so most of the traffic
+    // here is `/session` rather than `/data`.
+    let client = HttpClient::new_lazy(pool_config_burst(
+        &server.uri(),
+        &keys.join(","),
+        100,
+        60,
+        1,
+    ))
+    .expect("client builds");
+
+    for _ in 0..40 {
+        if tokio::time::timeout(
+            Duration::from_millis(50),
+            client.get::<Dummy>("/data", Some(1)),
+        )
+        .await
+        .is_err()
+        {
+            break;
+        }
+    }
+
+    let total = all_requests(&server).await;
+    let logins = server
+        .received_requests()
+        .await
+        .unwrap_or_default()
+        .iter()
+        .filter(|r| r.url.path() == "/session")
+        .count();
+
+    assert!(logins > 0, "the test exercised the login path");
+    assert!(
+        total <= 30,
+        "logins and data together stayed under the ceiling: {total} sent ({logins} logins)"
+    );
+}
+
+/// Retries pay the account budget as well: each attempt is a request IG counts.
+#[tokio::test]
+async fn test_account_budget_covers_retries() {
+    let server = MockServer::start().await;
+    mount_login_ok(&server).await;
+    // A persistently failing endpoint, so the client exhausts its retry budget.
+    Mock::given(method("GET"))
+        .and(path("/data"))
+        .respond_with(ResponseTemplate::new(503))
+        .mount(&server)
+        .await;
+
+    let client = HttpClient::new_lazy(pool_config_burst(&server.uri(), "key-a", 100, 60, 100))
+        .expect("client builds");
+
+    let before = all_requests(&server).await;
+    let _ = tokio::time::timeout(
+        Duration::from_secs(2),
+        client.get::<Dummy>("/data", Some(1)),
+    )
+    .await;
+    let sent = all_requests(&server).await - before;
+
+    // Whatever the retry budget allows, the account limiter is a burst of one
+    // per two seconds, so a burst of attempts cannot slip through untimed.
+    assert!(
+        sent <= 2,
+        "each retry waited on the account budget, {sent} attempts went out at once"
+    );
+}
+
+/// `HttpClient::new` logs in on the first key that accepts it. One spent key
+/// must not throw away a pool whose other keys are fine.
+#[tokio::test]
+async fn test_new_rotates_when_the_first_key_is_exhausted() {
+    let server = MockServer::start().await;
+
+    // The first login is refused for that key's allowance; the next succeeds.
+    Mock::given(method("POST"))
+        .and(path("/session"))
+        .respond_with(ResponseTemplate::new(403).set_body_json(serde_json::json!({
+            "errorCode": "error.public-api.exceeded-api-key-allowance"
+        })))
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
+    mount_login_ok(&server).await;
+
+    let client = tokio::time::timeout(
+        Duration::from_secs(10),
+        HttpClient::new(pool_config_burst(&server.uri(), "key-a,key-b", 20, 1, 20)),
+    )
+    .await;
+
+    assert!(
+        matches!(client, Ok(Ok(_))),
+        "construction rotated to the second key, got {:?}",
+        client.as_ref().map(std::result::Result::is_ok)
+    );
+
+    let logins = server
+        .received_requests()
+        .await
+        .unwrap_or_default()
+        .iter()
+        .filter(|r| r.url.path() == "/session")
+        .count();
+    assert_eq!(
+        logins, 2,
+        "the refused key was not retried, the next one was"
+    );
+}
+
+/// A single key keeps failing construction: rotation must not turn a real
+/// authentication failure into a silent success.
+#[tokio::test]
+async fn test_new_fails_when_no_key_can_authenticate() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/session"))
+        .respond_with(ResponseTemplate::new(403).set_body_json(serde_json::json!({
+            "errorCode": "error.public-api.exceeded-api-key-allowance"
+        })))
+        .mount(&server)
+        .await;
+
+    let client = tokio::time::timeout(
+        Duration::from_secs(10),
+        HttpClient::new(pool_config_burst(&server.uri(), "key-a,key-b", 20, 1, 20)),
+    )
+    .await;
+
+    match client {
+        Ok(Err(AppError::ApiKeyAllowanceExceeded)) => {}
+        other => panic!(
+            "expected ApiKeyAllowanceExceeded, got {:?}",
+            other.map(|r| r.is_ok())
+        ),
+    }
 }

--- a/tests/unit/application/test_key_pool.rs
+++ b/tests/unit/application/test_key_pool.rs
@@ -1,0 +1,490 @@
+//! Acceptance tests for the API key pool.
+//!
+//! The pool exists because IG meters its non-trading allowance per API key. The
+//! properties asserted here are the ones that make that worth having: work is
+//! spread *before* a key is rejected, one sent request costs exactly one token,
+//! and the errors that do not belong to a key never burn another one.
+//!
+//! Driven against a `wiremock::MockServer`, which records the `X-IG-API-KEY` of
+//! every request and so shows which key served what.
+
+use ig_client::application::config::{
+    Config, Credentials, DatabaseConfig, RateLimiterConfig, RestApiConfig, WebSocketConfig,
+};
+use ig_client::application::http::HttpClient;
+use ig_client::application::rate_limiter::{RateLimitClass, RateLimiter};
+use ig_client::error::AppError;
+use ig_client::model::retry::RetryConfig;
+use serde::Deserialize;
+use std::time::{Duration, Instant};
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// Minimal DTO for the mock endpoint; the tests care about the traffic, not the
+/// payload.
+#[derive(Debug, Deserialize)]
+struct Dummy {
+    #[allow(dead_code)]
+    ok: bool,
+}
+
+/// Builds a config whose `api_key` is the comma-separated pool under test.
+///
+/// Budgets here count the login too: a key's session and its data requests
+/// share one limiter, because IG meters both against the same per-key
+/// allowance. So "one data request" on a fresh key costs two tokens — one for
+/// `/session`, one for the data — and the tests size `max_requests`
+/// accordingly.
+fn pool_config(base_url: &str, keys: &str, max_requests: u32, period_seconds: u64) -> Config {
+    pool_config_burst(base_url, keys, max_requests, period_seconds, max_requests)
+}
+
+/// Same as [`pool_config`] with an explicit burst size.
+///
+/// The burst is the bucket's capacity, so it decides how many tokens can be
+/// held at once: with a burst of 1 a key can never have a login and a data
+/// request ready together, no matter how large the per-period budget is.
+fn pool_config_burst(
+    base_url: &str,
+    keys: &str,
+    max_requests: u32,
+    period_seconds: u64,
+    burst_size: u32,
+) -> Config {
+    Config {
+        credentials: Credentials {
+            username: "fake-user".to_string(),
+            password: "fake-pass".to_string(),
+            account_id: "ABC12".to_string(),
+            api_key: keys.to_string(),
+            client_token: None,
+            account_token: None,
+        },
+        rest_api: RestApiConfig {
+            base_url: base_url.to_string(),
+            timeout: 30,
+        },
+        websocket: WebSocketConfig {
+            url: "wss://example.invalid".to_string(),
+            reconnect_interval: 5,
+        },
+        database: DatabaseConfig {
+            url: "postgres://localhost/none".to_string(),
+            max_connections: 1,
+        },
+        rate_limiter: RateLimiterConfig {
+            max_requests,
+            period_seconds,
+            burst_size,
+        },
+        sleep_hours: 1,
+        page_size: 20,
+        days_to_look_back: 7,
+        api_version: Some(3),
+    }
+}
+
+/// Mounts a `/session` endpoint that always authenticates.
+async fn mount_login_ok(server: &MockServer) {
+    Mock::given(method("POST"))
+        .and(path("/session"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "clientId": "FAKE-CLIENT-1",
+            "accountId": "ABC12",
+            "timezoneOffset": 1,
+            "lightstreamerEndpoint": "https://example.invalid",
+            "oauthToken": {
+                "access_token": "FAKE-ACCESS",
+                "refresh_token": "FAKE-REFRESH",
+                "scope": "profile",
+                "token_type": "Bearer",
+                "expires_in": "600"
+            }
+        })))
+        .mount(server)
+        .await;
+}
+
+/// Mounts the data endpoint used by every test, always succeeding.
+async fn mount_data_ok(server: &MockServer) {
+    Mock::given(method("GET"))
+        .and(path("/data"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"ok": true})))
+        .mount(server)
+        .await;
+}
+
+/// The `X-IG-API-KEY` of every `/data` request the server received, in order.
+async fn keys_used(server: &MockServer) -> Vec<String> {
+    server
+        .received_requests()
+        .await
+        .unwrap_or_default()
+        .iter()
+        .filter(|r| r.url.path() == "/data")
+        .map(|r| {
+            r.headers
+                .get("X-IG-API-KEY")
+                .and_then(|v| v.to_str().ok())
+                .unwrap_or_default()
+                .to_string()
+        })
+        .collect()
+}
+
+/// Two keys with one token each: both requests go out at once, on different
+/// keys. A pool that waited for the first key instead of moving to the second
+/// would serialise them.
+#[tokio::test]
+async fn test_pool_two_keys_first_two_requests_use_distinct_keys_immediately() {
+    let server = MockServer::start().await;
+    mount_login_ok(&server).await;
+    mount_data_ok(&server).await;
+
+    // Capacity for exactly a login plus one data request per key, so a second
+    // data request on the same key would have to wait for a refill.
+    let client = HttpClient::new_lazy(pool_config_burst(&server.uri(), "key-a,key-b", 2, 60, 2))
+        .expect("client builds");
+
+    let started = Instant::now();
+    client.get::<Dummy>("/data", Some(1)).await.expect("first");
+    client.get::<Dummy>("/data", Some(1)).await.expect("second");
+    let elapsed = started.elapsed();
+
+    let used = keys_used(&server).await;
+    assert_eq!(used.len(), 2, "both requests were sent");
+    assert_ne!(used[0], used[1], "the two requests used different keys");
+    assert!(
+        elapsed < Duration::from_secs(5),
+        "neither request waited on a refill, took {elapsed:?}"
+    );
+}
+
+/// The third request has no token anywhere, so it must wait for a refill. With
+/// a 60 s period and one token per key, it cannot complete quickly.
+#[tokio::test]
+async fn test_pool_third_request_waits_for_the_first_refill() {
+    let server = MockServer::start().await;
+    mount_login_ok(&server).await;
+    mount_data_ok(&server).await;
+
+    // Login plus exactly one data request per key; nothing left for a third.
+    let client = HttpClient::new_lazy(pool_config_burst(&server.uri(), "key-a,key-b", 2, 60, 2))
+        .expect("client builds");
+
+    client.get::<Dummy>("/data", Some(1)).await.expect("first");
+    client.get::<Dummy>("/data", Some(1)).await.expect("second");
+
+    // Both buckets are empty now; the third must block rather than be sent.
+    let third = tokio::time::timeout(
+        Duration::from_millis(300),
+        client.get::<Dummy>("/data", Some(1)),
+    )
+    .await;
+
+    assert!(third.is_err(), "the third request waited for a refill");
+    assert_eq!(
+        keys_used(&server).await.len(),
+        2,
+        "no third request reached the server while waiting"
+    );
+}
+
+/// One sent request costs exactly one token.
+///
+/// This is the reserve-then-wait bug made visible: selection took a cell with
+/// `check()` and the send took another with `until_ready()`, so every request
+/// cost two and the effective rate was half the configured one. Counted
+/// directly on the bucket rather than by timing, so the assertion is exact.
+#[tokio::test]
+async fn test_send_with_reservation_consumes_exactly_one_token() {
+    let server = MockServer::start().await;
+    mount_data_ok(&server).await;
+
+    // Three tokens available at once, none refilling during the test.
+    let limiter = RateLimiter::new(&RateLimiterConfig {
+        max_requests: 3,
+        period_seconds: 600,
+        burst_size: 3,
+    });
+
+    // Reserve as the pool does, then send saying the token is already held.
+    assert!(limiter.try_reserve(RateLimitClass::NonTrading), "token 1");
+    let response = ig_client::application::http::make_http_request_reserved(
+        &reqwest::Client::new(),
+        &limiter,
+        reqwest::Method::GET,
+        &format!("{}/data", server.uri()),
+        vec![],
+        &None::<()>,
+        RetryConfig {
+            max_retry_count: Some(0),
+            retry_delay_secs: Some(0),
+        },
+        true,
+    )
+    .await;
+    assert!(response.is_ok(), "the request was sent");
+
+    // Two of the three tokens must remain: the send spent none of its own.
+    assert!(
+        limiter.try_reserve(RateLimitClass::NonTrading),
+        "second token still available"
+    );
+    assert!(
+        limiter.try_reserve(RateLimitClass::NonTrading),
+        "third token still available - the send did not take a second one"
+    );
+    assert!(
+        !limiter.try_reserve(RateLimitClass::NonTrading),
+        "and the budget is now genuinely spent"
+    );
+}
+
+/// A failed login must cost only the login request. If the data token were
+/// reserved first, it would be spent on a request that is never sent.
+#[tokio::test]
+async fn test_pool_failed_login_does_not_consume_a_data_token() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/session"))
+        .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+            "errorCode": "error.security.invalid-details"
+        })))
+        .mount(&server)
+        .await;
+    mount_data_ok(&server).await;
+
+    // Capacity for the failed login, the retried login and one data request. If
+    // the failed attempt also took a data token, the budget would not cover the
+    // request that follows it.
+    let client = HttpClient::new_lazy(pool_config_burst(&server.uri(), "key-a", 3, 60, 3))
+        .expect("client builds");
+
+    let failed = client.get::<Dummy>("/data", Some(1)).await;
+    assert!(failed.is_err(), "the request fails because login fails");
+    assert!(
+        keys_used(&server).await.is_empty(),
+        "no data request was sent"
+    );
+
+    // The token survived the failed login, so a working login can spend it now
+    // without waiting for a refill.
+    server.reset().await;
+    mount_login_ok(&server).await;
+    mount_data_ok(&server).await;
+
+    let started = Instant::now();
+    let second = tokio::time::timeout(
+        Duration::from_secs(5),
+        client.get::<Dummy>("/data", Some(1)),
+    )
+    .await;
+    assert!(
+        second.is_ok(),
+        "the data token was not spent by the failed login, waited {:?}",
+        started.elapsed()
+    );
+}
+
+/// Concurrent requests spread over the pool instead of stacking on the first
+/// key. Without the round-robin cursor every caller starts its scan at index 0.
+#[tokio::test]
+async fn test_pool_concurrent_requests_spread_across_keys() {
+    let server = MockServer::start().await;
+    mount_login_ok(&server).await;
+    mount_data_ok(&server).await;
+
+    let client = std::sync::Arc::new(
+        HttpClient::new_lazy(pool_config_burst(
+            &server.uri(),
+            "key-a,key-b,key-c,key-d",
+            2,
+            60,
+            2,
+        ))
+        .expect("client builds"),
+    );
+
+    let mut tasks = Vec::new();
+    for _ in 0..4 {
+        let client = client.clone();
+        tasks.push(tokio::spawn(async move {
+            client
+                .get::<Dummy>("/data", Some(1))
+                .await
+                .map(|_: Dummy| ())
+        }));
+    }
+    for task in tasks {
+        let _ = task.await;
+    }
+
+    let mut used = keys_used(&server).await;
+    used.sort();
+    used.dedup();
+    assert_eq!(
+        used.len(),
+        4,
+        "four concurrent requests used four distinct keys, got {used:?}"
+    );
+}
+
+/// When every key is empty the pool waits on all of them and takes whichever
+/// refills first, rather than parking on an arbitrary one. Key B refills in 1 s
+/// while key A would need 60 s, so the wait must be the short one.
+#[tokio::test]
+async fn test_rate_limiter_waits_for_the_key_that_refills_first() {
+    let slow = RateLimiter::new(&RateLimiterConfig {
+        max_requests: 1,
+        period_seconds: 60,
+        burst_size: 1,
+    });
+    let fast = RateLimiter::new(&RateLimiterConfig {
+        max_requests: 1,
+        period_seconds: 1,
+        burst_size: 1,
+    });
+
+    // Drain both buckets.
+    assert!(slow.try_reserve(RateLimitClass::NonTrading));
+    assert!(fast.try_reserve(RateLimitClass::NonTrading));
+
+    let started = Instant::now();
+    let waits: Vec<std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>>> = vec![
+        Box::pin(async move { slow.reserve(RateLimitClass::NonTrading).await }),
+        Box::pin(async move { fast.reserve(RateLimitClass::NonTrading).await }),
+    ];
+    let (_, _, _) = futures::future::select_all(waits).await;
+
+    assert!(
+        started.elapsed() < Duration::from_secs(10),
+        "the wait ended on the fast bucket, took {:?}",
+        started.elapsed()
+    );
+}
+
+/// A per-key allowance rejection moves to another key straight away, and the
+/// request succeeds there.
+#[tokio::test]
+async fn test_pool_api_key_allowance_rotates_immediately() {
+    let server = MockServer::start().await;
+    mount_login_ok(&server).await;
+
+    // First data call is rejected for the key's allowance; the retry on the
+    // other key succeeds.
+    Mock::given(method("GET"))
+        .and(path("/data"))
+        .respond_with(ResponseTemplate::new(403).set_body_json(serde_json::json!({
+            "errorCode": "error.public-api.exceeded-api-key-allowance"
+        })))
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
+    mount_data_ok(&server).await;
+
+    let client = HttpClient::new_lazy(pool_config(&server.uri(), "key-a,key-b", 5, 1))
+        .expect("client builds");
+
+    let result = client.get::<Dummy>("/data", Some(1)).await;
+    assert!(result.is_ok(), "the request succeeded on another key");
+
+    let used = keys_used(&server).await;
+    assert_eq!(used.len(), 2, "one rejection plus one success");
+    assert_ne!(used[0], used[1], "the retry went to a different key");
+}
+
+/// The account-wide allowance belongs to the account every key authenticates,
+/// so it must surface as its own error without spending a second key.
+#[tokio::test]
+async fn test_pool_account_allowance_does_not_rotate() {
+    let server = MockServer::start().await;
+    mount_login_ok(&server).await;
+    Mock::given(method("GET"))
+        .and(path("/data"))
+        .respond_with(ResponseTemplate::new(403).set_body_json(serde_json::json!({
+            "errorCode": "error.public-api.exceeded-account-allowance"
+        })))
+        .mount(&server)
+        .await;
+
+    let client = HttpClient::new_lazy(pool_config(&server.uri(), "key-a,key-b", 5, 1))
+        .expect("client builds");
+
+    let err = client
+        .get::<Dummy>("/data", Some(1))
+        .await
+        .expect_err("account allowance is an error");
+    assert!(
+        matches!(err, AppError::AccountAllowanceExceeded),
+        "got {err:?}"
+    );
+
+    let used = keys_used(&server).await;
+    assert!(
+        used.iter().collect::<std::collections::HashSet<_>>().len() <= 1,
+        "the account allowance did not burn a second key, used {used:?}"
+    );
+}
+
+/// Trading traffic stays pinned to one key: the trading allowance is metered
+/// against the account, so rotating buys nothing and would scatter order
+/// traffic over sessions.
+#[tokio::test]
+async fn test_pool_trading_allowance_does_not_rotate() {
+    let server = MockServer::start().await;
+    mount_login_ok(&server).await;
+    Mock::given(method("POST"))
+        .and(path("/positions/otc"))
+        .respond_with(ResponseTemplate::new(403).set_body_json(serde_json::json!({
+            "errorCode": "error.public-api.exceeded-account-trading-allowance"
+        })))
+        .mount(&server)
+        .await;
+
+    let client = HttpClient::new_lazy(pool_config(&server.uri(), "key-a,key-b", 5, 1))
+        .expect("client builds");
+
+    let err = client
+        .post::<_, Dummy>("/positions/otc", serde_json::json!({}), Some(2))
+        .await
+        .expect_err("trading allowance is an error");
+    assert!(
+        matches!(err, AppError::TradingAllowanceExceeded),
+        "got {err:?}"
+    );
+
+    let orders: Vec<String> = server
+        .received_requests()
+        .await
+        .unwrap_or_default()
+        .iter()
+        .filter(|r| r.url.path() == "/positions/otc")
+        .map(|r| {
+            r.headers
+                .get("X-IG-API-KEY")
+                .and_then(|v| v.to_str().ok())
+                .unwrap_or_default()
+                .to_string()
+        })
+        .collect();
+    assert_eq!(orders.len(), 1, "the order was sent once, got {orders:?}");
+}
+
+/// A single key behaves exactly as before the pool existed: requests go out on
+/// that key, paced by its budget.
+#[tokio::test]
+async fn test_pool_single_key_keeps_previous_behaviour() {
+    let server = MockServer::start().await;
+    mount_login_ok(&server).await;
+    mount_data_ok(&server).await;
+
+    let client =
+        HttpClient::new_lazy(pool_config(&server.uri(), "only-key", 5, 1)).expect("client builds");
+
+    client.get::<Dummy>("/data", Some(1)).await.expect("first");
+    client.get::<Dummy>("/data", Some(1)).await.expect("second");
+
+    let used = keys_used(&server).await;
+    assert_eq!(used, vec!["only-key".to_string(), "only-key".to_string()]);
+}

--- a/tests/unit/application/test_key_pool.rs
+++ b/tests/unit/application/test_key_pool.rs
@@ -1088,6 +1088,96 @@ async fn test_lazy_client_moves_the_primary_to_the_key_that_authenticates() {
     );
 }
 
+/// A fallback that was *already authenticated* also takes over as primary.
+///
+/// The first selection pass returns a key that holds both a session and a
+/// token, which is the common case once the pool is warm. Promoting only in the
+/// second pass left trading and streaming pointing at a primary IG had just
+/// refused, because a warm fallback never needs to log in and so never reaches
+/// that pass.
+#[tokio::test]
+async fn test_ready_fallback_becomes_primary_after_the_primary_is_refused() {
+    let server = MockServer::start().await;
+    mount_login_ok(&server).await;
+    mount_data_ok(&server).await;
+
+    // A tight per-key budget is what makes the second key get used at all: with
+    // spare capacity the pool keeps serving from the first, which is correct but
+    // leaves the fallback cold and the first pass untested.
+    let client = HttpClient::new_lazy(pool_config_burst(&server.uri(), "key-a,key-b", 4, 10, 2))
+        .expect("client builds");
+
+    // Warm both keys with no refusals at all, so each holds a session and the
+    // selection below resolves entirely in the first pass.
+    let mut logins = 0;
+    for _ in 0..8 {
+        let _ = client.get::<Dummy>("/data", Some(1)).await;
+        logins = server
+            .received_requests()
+            .await
+            .unwrap_or_default()
+            .iter()
+            .filter(|r| r.url.path() == "/session")
+            .count();
+        if logins >= 2 {
+            break;
+        }
+    }
+    assert_eq!(logins, 2, "both keys authenticated during the warm-up");
+
+    // Only now start refusing key-a, the initial primary. Resetting first keeps
+    // the 403 ahead of the catch-all data mock; the sessions live in the client
+    // and survive it.
+    server.reset().await;
+    mount_login_ok(&server).await;
+    Mock::given(method("GET"))
+        .and(path("/data"))
+        .and(wiremock::matchers::header("X-IG-API-KEY", "key-a"))
+        .respond_with(ResponseTemplate::new(403).set_body_json(serde_json::json!({
+            "errorCode": "error.public-api.exceeded-api-key-allowance"
+        })))
+        .mount(&server)
+        .await;
+    mount_data_ok(&server).await;
+    Mock::given(method("POST"))
+        .and(path("/positions/otc"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"ok": true})))
+        .mount(&server)
+        .await;
+
+    // Drive reads until key-a is refused and the pool falls back to key-b,
+    // which is already authenticated - so this resolves in the first pass.
+    for _ in 0..4 {
+        let _ = client.get::<Dummy>("/data", Some(1)).await;
+    }
+
+    // Trading pins to the primary, so the order shows where the primary is.
+    client
+        .post::<_, Dummy>("/positions/otc", serde_json::json!({}), Some(2))
+        .await
+        .expect("order accepted");
+
+    let order_key = server
+        .received_requests()
+        .await
+        .unwrap_or_default()
+        .iter()
+        .filter(|r| r.url.path() == "/positions/otc")
+        .filter_map(|r| {
+            r.headers
+                .get("X-IG-API-KEY")
+                .and_then(|v| v.to_str().ok())
+                .map(str::to_string)
+        })
+        .next_back()
+        .expect("an order was sent");
+
+    assert_eq!(
+        order_key, "key-b",
+        "trading followed the primary onto the key IG did not refuse"
+    );
+}
+
 /// `switch_account` is refused with a pool rather than silently leaving the
 /// other slots on the previous account.
 #[tokio::test]
@@ -1102,10 +1192,7 @@ async fn test_switch_account_is_refused_with_a_key_pool() {
         .switch_account("OTHER", Some(false))
         .await
         .expect_err("switching is refused with a pool");
-    assert!(
-        matches!(err, AppError::UnsupportedWithKeyPool(_)),
-        "got {err:?}"
-    );
+    assert!(matches!(err, AppError::InvalidInput(_)), "got {err:?}");
 
     let switches = server
         .received_requests()
@@ -1142,8 +1229,11 @@ async fn test_switch_account_still_works_with_one_key() {
         .expect("client builds");
 
     let result = client.switch_account("OTHER", Some(false)).await;
+    // The guard reports InvalidInput naming the pool; a single key must fail
+    // for some other reason, or not at all.
+    let hit_pool_guard = matches!(&result, Err(AppError::InvalidInput(m)) if m.contains("pool"));
     assert!(
-        !matches!(result, Err(AppError::UnsupportedWithKeyPool(_))),
+        !hit_pool_guard,
         "the pool guard did not fire for a single key, got {result:?}"
     );
 }

--- a/tests/unit/application/test_key_pool.rs
+++ b/tests/unit/application/test_key_pool.rs
@@ -20,6 +20,10 @@ use std::time::{Duration, Instant};
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
+/// Hands each test its own account id, so the per-account budget does not leak
+/// between tests running in the same process.
+static ACCOUNT_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+
 /// Minimal DTO for the mock endpoint; the tests care about the traffic, not the
 /// payload.
 #[derive(Debug, Deserialize)]
@@ -55,7 +59,14 @@ fn pool_config_burst(
         credentials: Credentials {
             username: "fake-user".to_string(),
             password: "fake-pass".to_string(),
-            account_id: "ABC12".to_string(),
+            // The account budget is shared per process *and per account*, which
+            // is the point of it — but it also means two tests sharing an
+            // account id would steal each other's tokens while running in
+            // parallel. Each config gets its own account unless a test pins one.
+            account_id: format!(
+                "TEST-{}",
+                ACCOUNT_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+            ),
             api_key: keys.to_string(),
             client_token: None,
             account_token: None,
@@ -901,6 +912,89 @@ async fn test_new_rotates_when_the_first_key_is_exhausted() {
     assert_eq!(
         logins, 2,
         "the refused key was not retried, the next one was"
+    );
+
+    // Construction succeeding is not enough: the client must have *adopted* the
+    // key that authenticated. Trading is pinned to the primary slot, so an order
+    // shows which key that is - and it must not be the exhausted one.
+    let client = client.expect("timeout").expect("client built");
+    Mock::given(method("POST"))
+        .and(path("/positions/otc"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"ok": true})))
+        .mount(&server)
+        .await;
+    client
+        .post::<_, Dummy>("/positions/otc", serde_json::json!({}), Some(2))
+        .await
+        .expect("order accepted");
+
+    let order_key = server
+        .received_requests()
+        .await
+        .unwrap_or_default()
+        .iter()
+        .filter(|r| r.url.path() == "/positions/otc")
+        .filter_map(|r| {
+            r.headers
+                .get("X-IG-API-KEY")
+                .and_then(|v| v.to_str().ok())
+                .map(str::to_string)
+        })
+        .next_back()
+        .expect("an order was sent");
+    assert_eq!(
+        order_key, "key-b",
+        "trading uses the key that authenticated, not the exhausted one"
+    );
+}
+
+/// The account bucket is one flat budget: market data and historical prices
+/// draw on the same 30/min, instead of getting 30 each.
+#[tokio::test]
+async fn test_account_budget_is_shared_between_data_and_history() {
+    let server = MockServer::start().await;
+    mount_login_ok(&server).await;
+    mount_data_ok(&server).await;
+    Mock::given(method("GET"))
+        .and(path("/prices/EPIC"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"ok": true})))
+        .mount(&server)
+        .await;
+
+    // Account id keys the shared bucket; a unique one keeps this test
+    // independent of the others running in the same process.
+    let mut config = pool_config_burst(&server.uri(), "key-hist", 100, 60, 100);
+    config.credentials.account_id = "SHARED-BUDGET-TEST".to_string();
+    let client = HttpClient::new_lazy(config).expect("client builds");
+
+    // Alternate the two classes over a fixed window. The account bucket refills
+    // one token every two seconds, so a shared bucket lets about three requests
+    // through in six seconds; two separate buckets would let through roughly
+    // twice that, since each class would refill on its own.
+    let deadline = Instant::now() + Duration::from_secs(6);
+    let mut i = 0;
+    while Instant::now() < deadline {
+        let endpoint = if i % 2 == 0 { "/data" } else { "/prices/EPIC" };
+        if tokio::time::timeout(
+            Duration::from_secs(3),
+            client.get::<Dummy>(endpoint, Some(1)),
+        )
+        .await
+        .is_err()
+        {
+            break;
+        }
+        i += 1;
+    }
+
+    let total = all_requests(&server).await;
+    assert!(
+        i >= 2,
+        "the window exercised both classes, only {i} calls made"
+    );
+    assert!(
+        total <= 5,
+        "history and market data shared one account budget: {total} requests in six seconds"
     );
 }
 

--- a/tests/unit/mod.rs
+++ b/tests/unit/mod.rs
@@ -1,3 +1,6 @@
+//! Offline unit tests: pure logic and HTTP behaviour driven against a mock
+//! server, with no IG credentials and no network.
+
 mod application;
 mod error_tests;
 mod model;


### PR DESCRIPTION
## What

Three defects made the API key pool cost throughput instead of adding it.

**The first key authenticated with the whole pool list.** `new_lazy` built an `Auth` from the original `Config`, whose `api_key` holds the entire comma-separated list, and slot 0 reused it. Every login on that slot sent a multi-kilobyte `X-IG-API-KEY` header containing all the keys and IG answered 403, while the other slots — built from single-key configs — worked. That is the 403/400 alternation seen in `data-engine`. Every slot is now built from a config carrying only its own key, and the client adopts slot 0's `Auth`.

**Each request cost two tokens.** Selection called `check_for()`, which consumes a governor cell, and the send then called `wait_for()`, consuming another — halving the effective rate. Selection now reserves atomically with `try_reserve`, the reservation is carried into the send, and only retries pay their own token.

**Auth and REST paced separately.** `Auth::try_new` built its own limiter per key, so a key's login and its data requests drew on separate budgets and together could exceed the one IG enforces. They now share one limiter per key.

## Behaviour

Rotation is proactive: a request goes to a key that can serve it now, chosen round-robin from an atomic cursor so concurrent callers do not pile onto slot 0. When every key is empty the pool waits on all of them and takes whichever refills first. Sessions are established before the token is taken, so a failed login never spends a data token.

Allowance errors are now distinct, because the right response differs:

| Error | Response |
|---|---|
| `ApiKeyAllowanceExceeded` | park the key, retry on another immediately |
| `AccountAllowanceExceeded` | shared by every key; does not rotate |
| `TradingAllowanceExceeded` | does not rotate |
| `RateLimitExceeded` (bare 429) | not read as a per-key rejection |

Rotation applies to non-trading REST only; order placement stays pinned to one key.

## Tests

Ten acceptance tests in `tests/unit/application/test_key_pool.rs` covering: two keys serving the first two requests immediately on distinct keys, the third waiting for a refill, one send costing exactly one token, a failed login not spending a data token, concurrent requests spreading across keys, an exhausted pool waiting on the first to refill, immediate rotation on `ApiKeyAllowanceExceeded`, no rotation for the account and trading allowances, and a single key behaving as before.

`cargo clippy --all-targets --all-features` clean, `cargo test` 533 passing, `cargo doc --no-deps --document-private-items` warning-free.