### PR TITLE
Fix catalogue page-limit test running for 71 minutes on real pacing (#98)

### DIFF
--- a/doc/MARKET_CATALOG.md
+++ b/doc/MARKET_CATALOG.md
@@ -145,11 +145,18 @@ mapping remains part of the consumer's integration verification.
 ## Verification and DATA-ENGINE adoption
 
 The public-client regressions in
-[`test_market_catalog.rs`](../tests/unit/application/test_market_catalog.rs) use
-local HTTP mocks. Their categories, instruments, dates, and failures are synthetic
+[`test_market_catalog.rs`](../tests/unit/application/test_market_catalog.rs) and
+the page-limit regression in the
+[`Client` test module](../src/application/client.rs) use local HTTP mocks.
+Their categories, instruments, dates, and failures are synthetic
 fixtures, not claims about observed production incidents. They exercise both
 public methods, pagination failures, duplicate handling, and individual expiries.
 DTO conversion round-trips also reuse the existing category payload fixture.
+
+The page-limit fixture uses an isolated account quota compiled only for tests.
+It exercises the actual 1,000-page boundary through both public methods without
+waiting for the production account budget. Other catalogue fixtures use distinct
+synthetic accounts so concurrent tests do not compete for one account quota.
 
 Official documentation was checked; this change has not been exercised against
 an authenticated IG account. Compilation and fixture checks do not establish

--- a/src/application/client.rs
+++ b/src/application/client.rs
@@ -2362,3 +2362,131 @@ mod streaming_tests {
         assert!(tasks.is_empty());
     }
 }
+
+#[cfg(test)]
+mod catalog_limit_tests {
+    use super::Client;
+    use crate::application::config::{Config, Credentials, RateLimiterConfig};
+    use crate::application::http::HttpClient;
+    use crate::application::interfaces::market::MarketService;
+    use crate::application::rate_limiter::RateLimiter;
+    use crate::error::AppError;
+    use serde_json::json;
+    use std::sync::Arc;
+    use std::time::Duration;
+    use wiremock::matchers::{header, method, path, query_param};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    #[tokio::test]
+    async fn test_public_catalog_page_limit_without_completion_is_an_error()
+    -> Result<(), Box<dyn std::error::Error>> {
+        // Synthetic transport fixtures, not recorded IG responses. This test
+        // checks traversal limits, not real-time governor scheduling; inject
+        // the account quota only in this cfg(test) build to keep all 2,000 page
+        // requests fast without weakening production's 30/minute allowance.
+        tokio::time::timeout(Duration::from_secs(30), async {
+            let server = MockServer::start().await;
+            Mock::given(method("POST"))
+                .and(path("/session"))
+                .and(header("Version", "3"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                    "clientId": "CATALOG-LIMIT-FIXTURE-CLIENT",
+                    "accountId": "CATALOG-LIMIT-FIXTURE-ACCOUNT",
+                    "timezoneOffset": 0,
+                    "lightstreamerEndpoint": "https://example.invalid",
+                    "oauthToken": {
+                        "access_token": "FIXTURE-NOT-A-REAL-ACCESS-TOKEN",
+                        "refresh_token": "FIXTURE-NOT-A-REAL-REFRESH-TOKEN",
+                        "scope": "profile",
+                        "token_type": "Bearer",
+                        "expires_in": "3600"
+                    }
+                })))
+                .expect(1)
+                .mount(&server)
+                .await;
+            Mock::given(method("GET"))
+                .and(path("/categories"))
+                .and(header("Version", "1"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                    "categories": [{"code": "unbounded", "nonTradeable": false}]
+                })))
+                .expect(2)
+                .mount(&server)
+                .await;
+            Mock::given(method("GET"))
+                .and(path("/categories/unbounded/instruments"))
+                .and(header("Version", "1"))
+                .and(query_param("pageSize", "500"))
+                .respond_with(|request: &wiremock::Request| {
+                    let page = request
+                        .url
+                        .query_pairs()
+                        .find(|(name, _)| name == "pageNumber")
+                        .and_then(|(_, value)| value.parse::<i64>().ok())
+                        .unwrap_or(-1);
+                    ResponseTemplate::new(200).set_body_json(json!({
+                        "instruments": [{
+                            "epic": format!("IX.D.FIXTURE.PAGE{page}.IP"),
+                            "instrumentName": "Synthetic never-ending category fixture",
+                            "expiry": "DFB",
+                            "instrumentType": "INDICES",
+                            "otcTradeable": true,
+                            "marketStatus": "TRADEABLE"
+                        }],
+                        "metadata": {"pageNumber": page, "pageSize": 1}
+                    }))
+                })
+                .expect(2_000)
+                .mount(&server)
+                .await;
+            let quota = RateLimiterConfig {
+                max_requests: 100_000,
+                period_seconds: 1,
+                burst_size: 2_010,
+            };
+            let mut config = Config::from_credentials(Credentials::new(
+                "FIXTURE-USER".into(),
+                "FIXTURE-PASSWORD".into(),
+                "CATALOG-LIMIT-FIXTURE-ACCOUNT".into(),
+                "FIXTURE-API-KEY".into(),
+            ));
+            config.rest_api.base_url = server.uri();
+            config.api_version = Some(3);
+            config.rate_limiter = quota.clone();
+            let client = Client {
+                http_client: Arc::new(HttpClient::new_lazy_with_test_account_limiter(
+                    config,
+                    RateLimiter::new(&quota),
+                )?),
+            };
+            let market_error = client
+                .get_all_markets()
+                .await
+                .err()
+                .ok_or("unbounded catalogue unexpectedly succeeded")?;
+            let entry_error = client
+                .get_vec_db_entries()
+                .await
+                .err()
+                .ok_or("unbounded database entries unexpectedly succeeded")?;
+            for error in [market_error, entry_error] {
+                let AppError::CatalogPagination {
+                    category_id,
+                    page_number,
+                    reason,
+                } = error
+                else {
+                    return Err("expected the catalogue page limit error".into());
+                };
+                assert_eq!(category_id, "unbounded");
+                assert_eq!(page_number, 1000);
+                assert!(reason.contains("page request limit"));
+            }
+            server.verify().await;
+            Ok::<(), Box<dyn std::error::Error>>(())
+        })
+        .await??;
+        Ok(())
+    }
+}

--- a/src/application/http.rs
+++ b/src/application/http.rs
@@ -281,6 +281,27 @@ impl HttpClient {
         })
     }
 
+    /// Creates a lazy fixture client with an isolated account quota.
+    ///
+    /// Rebuild the auth pool as well as request pacing before any request, so
+    /// login and data traffic share the same injected quota. Production builds
+    /// expose no override and retain the fixed per-account allowance.
+    #[cfg(test)]
+    pub(crate) fn new_lazy_with_test_account_limiter(
+        config: Config,
+        account_limiter: RateLimiter,
+    ) -> Result<Self, AppError> {
+        let mut client = Self::new_lazy(config)?;
+        let (auth, pool) = Self::build_pool(&client.config, &account_limiter)?;
+        client.auth = auth;
+        client.pool = pool;
+        client.selected = Arc::new(StdMutex::new(SelectedAccount {
+            id: client.config.credentials.account_id.clone(),
+            limiter: account_limiter,
+        }));
+        Ok(client)
+    }
+
     /// Builds one [`KeySlot`] per API key declared in the configuration.
     ///
     /// Every slot — the first included — gets a `Config` carrying **only its own

--- a/tests/unit/application/test_market_catalog.rs
+++ b/tests/unit/application/test_market_catalog.rs
@@ -11,18 +11,27 @@ use ig_client::presentation::instrument::InstrumentType;
 use serde_json::{Value, json};
 use std::collections::HashMap;
 use std::error::Error;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use wiremock::matchers::{header, method, path, query_param};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 type TestResult = Result<(), Box<dyn Error>>;
 
+// Production pacing is shared per account. Independent fixtures must not share
+// that budget when the test harness runs them concurrently.
+static FIXTURE_ACCOUNT_SEQUENCE: AtomicUsize = AtomicUsize::new(0);
+
 /// Build an env-free client with fake credentials and a local mock session.
 async fn fixture_client(server: &MockServer) -> Result<Client, Box<dyn Error>> {
+    let account_id = format!(
+        "CATALOG-FIXTURE-ACCOUNT-{}",
+        FIXTURE_ACCOUNT_SEQUENCE.fetch_add(1, Ordering::Relaxed)
+    );
     Mock::given(method("POST"))
         .and(path("/session"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "clientId": "FIXTURE-CLIENT",
-            "accountId": "FIXTURE-ACCOUNT",
+            "accountId": account_id,
             "timezoneOffset": 0,
             "lightstreamerEndpoint": "https://example.invalid",
             "oauthToken": {
@@ -39,7 +48,7 @@ async fn fixture_client(server: &MockServer) -> Result<Client, Box<dyn Error>> {
     let mut config = Config::from_credentials(Credentials::new(
         "FIXTURE-USER".into(),
         "FIXTURE-PASSWORD".into(),
-        "FIXTURE-ACCOUNT".into(),
+        account_id,
         "FIXTURE-API-KEY".into(),
     ));
     config.rest_api.base_url = server.uri();
@@ -432,58 +441,9 @@ async fn test_public_catalog_changing_effective_page_size_is_an_error() -> TestR
     Ok(())
 }
 
-#[tokio::test]
-async fn test_public_catalog_page_limit_without_completion_is_an_error() -> TestResult {
-    let server = MockServer::start().await;
-    let client = fixture_client(&server).await?;
-    mount_categories(&server, &["unbounded"], 2).await;
-    Mock::given(method("GET"))
-        .and(path("/categories/unbounded/instruments"))
-        .and(header("Version", "1"))
-        .and(query_param("pageSize", "500"))
-        .respond_with(|request: &wiremock::Request| {
-            let page = request
-                .url
-                .query_pairs()
-                .find(|(name, _)| name == "pageNumber")
-                .and_then(|(_, value)| value.parse::<i64>().ok())
-                .unwrap_or(-1);
-            // A synthetic server that never finishes and never repeats an EPIC.
-            ResponseTemplate::new(200).set_body_json(fixture_page(
-                page,
-                1,
-                vec![fixture_instrument(
-                    &format!("IX.D.FIXTURE.PAGE{page}.IP"),
-                    "DFB",
-                    "INDICES",
-                )],
-            ))
-        })
-        .expect(2_000)
-        .mount(&server)
-        .await;
-    let market_error = client
-        .get_all_markets()
-        .await
-        .err()
-        .ok_or("unbounded catalog succeeded")?;
-    let entry_error = client
-        .get_vec_db_entries()
-        .await
-        .err()
-        .ok_or("unbounded entries succeeded")?;
-    for error in [market_error, entry_error] {
-        assert!(matches!(
-            error,
-            AppError::CatalogPagination {
-                page_number: 1000,
-                ..
-            }
-        ));
-    }
-    server.verify().await;
-    Ok(())
-}
+// The 1,000-page safety-limit regression lives in the client's cfg(test)
+// module. It exercises both public methods with an injected test-only account
+// quota, so it does not spend over an hour on the real 30/minute allowance.
 
 #[tokio::test]
 async fn test_public_catalog_blank_category_or_epic_is_an_error() -> TestResult {


### PR DESCRIPTION
## Summary

`Run Tests`, `Features` and `Code Coverage Report` have been red on `main` since `03a7613`, all three on one test. The catalogue page-limit regression drove roughly 2,000 requests through the per-account budget of 30 requests per minute, which is fixed in `http.rs` and unreachable from `Config`. At 2 seconds per request the test ran for 71 minutes, outlived its own fixture token (`expires_in: 3600`), triggered a re-login, and broke the session mock's `.expect(1)`. This makes the budget injectable in test builds only and moves the regression where it can use that, keeping the real 1,000-page boundary covered.

## Changes

- Test-only constructor `HttpClient::new_lazy_with_test_account_limiter`, gated behind `#[cfg(test)]`, that accepts an account quota and rebuilds the auth pool so login and data traffic charge the same injected bucket. Production exposes no override and keeps the fixed 30/minute allowance unchanged.
- The 1,000-page regression moves from `tests/unit/application/test_market_catalog.rs` into a `catalog_limit_tests` module inside `client.rs`, where the test-only constructor is reachable. It still exercises the real boundary through both `get_all_markets` and `get_vec_db_entries`, and now asserts the category, the page number and the failure reason rather than only the page number.
- A 30-second `tokio::time::timeout` wraps that test, so reintroducing real pacing into an offline test fails in half a minute instead of running for over an hour.
- The remaining catalogue fixtures take distinct synthetic account ids, so concurrent tests no longer compete for the single bucket that `build_account_limiter` caches per account in a global `OnceLock`.
- `doc/MARKET_CATALOG.md` records where the page-limit regression now lives and why it uses an isolated quota.

## Technical decisions

The quota is injected rather than the page limit being lowered. Making `MAX_CATEGORY_PAGES` configurable would have been a smaller change, but the test would then no longer exercise the value that ships, and the limit is precisely the guarantee that a category which never returns an empty page ends in a typed error instead of looping forever. Injecting the budget keeps the assertion honest and also unblocks any future test that needs more than 30 requests.

The override is `#[cfg(test)]` and crate-internal, so the production pacing path is untouched and no public API grows. That is also why the regression had to move into the crate: a test under `tests/` cannot reach a `cfg(test)` constructor.

The added timeout is deliberately part of the fix and not incidental. The original failure was expensive precisely because it was slow rather than wrong, and burned 75 minutes of CI per run across three jobs before reporting.

## Testing

- [x] Unit tests added or updated
- [x] `make pre-push` run locally and clean

Verified locally:

- `cargo test --lib catalog_limit_tests`: 1 passed in **0.83 s**, against 71 minutes before.
- `cargo test`: 277 + 286 + 11 passed, 0 failed, full suite in **52 s**.
- `cargo clippy --all-targets --all-features -- -D warnings`: clean.
- `cargo fmt --all --check`: clean.
- `cargo build --release`: clean.
- `make check-features`: all four feature combinations build, lint, test and document; dependency-graph assertions all pass.

## Checklist

- [x] Code follows `rules/global_rules.md` and `CLAUDE.md`
- [x] No `.unwrap()` / `.expect()` / unchecked indexing in production code
- [x] No `unsafe` introduced (banned crate-wide)
- [x] Module boundaries respected (`model` / `presentation` stay I/O-free; `application` has no deps on `storage`)
- [x] No new dependencies added without explicit approval
- [x] `tracing` only for logging — no credentials / tokens / CST / X-SECURITY-TOKEN in logs, errors, or fixtures
- [x] Retry stays finite — no unbounded retry loops (removed in PR #26)

No public API change, so `src/lib.rs` re-exports, `src/prelude.rs`, `README.md` and the crate version are untouched.

Closes #98
