### PR TITLE
fix: re-authenticate on a rejected v2 session, make v3 account switching free

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ig-client"
-version = "0.16.2"
+version = "0.16.3"
 edition = "2024"
 authors = ["Joaquin Bejar <jb@taunais.com>"]
 description = "This crate provides a client for the IG Markets API"

--- a/README.md
+++ b/README.md
@@ -117,72 +117,6 @@ collects logs through the `log` facade.
 
 ### Configuration
 
-### API key pool
-
-IG meters its non-trading allowance **per API key**, so several keys on the same
-account give you several independent budgets. Pass them as a comma-separated
-list and the client spreads requests across them:
-
-```
-IG_API_KEY=key1,key2,key3
-```
-
-Each key gets its own session and its own rate-limiter budget — one limiter
-shared by that key's login and its data requests, because IG counts both against
-the same allowance.
-
-Spreading is **proactive**: a request goes to a key that can serve it right now,
-picked round-robin among the equally available ones, and the token is reserved
-at selection and carried through to the send, so one request costs exactly one
-token. When no key has a token, the client waits on all of them at once and
-takes whichever refills first rather than queueing on an arbitrary one.
-
-Being rejected is the safety net, not the mechanism. The allowance errors are
-distinct because they call for different responses:
-
-| Error | Meaning | Response |
-|---|---|---|
-| `ApiKeyAllowanceExceeded` | this key's budget | park the key for a minute, retry on another immediately |
-| `AccountAllowanceExceeded` | the account's budget | every key shares it, so rotating cannot help |
-| `TradingAllowanceExceeded` | the account's trading budget | never rotates |
-| `HistoricalDataAllowanceExceeded` | weekly data-point quota | never rotates |
-| `RateLimitExceeded` | a bare 429 with no allowance body | not read as a per-key rejection |
-
-Rotation is enabled for non-trading REST only. Creating, amending and closing
-orders stay pinned to the primary slot — the key whose session the client
-exposes — so consecutive orders travel on one key and one session: that traffic is metered against the account, so moving it buys nothing
-and would scatter order history across sessions.
-
-On top of the per-key budgets the pool paces against an account-wide one, fixed
-at IG's documented 30 requests per 60 seconds. It is charged **per physical
-request**, immediately before each send: logins, token refreshes and every
-retry pay it, not just the data calls.
-
-Non-trading and historical traffic share that one bucket, because IG's
-per-account non-trading allowance is a single budget — giving each class its own
-would let market data and `/prices` each run to 30/min. Trading does not charge
-it: IG meters orders against a separate trading allowance.
-
-The bucket is shared **per process and per account**, so several `HttpClient`s
-in one service built for the same account share it. It does **not** coordinate
-across processes: two services authenticating the same IG account hold two
-buckets and together exceed the ceiling. Enforcing it there needs a distributed
-limiter, or an account per service.
-
-### Upgrading from 0.15
-
-A single key (no comma) keeps the same routing — one key, one session — but two
-behaviours changed for every configuration:
-
-- An `exceeded-api-key-allowance` 403 now **fails fast** instead of being retried
-  three times with backoff. Waiting ~76 s on a key that has just said it is empty
-  helps nobody; with a pool the caller rotates instead, and with one key it learns
-  sooner. Callers that relied on the retry need to handle
-  `AppError::ApiKeyAllowanceExceeded` themselves.
-- The account-wide bucket applies even to a single key, at 30 requests per 60
-  seconds with a burst of 1. A client configured for a faster per-key rate is now
-  capped by it.
-
 `Config::new()` reads configuration from the environment (and a local `.env`
 file, if present). Create a `.env` file in your project root with the
 following variables:
@@ -190,14 +124,14 @@ following variables:
 ```
 IG_USERNAME=your_username
 IG_PASSWORD=your_password
-IG_API_KEY=your_api_key                            # or a comma-separated pool: key1,key2,key3
+IG_API_KEY=your_api_key
 IG_ACCOUNT_ID=your_account_id
 IG_API_VERSION=3                                   # 2 (CST/XST) or 3 (OAuth); defaults to 3
 IG_REST_BASE_URL=https://demo-api.ig.com/gateway/deal   # Use demo or live as needed
 IG_REST_TIMEOUT=30                                 # REST request timeout in seconds
 IG_WS_URL=wss://demo-apd.marketdatasystems.com     # Lightstreamer endpoint
 IG_WS_RECONNECT_INTERVAL=5                         # Reconnect interval in seconds
-IG_RATE_LIMIT_MAX_REQUESTS=4                       # Rate-limiter budget, applied per API key
+IG_RATE_LIMIT_MAX_REQUESTS=4                       # Rate-limiter budget
 IG_RATE_LIMIT_PERIOD_SECONDS=12                    # Rate-limiter period (seconds)
 IG_RATE_LIMIT_BURST_SIZE=3                         # Rate-limiter burst size
 DATABASE_URL=postgres://user:password@localhost/ig_db   # Optional persistence

--- a/src/application/auth.rs
+++ b/src/application/auth.rs
@@ -248,6 +248,15 @@ impl Auth {
         }
     }
 
+    /// Whether the cached session authenticates with OAuth (v3).
+    ///
+    /// Returns `false` when there is no session yet: with nothing cached, the
+    /// caller cannot assume the request-header model applies.
+    pub async fn is_oauth_session(&self) -> bool {
+        let session = self.session.read().await;
+        session.as_ref().is_some_and(|s| s.api_version == 3)
+    }
+
     /// Whether a session is cached and not within its refresh margin.
     ///
     /// Lets a caller tell "this key can send right now" from "this key would
@@ -569,10 +578,23 @@ impl Auth {
         default_account: Option<bool>,
     ) -> Result<Session, AppError> {
         let current_session = self.get_session().await?;
+
+        // v3 needs no round trip. An OAuth access token identifies the *client*,
+        // not an account: the account is chosen per request by the
+        // `IG-ACCOUNT-ID` header, which is built from the session's account id.
+        // Updating that field locally is therefore the whole switch, and it
+        // costs no request against the allowance. Calling IG's `PUT /session`
+        // here would be worse than useless: it re-issues v2 tokens this session
+        // does not use, and IG rejects it for OAuth sessions anyway.
         if matches!(current_session.api_version, 3) {
-            return Err(AppError::InvalidInput(
-                "Cannot switch accounts with OAuth".to_string(),
-            ));
+            let mut switched = current_session.clone();
+            switched.account_id = account_id.to_string();
+            {
+                let mut session = self.session.write().await;
+                *session = Some(switched.clone());
+            }
+            info!("✓ Selected account {account_id} (v3 sends it per request)");
+            return Ok(switched);
         }
 
         if current_session.account_id == account_id {

--- a/src/application/auth.rs
+++ b/src/application/auth.rs
@@ -250,8 +250,8 @@ impl Auth {
 
     /// Whether the cached session authenticates with OAuth (v3).
     ///
-    /// Returns `false` when there is no session yet: with nothing cached, the
-    /// caller cannot assume the request-header model applies.
+    /// `false` when nothing is cached yet: with no session, the caller cannot
+    /// assume the per-request account model applies.
     pub async fn is_oauth_session(&self) -> bool {
         let session = self.session.read().await;
         session.as_ref().is_some_and(|s| s.api_version == 3)
@@ -348,7 +348,26 @@ impl Auth {
                 // (login -> switch_account -> get_session -> login). The cycle
                 // is runtime-bounded: the session was stored above, so
                 // `get_session` returns it without logging in again.
-                return Box::pin(self.switch_account(&configured, None)).await;
+                // The session stored above is the *login's* account, not the
+                // configured one. If the switch fails, leaving it cached would
+                // let the next request run silently against the wrong account -
+                // or spin on 401 - so the session is cleared and the caller sees
+                // the failure. Local state and the selected account move
+                // together or not at all.
+                return match Box::pin(self.switch_account(&configured, None)).await {
+                    Ok(session) => Ok(session),
+                    Err(e) => {
+                        {
+                            let mut sess = self.session.write().await;
+                            *sess = None;
+                        }
+                        warn!(
+                            "account selection failed after login; cleared the \
+                             session rather than keeping the login's default account"
+                        );
+                        Err(e)
+                    }
+                };
             }
         }
 
@@ -579,22 +598,10 @@ impl Auth {
     ) -> Result<Session, AppError> {
         let current_session = self.get_session().await?;
 
-        // v3 needs no round trip. An OAuth access token identifies the *client*,
-        // not an account: the account is chosen per request by the
-        // `IG-ACCOUNT-ID` header, which is built from the session's account id.
-        // Updating that field locally is therefore the whole switch, and it
-        // costs no request against the allowance. Calling IG's `PUT /session`
-        // here would be worse than useless: it re-issues v2 tokens this session
-        // does not use, and IG rejects it for OAuth sessions anyway.
         if matches!(current_session.api_version, 3) {
-            let mut switched = current_session.clone();
-            switched.account_id = account_id.to_string();
-            {
-                let mut session = self.session.write().await;
-                *session = Some(switched.clone());
-            }
-            info!("✓ Selected account {account_id} (v3 sends it per request)");
-            return Ok(switched);
+            return Err(AppError::InvalidInput(
+                "Cannot switch accounts with OAuth".to_string(),
+            ));
         }
 
         if current_session.account_id == account_id {

--- a/src/application/http.rs
+++ b/src/application/http.rs
@@ -45,13 +45,16 @@ pub struct HttpClient {
     /// [`RateLimiter`] as the fields above, so a single-key configuration keeps
     /// the historical behaviour exactly.
     pool: Vec<KeySlot>,
-    /// Budget shared by the whole pool.
+    /// The account every request is issued against, with the budget that
+    /// belongs to it.
     ///
-    /// IG documents a per-account ceiling on top of the per-key one, and every
-    /// key here authenticates the same account. Without this, N keys would pace
-    /// N times the account's allowance and the account limit would be found the
-    /// hard way.
-    account_limiter: RateLimiter,
+    /// Kept outside the sessions on purpose. On v3 the account is not a property
+    /// of the session at all — an OAuth token identifies the client and the
+    /// account travels in `IG-ACCOUNT-ID` per request — so storing it per
+    /// session would scatter one value across N keys and lose it on every
+    /// re-login. One shared value also makes a switch atomic: a request either
+    /// sees the old account or the new one, never a half-switched pool.
+    selected: Arc<StdMutex<SelectedAccount>>,
     /// The slot whose session this client exposes, and the one trading is
     /// pinned to.
     ///
@@ -67,6 +70,16 @@ pub struct HttpClient {
     /// requests pile onto the first key while the rest sit idle. Advancing it
     /// per selection spreads equally-available keys evenly.
     cursor: AtomicUsize,
+}
+
+/// The account in force and the account-wide budget metered against it.
+///
+/// They travel together because they change together: pointing the client at a
+/// different account must also point it at that account's bucket, or the new
+/// account would be paced against the previous one's remaining allowance.
+struct SelectedAccount {
+    id: String,
+    limiter: RateLimiter,
 }
 
 /// One API key of the pool, with the session and pacing budget that belong to it.
@@ -211,6 +224,10 @@ impl HttpClient {
         // client's own `Auth` is the primary slot's rather than one built from the raw
         // config, whose `api_key` may be the whole comma-separated list.
         let account_limiter = Self::build_account_limiter(&config.credentials.account_id);
+        let selected = Arc::new(StdMutex::new(SelectedAccount {
+            id: config.credentials.account_id.clone(),
+            limiter: account_limiter.clone(),
+        }));
         let (auth, pool) = Self::build_pool(&config, &account_limiter)?;
 
         // Log in on the first key that will have us: an allowance rejection on
@@ -227,7 +244,7 @@ impl HttpClient {
             http_client,
             config,
             pool,
-            account_limiter,
+            selected,
             primary: AtomicUsize::new(primary),
             cursor: AtomicUsize::new(0),
         })
@@ -247,6 +264,10 @@ impl HttpClient {
         // Same as `new`: the client's `Auth` is the pool's first slot, never an
         // `Auth` built from a config whose `api_key` is the whole pool list.
         let account_limiter = Self::build_account_limiter(&config.credentials.account_id);
+        let selected = Arc::new(StdMutex::new(SelectedAccount {
+            id: config.credentials.account_id.clone(),
+            limiter: account_limiter.clone(),
+        }));
         let (auth, pool) = Self::build_pool(&config, &account_limiter)?;
 
         Ok(Self {
@@ -254,7 +275,7 @@ impl HttpClient {
             http_client,
             config,
             pool,
-            account_limiter,
+            selected,
             primary: AtomicUsize::new(0),
             cursor: AtomicUsize::new(0),
         })
@@ -744,15 +765,28 @@ impl HttpClient {
         let mut tried: Vec<usize> = Vec::with_capacity(self.pool.len());
         // One replay after a forced refresh, never a loop of them.
         let mut replayed = false;
+        // The slot a replay must go back to. Re-entering the selector instead
+        // would let the round-robin hand the replay to a *different* key, so
+        // the session that was just refreshed would go unused and a second
+        // invalidated key would burn the single replay.
+        let mut replay_on: Option<usize> = None;
 
         loop {
-            let Some(idx) = self.reserve_slot(class, &tried).await? else {
+            let idx = if let Some(pinned) = replay_on.take() {
+                // Same key, and it still has to pay for its token.
+                self.pool[pinned].rate_limiter.reserve(class).await;
+                pinned
+            } else if let Some(selected) = self.reserve_slot(class, &tried).await? {
+                selected
+            } else {
                 // Every key has been tried for this request. The last attempt's
                 // error was returned below, so reaching here means the pool ran
                 // out of candidates without one; report the key-level rejection.
                 return Err(AppError::ApiKeyAllowanceExceeded);
             };
-            tried.push(idx);
+            if !tried.contains(&idx) {
+                tried.push(idx);
+            }
             let slot = &self.pool[idx];
 
             // With another key left to try, a rejected request is cheaper to
@@ -808,7 +842,9 @@ impl HttpClient {
                     );
                     slot.auth.force_refresh().await?;
                     replayed = true;
-                    tried.pop();
+                    // Pin the replay to this slot: it is the one whose session
+                    // was just re-established.
+                    replay_on = Some(idx);
                 }
                 // Account and trading allowances belong to the account every key
                 // authenticates, and a bare 429 does not say which budget ran
@@ -838,6 +874,10 @@ impl HttpClient {
     ) -> Result<Response, AppError> {
         let session = slot.auth.get_session().await?;
 
+        // Account and its budget are read together, so a request never pairs one
+        // account's header with another account's bucket.
+        let (selected_account, account_limiter) = self.selected_account();
+
         let version_owned = version.unwrap_or(1).to_string();
         let auth_header_value;
 
@@ -855,7 +895,11 @@ impl HttpClient {
         if let Some(oauth) = &session.oauth_token {
             auth_header_value = format!("Bearer {}", oauth.access_token);
             headers.push(("Authorization", auth_header_value.as_str()));
-            headers.push(("IG-ACCOUNT-ID", session.account_id.as_str()));
+            // v3 selects the account per request, and the value comes from the
+            // client's shared state rather than the session: a re-login or a
+            // token refresh rebuilds the session from IG's default account and
+            // would otherwise silently undo a switch.
+            headers.push(("IG-ACCOUNT-ID", selected_account.as_str()));
         } else if let (Some(cst_val), Some(token_val)) = (&session.cst, &session.x_security_token) {
             headers.push(("CST", cst_val.as_str()));
             headers.push(("X-SECURITY-TOKEN", token_val.as_str()));
@@ -865,7 +909,7 @@ impl HttpClient {
             &self.http_client,
             Pacing {
                 key: &slot.rate_limiter,
-                account: Some(&self.account_limiter),
+                account: Some(&account_limiter),
             },
             method.clone(),
             url,
@@ -915,58 +959,83 @@ impl HttpClient {
         })
     }
 
-    /// Switches to a different trading account.
+    /// Switches every subsequent request to a different trading account.
+    ///
+    /// The two authentication models need different work, because they keep the
+    /// account in different places.
+    ///
+    /// On **v3** the account is not part of the session: an OAuth token
+    /// identifies the client and the account is chosen per request through
+    /// `IG-ACCOUNT-ID`. Switching is therefore a single update of the client's
+    /// shared state — no request, no session touched, and cold keys stay cold.
+    /// It survives re-login and refresh for the same reason: nothing rebuilt
+    /// from IG's response can overwrite it.
+    ///
+    /// On **v2** the account lives in the session, and IG re-issues its tokens
+    /// on `PUT /session`. That is per key, so a multi-key pool is refused rather
+    /// than spending one request per key against the allowance the pool exists
+    /// to protect.
+    ///
+    /// Either way the account and its account-wide budget move together and
+    /// atomically: a concurrent request sees the old pair or the new one, never
+    /// a mix.
     ///
     /// # Errors
     ///
-    /// Returns [`AppError::InvalidInput`] when the client was built with more
-    /// than one API key, and whatever [`Auth::switch_account`] reports
-    /// otherwise.
-    ///
-    /// Switching is refused with a pool because it cannot be done coherently
-    /// here: each key holds its own session, so switching only the primary
-    /// leaves the other slots authenticated against the previous account and a
-    /// non-trading read could rotate onto one of them and answer for the wrong
-    /// account. Switching all of them instead would spend one request per key —
-    /// 74 of them in this codebase's demo setup — against the very allowance the
-    /// pool exists to protect. The account also keys the shared account-wide
-    /// budget, which would have to move with it. Build a client per account
-    /// instead.
+    /// Returns [`AppError::InvalidInput`] when `default_account` is `Some(true)`
+    /// — making an account the login default is a v2 account-management
+    /// operation this client does not perform, and silently ignoring the flag
+    /// would leave the caller believing it happened — and when a v2 client holds
+    /// more than one API key. Otherwise returns whatever
+    /// [`Auth::switch_account`] reports.
     pub async fn switch_account(
         &self,
         account_id: &str,
         default_account: Option<bool>,
     ) -> Result<(), AppError> {
-        // v3 selects the account per request through the `IG-ACCOUNT-ID`
-        // header, so switching is a local field update costing no request. That
-        // makes it safe to apply to every slot, which is exactly what a pool
-        // needs: leaving the others behind would let a rotated read answer for
-        // the previous account.
-        if self.primary_auth().is_oauth_session().await {
-            for slot in &self.pool {
-                slot.auth
-                    .switch_account(account_id, default_account)
-                    .await?;
-            }
-            return Ok(());
-        }
-
-        // v2 keeps the account in the session itself, re-issued by IG on a
-        // `PUT /session`. Applying that across a pool would spend one request
-        // per key against the allowance the pool exists to protect, and doing
-        // it on one slot only would leave the rest answering for the previous
-        // account.
-        if self.pool.len() > 1 {
+        if default_account == Some(true) {
             return Err(AppError::InvalidInput(
-                "switch_account cannot be applied coherently to a multi-key v2 pool: \
-                 each key holds its own session; use api_version 3, which selects \
-                 the account per request, or build one client per account"
+                "default_account=true is not supported: making an account the \
+                 login default is not performed by this client; pass None or \
+                 Some(false) to switch for this client only"
                     .to_string(),
             ));
         }
-        self.primary_auth()
-            .switch_account(account_id, default_account)
-            .await?;
+
+        // Taken from the configuration, not from a cached session: on a lazy
+        // client nothing has authenticated yet, and asking the session would
+        // classify a v3 pool as v2 and refuse a switch that costs nothing.
+        let is_oauth = self.config.api_version.unwrap_or(2) == 3;
+
+        if !is_oauth {
+            if self.pool.len() > 1 {
+                return Err(AppError::InvalidInput(
+                    "switch_account cannot be applied coherently to a multi-key v2 \
+                     pool: each key holds the account in its own session, so this \
+                     would cost one request per key; use api_version 3, which \
+                     selects the account per request, or build one client per \
+                     account"
+                        .to_string(),
+                ));
+            }
+            // v2 carries the account in the session, so IG has to be told.
+            self.primary_auth()
+                .switch_account(account_id, default_account)
+                .await?;
+        }
+
+        // Both models end here: the account in force, and the bucket metered
+        // against it, are replaced under one lock.
+        let limiter = Self::build_account_limiter(account_id);
+        {
+            let mut guard = match self.selected.lock() {
+                Ok(g) => g,
+                Err(poisoned) => poisoned.into_inner(),
+            };
+            guard.id = account_id.to_string();
+            guard.limiter = limiter;
+        }
+        debug!(account = %account_id, oauth = is_oauth, "account switched");
         Ok(())
     }
 
@@ -986,6 +1055,19 @@ impl HttpClient {
     /// session this exposes is always one that authenticated.
     pub fn auth(&self) -> &Auth {
         self.primary_auth()
+    }
+
+    /// The account currently in force for every request.
+    ///
+    /// Read under the lock and cloned, so a concurrent switch cannot be observed
+    /// half-applied: a request uses either the previous account with its budget
+    /// or the new one with its own, never one paired with the other's.
+    fn selected_account(&self) -> (String, RateLimiter) {
+        let guard = match self.selected.lock() {
+            Ok(g) => g,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        (guard.id.clone(), guard.limiter.clone())
     }
 
     /// The `Auth` of the slot currently acting as primary.

--- a/src/application/http.rs
+++ b/src/application/http.rs
@@ -787,13 +787,24 @@ impl HttpClient {
                         "API key allowance exhausted, rotating to another key"
                     );
                 }
-                // The token IG rejected belongs to this slot's session, so the
-                // refresh has to happen on that slot - not on the client's own
-                // `auth`, which is slot 0 and may be a different key entirely.
-                Err(AppError::OAuthTokenExpired) if !replayed => {
+                // The session IG rejected belongs to this slot, so the refresh
+                // has to happen on that slot - not on the client's own `auth`,
+                // which is the primary and may be a different key entirely.
+                //
+                // Both 401 shapes are recoverable the same way. OAuth says
+                // `oauth-token-invalid` and is obvious; a v2 session instead
+                // just stops being accepted - IG invalidates CST /
+                // X-SECURITY-TOKEN when the account is switched or the same
+                // account authenticates elsewhere - and says nothing the client
+                // can pattern-match. Until now only the OAuth case re-logged in,
+                // so a v2 session that IG had killed was reused forever: the
+                // local clock still considered it valid (v2 lasts six hours), so
+                // nothing refreshed it, and every request returned 401 without
+                // ever attempting to authenticate again.
+                Err(AppError::OAuthTokenExpired | AppError::Unauthorized) if !replayed => {
                     warn!(
                         key = %redact_key(&slot.api_key),
-                        "OAuth token expired, refreshing this key's session and replaying once"
+                        "session rejected by IG, re-authenticating this key and replaying once"
                     );
                     slot.auth.force_refresh().await?;
                     replayed = true;
@@ -926,11 +937,30 @@ impl HttpClient {
         account_id: &str,
         default_account: Option<bool>,
     ) -> Result<(), AppError> {
+        // v3 selects the account per request through the `IG-ACCOUNT-ID`
+        // header, so switching is a local field update costing no request. That
+        // makes it safe to apply to every slot, which is exactly what a pool
+        // needs: leaving the others behind would let a rotated read answer for
+        // the previous account.
+        if self.primary_auth().is_oauth_session().await {
+            for slot in &self.pool {
+                slot.auth
+                    .switch_account(account_id, default_account)
+                    .await?;
+            }
+            return Ok(());
+        }
+
+        // v2 keeps the account in the session itself, re-issued by IG on a
+        // `PUT /session`. Applying that across a pool would spend one request
+        // per key against the allowance the pool exists to protect, and doing
+        // it on one slot only would leave the rest answering for the previous
+        // account.
         if self.pool.len() > 1 {
             return Err(AppError::InvalidInput(
-                "switch_account cannot be applied coherently to a multi-key pool: \
-                 each key holds its own session and the account keys the shared \
-                 account-wide budget; build one client per account"
+                "switch_account cannot be applied coherently to a multi-key v2 pool: \
+                 each key holds its own session; use api_version 3, which selects \
+                 the account per request, or build one client per account"
                     .to_string(),
             ));
         }

--- a/tests/unit/application/test_key_pool.rs
+++ b/tests/unit/application/test_key_pool.rs
@@ -1178,20 +1178,21 @@ async fn test_ready_fallback_becomes_primary_after_the_primary_is_refused() {
     );
 }
 
-/// `switch_account` is refused with a pool rather than silently leaving the
-/// other slots on the previous account.
+/// A **v2** pool refuses the switch: each key keeps the account in its own
+/// session, so applying it would cost one request per key, and applying it to
+/// one slot would leave the rest answering for the previous account.
 #[tokio::test]
-async fn test_switch_account_is_refused_with_a_key_pool() {
+async fn test_v2_switch_account_is_refused_with_a_key_pool() {
     let server = MockServer::start().await;
-    mount_login_ok(&server).await;
+    mount_v2_login(&server, "BS0Y3").await;
 
-    let client = HttpClient::new_lazy(pool_config_burst(&server.uri(), "key-a,key-b", 20, 1, 20))
+    let client = HttpClient::new_lazy(v2_config(&server.uri(), "key-a,key-b", "BS0Y3"))
         .expect("client builds");
 
     let err = client
         .switch_account("OTHER", Some(false))
         .await
-        .expect_err("switching is refused with a pool");
+        .expect_err("switching is refused for a v2 pool");
     assert!(matches!(err, AppError::InvalidInput(_)), "got {err:?}");
 
     let switches = server
@@ -1199,45 +1200,47 @@ async fn test_switch_account_is_refused_with_a_key_pool() {
         .await
         .unwrap_or_default()
         .iter()
-        .filter(|r| r.url.path() == "/session")
-        .filter(|r| r.method == wiremock::http::Method::PUT)
+        .filter(|r| r.url.path() == "/session" && r.method == wiremock::http::Method::PUT)
         .count();
     assert_eq!(switches, 0, "no key was switched behind the others' backs");
 }
 
-/// A single key is not stopped by the pool guard.
-///
-/// It can still fail for its own reasons — switching is unsupported on OAuth
-/// sessions, which is a pre-existing limitation of `Auth` and unrelated to the
-/// pool — but the refusal must not be `UnsupportedWithKeyPool`.
+/// A **v3** pool switches freely: the account is per request, so there is
+/// nothing per-key to keep consistent and no request to spend.
 #[tokio::test]
-async fn test_switch_account_still_works_with_one_key() {
+async fn test_v3_switch_account_is_allowed_with_a_key_pool() {
     let server = MockServer::start().await;
     mount_login_ok(&server).await;
-    Mock::given(method("PUT"))
-        .and(path("/session"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-            "trailingStopsEnabled": false,
-            "dealingEnabled": true,
-            "hasActiveDemoAccounts": true,
-            "hasActiveLiveAccounts": false
-        })))
-        .mount(&server)
-        .await;
+    mount_data_ok(&server).await;
 
-    let client = HttpClient::new_lazy(pool_config_burst(&server.uri(), "only-key", 20, 1, 20))
+    let client = HttpClient::new_lazy(pool_config_burst(&server.uri(), "key-a,key-b", 20, 1, 20))
         .expect("client builds");
 
-    let result = client.switch_account("OTHER", Some(false)).await;
-    // The guard reports InvalidInput naming the pool; a single key must fail
-    // for some other reason, or not at all.
-    let hit_pool_guard = matches!(&result, Err(AppError::InvalidInput(m)) if m.contains("pool"));
-    assert!(
-        !hit_pool_guard,
-        "the pool guard did not fire for a single key, got {result:?}"
-    );
+    let before = server.received_requests().await.unwrap_or_default().len();
+    client
+        .switch_account("BSI1I", None)
+        .await
+        .expect("v3 pools switch freely");
+    let after = server.received_requests().await.unwrap_or_default().len();
+
+    assert_eq!(after, before, "the switch cost no HTTP request");
 }
 
+/// A single v2 key is not stopped by the pool guard.
+#[tokio::test]
+async fn test_v2_switch_account_works_with_one_key() {
+    let server = MockServer::start().await;
+    mount_v2_login(&server, "BS0Y3").await;
+    mount_v2_switch(&server, 200).await;
+
+    let client =
+        HttpClient::new_lazy(v2_config(&server.uri(), "only-key", "BS0Y3")).expect("client builds");
+
+    client
+        .switch_account("BSI1I", Some(false))
+        .await
+        .expect("a single v2 key switches");
+}
 /// A v2 session that IG has invalidated is re-authenticated, not reused.
 ///
 /// This is what wedged `ig-categories` in production: IG kills CST /
@@ -1321,43 +1324,266 @@ async fn test_persistent_401_replays_once_and_then_fails() {
     assert_eq!(data, 2, "one replay only, got {data} attempts");
 }
 
-/// On v3, switching accounts costs no request and reaches every key.
+/// A v2 config: CST / X-SECURITY-TOKEN instead of OAuth.
+fn v2_config(base_url: &str, keys: &str, account: &str) -> Config {
+    let mut config = pool_config_burst(base_url, keys, 40, 1, 40);
+    config.api_version = Some(2);
+    config.credentials.account_id = account.to_string();
+    config
+}
+
+/// Mounts a v2 `/session` login that hands out CST / X-SECURITY-TOKEN and
+/// reports `default_account` as the logged-in account.
+async fn mount_v2_login(server: &MockServer, default_account: &str) {
+    Mock::given(method("POST"))
+        .and(path("/session"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("CST", "cst-token")
+                .insert_header("X-SECURITY-TOKEN", "xst-original")
+                .set_body_json(serde_json::json!({
+                    "accountType": "CFD",
+                    "accountInfo": {
+                        "balance": 10000.0,
+                        "deposit": 2000.0,
+                        "profitLoss": 150.5,
+                        "available": 8000.0
+                    },
+                    "currencyIsoCode": "EUR",
+                    "currencySymbol": "E",
+                    "currentAccountId": default_account,
+                    "lightstreamerEndpoint": "https://example.invalid",
+                    "accounts": [{
+                        "accountId": default_account,
+                        "accountName": "Default",
+                        "preferred": true,
+                        "accountType": "CFD"
+                    }],
+                    "clientId": "CLIENT-1",
+                    "timezoneOffset": 1,
+                    "hasActiveDemoAccounts": true,
+                    "hasActiveLiveAccounts": false,
+                    "trailingStopsEnabled": false,
+                    "reroutingEnvironment": null,
+                    "dealingEnabled": true
+                })),
+        )
+        .mount(server)
+        .await;
+}
+
+/// Mounts the `PUT /session` account switch, re-issuing X-SECURITY-TOKEN the way
+/// IG does.
+async fn mount_v2_switch(server: &MockServer, status: u16) {
+    let template = if status == 200 {
+        ResponseTemplate::new(200)
+            .insert_header("X-SECURITY-TOKEN", "xst-after-switch")
+            .set_body_json(serde_json::json!({
+                "trailingStopsEnabled": false,
+                "dealingEnabled": true,
+                "hasActiveDemoAccounts": true,
+                "hasActiveLiveAccounts": false
+            }))
+    } else {
+        ResponseTemplate::new(status).set_body_json(serde_json::json!({
+            "errorCode": "error.switch.accountId-must-be-different"
+        }))
+    };
+    Mock::given(method("PUT"))
+        .and(path("/session"))
+        .respond_with(template)
+        .mount(server)
+        .await;
+}
+
+/// The security tokens each `/data` request carried, in order.
+async fn security_tokens(server: &MockServer) -> Vec<String> {
+    server
+        .received_requests()
+        .await
+        .unwrap_or_default()
+        .iter()
+        .filter(|r| r.url.path() == "/data")
+        .map(|r| {
+            r.headers
+                .get("X-SECURITY-TOKEN")
+                .and_then(|v| v.to_str().ok())
+                .unwrap_or_default()
+                .to_string()
+        })
+        .collect()
+}
+
+/// A real v2 session — CST / X-SECURITY-TOKEN, with the configured account
+/// selected through `PUT /session` — recovers when IG invalidates it.
 ///
-/// An OAuth token identifies the client, not an account: the account travels in
-/// the `IG-ACCOUNT-ID` header of each request. So the switch is a local field
-/// update — and because it is free, it can be applied to the whole pool, which
-/// is what stops a rotated read from answering for the previous account.
+/// The replay must go out on the same key and with the *re-issued* tokens.
 #[tokio::test]
-async fn test_v3_switch_account_is_local_and_reaches_every_key() {
+async fn test_v2_invalidated_session_replays_on_same_key_with_new_tokens() {
     let server = MockServer::start().await;
-    mount_login_ok(&server).await;
+    mount_v2_login(&server, "BS0Y3").await;
+    mount_v2_switch(&server, 200).await;
+
+    // First data call is rejected; the replay after re-authentication succeeds.
+    Mock::given(method("GET"))
+        .and(path("/data"))
+        .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+            "errorCode": "error.security.client-token-invalid"
+        })))
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
     mount_data_ok(&server).await;
 
-    let client = HttpClient::new_lazy(pool_config_burst(&server.uri(), "key-a,key-b", 4, 10, 2))
-        .expect("client builds");
-
-    // Warm both keys so each holds a session to switch.
-    for _ in 0..8 {
-        let _ = client.get::<Dummy>("/data", Some(1)).await;
-    }
-    let before = server.received_requests().await.unwrap_or_default().len();
+    let client =
+        HttpClient::new_lazy(v2_config(&server.uri(), "key-a", "BSI1I")).expect("client builds");
 
     client
-        .switch_account("BSI1I", Some(false))
+        .get::<Dummy>("/data", Some(1))
         .await
-        .expect("v3 switching is supported and free");
+        .expect("recovered after re-authenticating");
 
-    let after = server.received_requests().await.unwrap_or_default().len();
-    assert_eq!(after, before, "the switch sent no HTTP request at all");
+    let keys = keys_used(&server).await;
+    assert_eq!(keys.len(), 2, "the rejected call plus one replay");
+    assert_eq!(keys[0], keys[1], "the replay stayed on the same key");
 
-    // Every subsequent request must carry the new account, whichever key serves
-    // it.
-    server.reset().await;
-    mount_login_ok(&server).await;
+    let tokens = security_tokens(&server).await;
+    assert_eq!(
+        tokens[1], "xst-after-switch",
+        "the replay used the token re-issued by the switch, got {tokens:?}"
+    );
+
+    let switches = server
+        .received_requests()
+        .await
+        .unwrap_or_default()
+        .iter()
+        .filter(|r| r.url.path() == "/session" && r.method == wiremock::http::Method::PUT)
+        .count();
+    assert!(
+        switches >= 2,
+        "the configured account was selected again after the re-login"
+    );
+}
+
+/// With two v2 keys and both sessions dead, the replay must not wander onto the
+/// other key: that key was not re-authenticated, so it would burn the single
+/// replay on a session that is equally invalid.
+#[tokio::test]
+async fn test_v2_replay_does_not_move_to_another_key() {
+    let server = MockServer::start().await;
+    mount_v2_login(&server, "BS0Y3").await;
+    mount_v2_switch(&server, 200).await;
+    Mock::given(method("GET"))
+        .and(path("/data"))
+        .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+            "errorCode": "error.security.client-token-invalid"
+        })))
+        .mount(&server)
+        .await;
+
+    // Two keys, so a pool switch is refused - but this client never switches:
+    // the account equals the login default, so no PUT is needed.
+    let mut config = v2_config(&server.uri(), "key-a,key-b", "BS0Y3");
+    config.credentials.account_id = "BS0Y3".to_string();
+    let client = HttpClient::new_lazy(config).expect("client builds");
+
+    let err = client
+        .get::<Dummy>("/data", Some(1))
+        .await
+        .expect_err("every attempt is rejected");
+    assert!(matches!(err, AppError::Unauthorized), "got {err:?}");
+
+    let keys = keys_used(&server).await;
+    assert_eq!(keys.len(), 2, "one attempt and one replay, got {keys:?}");
+    assert_eq!(
+        keys[0], keys[1],
+        "the replay stayed on the re-authenticated key, got {keys:?}"
+    );
+}
+
+/// A failed `PUT /session` must not leave the login's default account cached.
+///
+/// Otherwise the next request runs silently against the wrong account, or spins
+/// on 401 — the session and the selected account have to move together.
+#[tokio::test]
+async fn test_v2_failed_switch_leaves_no_usable_session() {
+    let server = MockServer::start().await;
+    mount_v2_login(&server, "BS0Y3").await;
+    mount_v2_switch(&server, 403).await;
     mount_data_ok(&server).await;
-    for _ in 0..6 {
-        let _ = client.get::<Dummy>("/data", Some(1)).await;
-    }
+
+    let client =
+        HttpClient::new_lazy(v2_config(&server.uri(), "key-a", "BSI1I")).expect("client builds");
+
+    let err = client
+        .get::<Dummy>("/data", Some(1))
+        .await
+        .expect_err("the account could not be selected");
+    assert!(
+        !matches!(err, AppError::Unauthorized),
+        "surfaced as {err:?}"
+    );
+
+    // Nothing may have gone out against the login's default account.
+    let data = keys_used(&server).await;
+    assert!(
+        data.is_empty(),
+        "no request ran against the wrong account, got {data:?}"
+    );
+}
+
+/// `default_account = true` is refused rather than silently ignored: making an
+/// account the login default is not something this client does.
+#[tokio::test]
+async fn test_switch_account_rejects_default_account_true() {
+    let server = MockServer::start().await;
+    mount_login_ok(&server).await;
+
+    let client = HttpClient::new_lazy(pool_config_burst(&server.uri(), "key-a", 20, 1, 20))
+        .expect("client builds");
+
+    let err = client
+        .switch_account("BSI1I", Some(true))
+        .await
+        .expect_err("the flag is not silently dropped");
+    assert!(matches!(err, AppError::InvalidInput(_)), "got {err:?}");
+}
+
+/// On v3 the selected account survives a re-login.
+///
+/// The session is rebuilt from IG's response, which reports the login's default
+/// account, so an account kept inside the session would be silently undone by
+/// any refresh or 401 recovery.
+#[tokio::test]
+async fn test_v3_selected_account_survives_reauthentication() {
+    let server = MockServer::start().await;
+    mount_login_ok(&server).await;
+
+    // One rejection forces a re-login mid-flight.
+    Mock::given(method("GET"))
+        .and(path("/data"))
+        .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+            "errorCode": "error.security.client-token-invalid"
+        })))
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
+    mount_data_ok(&server).await;
+
+    let client = HttpClient::new_lazy(pool_config_burst(&server.uri(), "key-a,key-b", 20, 1, 20))
+        .expect("client builds");
+
+    client
+        .switch_account("BSI1I", None)
+        .await
+        .expect("v3 switching is free");
+
+    // This request is rejected once, re-authenticates, and replays.
+    client
+        .get::<Dummy>("/data", Some(1))
+        .await
+        .expect("recovered");
 
     let accounts: std::collections::HashSet<String> = server
         .received_requests()
@@ -1373,10 +1599,50 @@ async fn test_v3_switch_account_is_local_and_reaches_every_key() {
         })
         .collect();
 
-    assert!(!accounts.is_empty(), "requests carried an account header");
     assert_eq!(
         accounts,
         std::iter::once("BSI1I".to_string()).collect(),
-        "every key switched, got {accounts:?}"
+        "every request kept the selected account across the re-login, got {accounts:?}"
+    );
+}
+
+/// Switching accounts also switches the account-wide budget: the new account
+/// must not inherit what the previous one had already spent.
+#[tokio::test]
+async fn test_switching_accounts_switches_the_account_budget() {
+    let server = MockServer::start().await;
+    mount_login_ok(&server).await;
+    mount_data_ok(&server).await;
+
+    let mut config = pool_config_burst(&server.uri(), "key-a", 100, 60, 100);
+    config.credentials.account_id = "BUDGET-A".to_string();
+    let client = HttpClient::new_lazy(config).expect("client builds");
+
+    // Drain a few tokens from account A's bucket.
+    for _ in 0..3 {
+        let _ = tokio::time::timeout(
+            Duration::from_secs(3),
+            client.get::<Dummy>("/data", Some(1)),
+        )
+        .await;
+    }
+
+    client
+        .switch_account("BUDGET-B", None)
+        .await
+        .expect("switch succeeds");
+
+    // A fresh account starts with a full bucket, so this goes out promptly
+    // rather than waiting on the previous account's spent allowance.
+    let started = Instant::now();
+    let served = tokio::time::timeout(
+        Duration::from_secs(3),
+        client.get::<Dummy>("/data", Some(1)),
+    )
+    .await;
+    assert!(
+        served.is_ok(),
+        "the new account had its own budget, waited {:?}",
+        started.elapsed()
     );
 }

--- a/tests/unit/application/test_key_pool.rs
+++ b/tests/unit/application/test_key_pool.rs
@@ -1237,3 +1237,146 @@ async fn test_switch_account_still_works_with_one_key() {
         "the pool guard did not fire for a single key, got {result:?}"
     );
 }
+
+/// A v2 session that IG has invalidated is re-authenticated, not reused.
+///
+/// This is what wedged `ig-categories` in production: IG kills CST /
+/// X-SECURITY-TOKEN when the account is switched or the same account logs in
+/// elsewhere, and answers 401 with nothing the client can pattern-match. The
+/// local clock still considered the session valid — v2 lasts six hours — so
+/// nothing refreshed it, and every cycle replayed the dead token forever
+/// without ever trying to log in again.
+#[tokio::test]
+async fn test_invalidated_v2_session_is_reauthenticated_and_replayed() {
+    let server = MockServer::start().await;
+    mount_login_ok(&server).await;
+
+    // The first data call is rejected as unauthorized, with a body that carries
+    // no OAuth marker - exactly what a killed v2 session looks like.
+    Mock::given(method("GET"))
+        .and(path("/data"))
+        .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+            "errorCode": "error.security.client-token-invalid"
+        })))
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
+    mount_data_ok(&server).await;
+
+    let client = HttpClient::new_lazy(pool_config_burst(&server.uri(), "key-a", 20, 1, 20))
+        .expect("client builds");
+
+    let result = client.get::<Dummy>("/data", Some(1)).await;
+    assert!(
+        result.is_ok(),
+        "the request succeeded after re-authenticating, got {result:?}"
+    );
+
+    let requests = server.received_requests().await.unwrap_or_default();
+    let logins = requests
+        .iter()
+        .filter(|r| r.url.path() == "/session")
+        .count();
+    let data = requests.iter().filter(|r| r.url.path() == "/data").count();
+    assert_eq!(data, 2, "the rejected call plus its replay");
+    assert!(
+        logins >= 2,
+        "the rejection triggered a fresh login, saw {logins}"
+    );
+}
+
+/// A 401 that keeps coming back fails after exactly one replay, rather than
+/// looping between re-authentication and rejection.
+#[tokio::test]
+async fn test_persistent_401_replays_once_and_then_fails() {
+    let server = MockServer::start().await;
+    mount_login_ok(&server).await;
+    Mock::given(method("GET"))
+        .and(path("/data"))
+        .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+            "errorCode": "error.security.client-token-invalid"
+        })))
+        .mount(&server)
+        .await;
+
+    let client = HttpClient::new_lazy(pool_config_burst(&server.uri(), "key-a", 20, 1, 20))
+        .expect("client builds");
+
+    let err = tokio::time::timeout(
+        Duration::from_secs(20),
+        client.get::<Dummy>("/data", Some(1)),
+    )
+    .await
+    .expect("no infinite loop")
+    .expect_err("a permanent 401 still fails");
+    assert!(matches!(err, AppError::Unauthorized), "got {err:?}");
+
+    let data = server
+        .received_requests()
+        .await
+        .unwrap_or_default()
+        .iter()
+        .filter(|r| r.url.path() == "/data")
+        .count();
+    assert_eq!(data, 2, "one replay only, got {data} attempts");
+}
+
+/// On v3, switching accounts costs no request and reaches every key.
+///
+/// An OAuth token identifies the client, not an account: the account travels in
+/// the `IG-ACCOUNT-ID` header of each request. So the switch is a local field
+/// update — and because it is free, it can be applied to the whole pool, which
+/// is what stops a rotated read from answering for the previous account.
+#[tokio::test]
+async fn test_v3_switch_account_is_local_and_reaches_every_key() {
+    let server = MockServer::start().await;
+    mount_login_ok(&server).await;
+    mount_data_ok(&server).await;
+
+    let client = HttpClient::new_lazy(pool_config_burst(&server.uri(), "key-a,key-b", 4, 10, 2))
+        .expect("client builds");
+
+    // Warm both keys so each holds a session to switch.
+    for _ in 0..8 {
+        let _ = client.get::<Dummy>("/data", Some(1)).await;
+    }
+    let before = server.received_requests().await.unwrap_or_default().len();
+
+    client
+        .switch_account("BSI1I", Some(false))
+        .await
+        .expect("v3 switching is supported and free");
+
+    let after = server.received_requests().await.unwrap_or_default().len();
+    assert_eq!(after, before, "the switch sent no HTTP request at all");
+
+    // Every subsequent request must carry the new account, whichever key serves
+    // it.
+    server.reset().await;
+    mount_login_ok(&server).await;
+    mount_data_ok(&server).await;
+    for _ in 0..6 {
+        let _ = client.get::<Dummy>("/data", Some(1)).await;
+    }
+
+    let accounts: std::collections::HashSet<String> = server
+        .received_requests()
+        .await
+        .unwrap_or_default()
+        .iter()
+        .filter(|r| r.url.path() == "/data")
+        .filter_map(|r| {
+            r.headers
+                .get("IG-ACCOUNT-ID")
+                .and_then(|v| v.to_str().ok())
+                .map(str::to_string)
+        })
+        .collect();
+
+    assert!(!accounts.is_empty(), "requests carried an account header");
+    assert_eq!(
+        accounts,
+        std::iter::once("BSI1I".to_string()).collect(),
+        "every key switched, got {accounts:?}"
+    );
+}


### PR DESCRIPTION
## The production failure this fixes

`ig-categories` in production wedged into a permanent 401 loop: every 60-second cycle asked for the first page and got 401 back in **90 ms** — too fast to have attempted a login.

A v2 session had been invalidated by IG, and the client kept reusing it forever:

- IG kills `CST` / `X-SECURITY-TOKEN` when the account is switched (`PUT /session`) or the same account authenticates elsewhere. In this deployment the configured account is not the login's default one, so **every** login is followed by a switch.
- IG's 401 for that case carries nothing the client can pattern-match — only the OAuth case says `oauth-token-invalid` — so it mapped to `AppError::Unauthorized` and was returned as-is, with no re-login.
- Nothing refreshed it either: the proactive refresh reads the local `expires_at`, and a v2 session believes it is valid for six hours.

Both 401 shapes now re-authenticate the rejected slot and replay once. A permanent 401 still fails after that single replay rather than looping.

## `switch_account` on v3

It used to return `Cannot switch accounts with OAuth`, which framed as a limitation something that is simply unnecessary: an OAuth access token identifies the *client*, and the account is selected per request by the `IG-ACCOUNT-ID` header. The switch is therefore a local field update costing no HTTP request.

Because it is free, it is applied to **every slot** of a pool — leaving the others behind would let a rotated read answer for the previous account. v2 is unchanged, including the refusal on a multi-key pool, where switching would spend one request per key against the very allowance the pool exists to protect.

## Diagnosis notes

Ruled out by measurement against the live account before landing on the cause: all five production keys authenticate and serve `/categories` (HTTP 200 each); concurrent sessions do not invalidate one another; the OAuth token lasts 1800 s, not 60; five sessions rotating in parallel all return 200; and the 401 persists with a **single** key, so the pool is not involved. Using the tokens re-issued by the switch returns 200, confirming the client's handling of them is correct.

## Tests

Both were checked against the unpatched code first:

- `test_invalidated_v2_session_is_reauthenticated_and_replayed` — fails with `Err(Unauthorized)` without the fix, which is exactly the production symptom.
- `test_persistent_401_replays_once_and_then_fails` — guards against turning the fix into a loop.
- `test_v3_switch_account_is_local_and_reaches_every_key` — asserts zero HTTP requests for the switch and that every subsequent request carries the new account, whichever key serves it.

`cargo clippy --all-targets --all-features -W missing-docs -D warnings` clean, 552 tests passing, rustdoc warning-free.