### PR TITLE
chore: dotenv to dotenvy, release 0.16.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ig-client"
-version = "0.16.4"
+version = "0.16.5"
 edition = "2024"
 authors = ["Joaquin Bejar <jb@taunais.com>"]
 description = "This crate provides a client for the IG Markets API"
@@ -51,7 +51,7 @@ reqwest ={ workspace = true}
 sqlx = { workspace = true, optional = true }
 async-trait = { workspace = true}
 regex = { workspace = true}
-dotenv = { workspace = true}
+dotenvy = { workspace = true}
 lightstreamer-rs = { workspace = true, optional = true }
 lazy_static = { workspace = true}
 nanoid = { workspace = true}
@@ -112,7 +112,7 @@ criterion = "0.8"
 sqlx = { version = "0.9", features = [ "postgres","macros","chrono","runtime-tokio","tls-native-tls"]}
 async-trait = "0.1"
 regex = "1.13"
-dotenv = "0.15"
+dotenvy = "0.15"
 lightstreamer-rs = "1.0"
 lazy_static = "1.5"
 nanoid = "0.5"

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ tracing = "0.1"                                  # Logging facade
 sqlx = { version = "0.9", features = ["runtime-tokio", "tls-native-tls", "postgres"] }
 ```
 
-You do not need to add `dotenv` yourself — `Config::new()` loads a local
+You do not need to add `dotenvy` yourself — `Config::new()` loads a local
 `.env` file internally. If your application supplies its own configuration
 and must not read a `.env` file or the `IG_*` namespace, use
 `Config::from_credentials()` with `Client::with_config()` instead (see

--- a/examples/simples/src/bin/client_with_config.rs
+++ b/examples/simples/src/bin/client_with_config.rs
@@ -4,7 +4,7 @@
 //! reads the global `IG_*` environment namespace. An embedding application that
 //! keeps credentials in its own namespaced variables — and must not have the
 //! crate reach for globals or a `.env` file — uses `Config::from_credentials`
-//! plus `Client::with_config` instead. Neither touches `dotenv` nor `IG_*`.
+//! plus `Client::with_config` instead. Neither touches `dotenvy` nor `IG_*`.
 //!
 //! Run with the embedder's own variables set:
 //!

--- a/src/application/config.rs
+++ b/src/application/config.rs
@@ -6,7 +6,7 @@ use crate::constants::{
     DEFAULT_WS_RECONNECT_INTERVAL_SECS, DEFAULT_WS_URL,
 };
 use crate::utils::config::get_env_or_default;
-use dotenv::dotenv;
+use dotenvy::dotenv;
 use pretty_simple_display::{DebugPretty, DisplaySimple};
 use serde::{Deserialize, Serialize};
 use std::env;
@@ -357,7 +357,7 @@ impl Config {
 
     /// Creates a new configuration instance from the environment.
     ///
-    /// Loads a local `.env` file (via `dotenv`) and reads the `IG_*` /
+    /// Loads a local `.env` file (via `dotenvy`) and reads the `IG_*` /
     /// `DATABASE_*` / `TX_*` environment variables, falling back to the
     /// documented defaults for anything unset. Embedders that must not touch
     /// the `.env` file or the `IG_*` namespace should use

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@
 //! sqlx = { version = "0.9", features = ["runtime-tokio", "tls-native-tls", "postgres"] }
 //! ```
 //!
-//! You do not need to add `dotenv` yourself — `Config::new()` loads a local
+//! You do not need to add `dotenvy` yourself — `Config::new()` loads a local
 //! `.env` file internally. If your application supplies its own configuration
 //! and must not read a `.env` file or the `IG_*` namespace, use
 //! `Config::from_credentials()` with `Client::with_config()` instead (see

--- a/src/storage/utils.rs
+++ b/src/storage/utils.rs
@@ -151,7 +151,7 @@ pub async fn create_connection_pool(config: &DatabaseConfig) -> Result<PgPool, A
 /// # Returns
 /// * `Result<DatabaseConfig, AppError>` - Database configuration or an error
 pub fn create_database_config_from_env() -> Result<DatabaseConfig, AppError> {
-    dotenv::dotenv().ok();
+    dotenvy::dotenv().ok();
     let url = std::env::var("DATABASE_URL").map_err(|_| {
         AppError::InvalidInput("DATABASE_URL environment variable is required".to_string())
     })?;


### PR DESCRIPTION
dotenv has been unmaintained since 2021 (RUSTSEC-2021-0141); dotenvy is the maintained fork and a drop-in replacement, so the swap is the import path and nothing else. The README and doc comments that named the crate follow.

`make pre-push` is clean and `cargo audit` no longer reports dotenv for this crate.

https://claude.ai/code/session_01GK7fbCMXWDVoNRSEVcUeaa