### PR TITLE
feat: expose switch_account on Client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ig-client"
-version = "0.16.3"
+version = "0.16.4"
 edition = "2024"
 authors = ["Joaquin Bejar <jb@taunais.com>"]
 description = "This crate provides a client for the IG Markets API"

--- a/src/application/client.rs
+++ b/src/application/client.rs
@@ -264,6 +264,31 @@ impl Client {
         self.http_client.config()
     }
 
+    /// Switches every subsequent request to a different trading account.
+    ///
+    /// Delegates to [`HttpClient::switch_account`]. A service holding one client
+    /// per IG login needs this to reach that login's other accounts: on v3 the
+    /// account is chosen per request through `IG-ACCOUNT-ID`, so switching costs
+    /// no request and does not disturb the session or the key pool. On v2 the
+    /// account lives in the session and IG is asked to change it.
+    ///
+    /// It mutates client-wide state, so a caller serving several accounts
+    /// concurrently must serialise the switch with the request that follows it.
+    ///
+    /// # Errors
+    /// Returns whatever [`HttpClient::switch_account`] reports: notably
+    /// [`AppError::InvalidInput`] for `default_account = true`, or for a
+    /// multi-key v2 pool where switching would cost one request per key.
+    pub async fn switch_account(
+        &self,
+        account_id: &str,
+        default_account: Option<bool>,
+    ) -> Result<(), AppError> {
+        self.http_client
+            .switch_account(account_id, default_account)
+            .await
+    }
+
     /// Gets WebSocket connection information for Lightstreamer, reusing the
     /// cached session.
     ///

--- a/tests/unit/application/test_key_pool.rs
+++ b/tests/unit/application/test_key_pool.rs
@@ -1646,3 +1646,30 @@ async fn test_switching_accounts_switches_the_account_budget() {
         started.elapsed()
     );
 }
+
+/// `Client` exposes the account switch, so a service holding one client per IG
+/// login can reach that login's other accounts without reaching for internals.
+#[tokio::test]
+async fn test_client_exposes_switch_account() {
+    let server = MockServer::start().await;
+    mount_login_ok(&server).await;
+    mount_data_ok(&server).await;
+
+    let client = ig_client::application::client::Client::with_config(pool_config_burst(
+        &server.uri(),
+        "key-a",
+        20,
+        1,
+        20,
+    ))
+    .expect("client builds");
+
+    let before = server.received_requests().await.unwrap_or_default().len();
+    client
+        .switch_account("BSI1I", None)
+        .await
+        .expect("v3 switching is supported through Client");
+    let after = server.received_requests().await.unwrap_or_default().len();
+
+    assert_eq!(after, before, "the switch cost no HTTP request");
+}


### PR DESCRIPTION
`HttpClient::switch_account` existed, but `Client` — the type consumers hold — did not expose it, so a service could not reach another account of the same IG login through the public API.

The workaround would have been one client per account. That splits the same API keys across two pools, and since each pool meters its own per-key budget, both would believe they had the whole allowance and together exceed it — producing exactly the `exceeded-api-key-allowance` rejections the pool exists to prevent.

On v3 the switch costs no HTTP request: the account travels in `IG-ACCOUNT-ID` per request, so it is a client-state update. On v2 it still performs `PUT /session`.

Needed by executionengine, which is gaining alias-based routing so an order can name which IG identity and which of its accounts executes it.

Test asserts the switch goes through `Client` and sends no request. `make pre-push` clean.